### PR TITLE
Manage only spring's libraries in Gradle version catalog.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,18 +7,6 @@ spring-jdbc = { module = "org.springframework:spring-jdbc", version.ref = "sprin
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref="spring-boot" }
 spring-boot-starter-plain = { module = "org.springframework.boot:spring-boot-starter", version.ref="spring-boot" }
 spring-boot-starter-jdbc = { module = "org.springframework.boot:spring-boot-starter-jdbc", version.ref="spring-boot" }
-slf4j-api = { module = "org.slf4j:slf4j-api", version = "1.7.30" }
-logback-classic = "ch.qos.logback:logback-classic:1.2.3"
-h2 = "com.h2database:h2:1.4.200"
-mysql = "mysql:mysql-connector-java:8.0.24"
-postgresql = "org.postgresql:postgresql:42.2.20"
-truth = "com.google.truth:truth:1.1.2"
-sqlcommenter = "com.google.cloud:sqlcommenter:1.1.0"
-opentelemetry-api = "io.opentelemetry:opentelemetry-api:0.12.0"
-symbol-processing-api = "com.google.devtools.ksp:symbol-processing-api:1.5.0-1.0.0-alpha09"
-symbol-processing-impl = "com.google.devtools.ksp:symbol-processing:1.5.0-1.0.0-alpha09"
-kotlin-compile-testing-ksp = "com.github.tschuchortdev:kotlin-compile-testing-ksp:1.4.0"
-hikariCP = "com.zaxxer:HikariCP:4.0.3"
 
 [bundles]
 ext-spring-boot-autoconfigure = ["spring-jdbc", "spring-boot-autoconfigure"]

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -19,14 +19,14 @@ dependencies {
     compileOnly(project(":komapper-annotation"))
     ksp(project(":komapper-processor"))
     implementation(project(":komapper-transaction"))
-    implementation(libs.postgresql)
+    implementation("org.postgresql:postgresql:42.2.20")
 
     implementation(project(":komapper-jdbc-h2"))
     runtimeOnly(project(":komapper-jdbc-mysql"))
     runtimeOnly(project(":komapper-jdbc-postgresql"))
     runtimeOnly(project(":komapper-template"))
     runtimeOnly(project(":komapper-ext-slf4j"))
-    runtimeOnly(libs.logback.classic)
+    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
 }
 
 ksp {

--- a/komapper-ext-slf4j/build.gradle.kts
+++ b/komapper-ext-slf4j/build.gradle.kts
@@ -1,4 +1,4 @@
 dependencies {
     api(project(":komapper-core"))
-    api(libs.slf4j.api)
+    api("org.slf4j:slf4j-api:1.7.30")
 }

--- a/komapper-ext-spring-boot-autoconfigure/build.gradle.kts
+++ b/komapper-ext-spring-boot-autoconfigure/build.gradle.kts
@@ -3,6 +3,6 @@ dependencies {
     implementation(project(":komapper-core"))
     testImplementation(project(":komapper-ext-slf4j"))
     testImplementation(project(":komapper-jdbc-h2"))
-    testImplementation(libs.logback.classic)
-    testImplementation(libs.hikariCP)
+    testImplementation("ch.qos.logback:logback-classic:1.2.3")
+    testImplementation("com.zaxxer:HikariCP:4.0.3")
 }

--- a/komapper-ext-sqlcommenter/build.gradle.kts
+++ b/komapper-ext-sqlcommenter/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
     api(project(":komapper-core"))
-    api(libs.sqlcommenter)
-    implementation(libs.opentelemetry.api)
+    api("com.google.cloud:sqlcommenter:1.1.0")
+    implementation("io.opentelemetry:opentelemetry-api:0.12.0")
 }

--- a/komapper-jdbc-h2/build.gradle.kts
+++ b/komapper-jdbc-h2/build.gradle.kts
@@ -1,4 +1,4 @@
 dependencies {
     api(project(":komapper-core"))
-    runtimeOnly(libs.h2)
+    runtimeOnly("com.h2database:h2:1.4.200")
 }

--- a/komapper-jdbc-mysql/build.gradle.kts
+++ b/komapper-jdbc-mysql/build.gradle.kts
@@ -1,4 +1,4 @@
 dependencies {
     api(project(":komapper-core"))
-    runtimeOnly(libs.mysql)
+    runtimeOnly("mysql:mysql-connector-java:8.0.24")
 }

--- a/komapper-jdbc-postgresql/build.gradle.kts
+++ b/komapper-jdbc-postgresql/build.gradle.kts
@@ -1,4 +1,4 @@
 dependencies {
     api(project(":komapper-core"))
-    runtimeOnly(libs.postgresql)
+    runtimeOnly("org.postgresql:postgresql:42.2.20")
 }

--- a/komapper-processor/build.gradle.kts
+++ b/komapper-processor/build.gradle.kts
@@ -4,9 +4,9 @@ plugins {
 
 dependencies {
     implementation(project(":komapper-core"))
-    implementation(libs.symbol.processing.api)
+    implementation("com.google.devtools.ksp:symbol-processing-api:1.5.0-1.0.0-alpha09")
     testImplementation(project(":komapper-annotation"))
-    testImplementation(libs.symbol.processing.impl)
-    testImplementation(libs.kotlin.compile.testing.ksp)
-    testImplementation(libs.truth)
+    testImplementation("com.google.devtools.ksp:symbol-processing:1.5.0-1.0.0-alpha09")
+    testImplementation("com.github.tschuchortdev:kotlin-compile-testing-ksp:1.4.0")
+    testImplementation("com.google.truth:truth:1.1.2")
 }

--- a/komapper-starter/build.gradle.kts
+++ b/komapper-starter/build.gradle.kts
@@ -7,5 +7,5 @@ dependencies {
     runtimeOnly(project(":komapper-jdbc-h2"))
     runtimeOnly(project(":komapper-jdbc-mysql"))
     runtimeOnly(project(":komapper-jdbc-postgresql"))
-    runtimeOnly(libs.logback.classic)
+    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
 }


### PR DESCRIPTION
Because renovate does not seem to support Gradle's version catalog currently.