### PR TITLE
Support default where clauses

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/SqlSelectQueryTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/SqlSelectQueryTest.kt
@@ -4,9 +4,12 @@ import integration.Address
 import integration.Employee
 import integration.meta
 import kotlinx.coroutines.flow.count
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.OptimisticLockException
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.expression.When
+import org.komapper.core.dsl.metamodel.define
 import org.komapper.core.dsl.operator.case
 import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.operator.desc
@@ -75,6 +78,7 @@ class SqlSelectQueryTest(private val db: JdbcDatabase) {
             list
         )
     }
+
     @Test
     fun option() {
         val e = Employee.meta
@@ -157,5 +161,70 @@ class SqlSelectQueryTest(private val db: JdbcDatabase) {
             listOf("STREET 1" to null, "STREET 2" to "HIT", "STREET 3" to null),
             list
         )
+    }
+
+    @Test
+    fun defaultWhere() {
+        val a = Address.meta.define { a ->
+            where { a.addressId eq 1 }
+        }
+        val list = db.runQuery { QueryDsl.from(a) }
+        assertEquals(1, list.size)
+    }
+
+    @Test
+    fun defaultWhere_join() {
+        val e = Employee.meta
+        val a = Address.meta.define { a ->
+            where { a.addressId eq 1 }
+        }
+        val list = db.runQuery {
+            QueryDsl.from(e).innerJoin(a) {
+                e.addressId eq a.addressId
+            }
+        }
+        assertEquals(1, list.size)
+    }
+
+    @Test
+    fun defaultWhere_update_single() {
+        val a = Address.meta
+        val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 15 }.first() }
+        val a2 = Address.meta.define { a2 ->
+            where { a2.version eq 99 }
+        }
+        assertThrows<OptimisticLockException> {
+            db.runQuery { QueryDsl.update(a2).single(address) }.run { }
+        }
+    }
+
+    @Test
+    fun defaultWhere_update_set() {
+        val a = Address.meta.define { a ->
+            where { a.addressId eq 15 }
+        }
+        val count = db.runQuery { QueryDsl.update(a).set { a.street set "hello" } }
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun defaultWhere_delete_single() {
+        val a = Address.meta
+        val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 15 }.first() }
+        val a2 = Address.meta.define { a2 ->
+            where { a2.version eq 99 }
+        }
+        assertThrows<OptimisticLockException> {
+            db.runQuery { QueryDsl.delete(a2).single(address) }
+        }
+    }
+
+    @Test
+    fun defaultWhere_delete_all() {
+        val a = Address.meta.define { a ->
+            where { a.addressId eq 15 }
+        }
+        val count = db.runQuery { QueryDsl.delete(a).all() }
+        assertEquals(1, count)
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/SqlSelectQueryWhereTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/SqlSelectQueryWhereTest.kt
@@ -9,6 +9,7 @@ import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.operator.desc
 import org.komapper.core.dsl.operator.plus
 import org.komapper.core.dsl.query.andThen
+import org.komapper.core.dsl.query.where
 import org.komapper.jdbc.JdbcDatabase
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -511,6 +512,13 @@ class SqlSelectQueryWhereTest(private val db: JdbcDatabase) {
             a.version eq 1
         }
         val list = db.runQuery { QueryDsl.from(a).where(w1 + w2) }
+        assertEquals(1, list.size)
+    }
+
+    @Test
+    fun defaultWhere() {
+        val a = Address.meta.where { it.addressId eq 1 }
+        val list = db.runQuery { QueryDsl.from(a) }
         assertEquals(1, list.size)
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/SqlSelectQueryWhereTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/SqlSelectQueryWhereTest.kt
@@ -9,7 +9,6 @@ import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.operator.desc
 import org.komapper.core.dsl.operator.plus
 import org.komapper.core.dsl.query.andThen
-import org.komapper.core.dsl.query.where
 import org.komapper.jdbc.JdbcDatabase
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -512,13 +511,6 @@ class SqlSelectQueryWhereTest(private val db: JdbcDatabase) {
             a.version eq 1
         }
         val list = db.runQuery { QueryDsl.from(a).where(w1 + w2) }
-        assertEquals(1, list.size)
-    }
-
-    @Test
-    fun defaultWhere() {
-        val a = Address.meta.where { it.addressId eq 1 }
-        val list = db.runQuery { QueryDsl.from(a) }
         assertEquals(1, list.size)
     }
 }

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/SqlSelectQueryTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/SqlSelectQueryTest.kt
@@ -3,9 +3,13 @@ package integration.r2dbc
 import integration.Address
 import integration.Employee
 import integration.meta
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.OptimisticLockException
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.expression.When
+import org.komapper.core.dsl.metamodel.define
 import org.komapper.core.dsl.operator.case
 import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.operator.desc
@@ -148,5 +152,60 @@ class SqlSelectQueryTest(private val db: R2dbcDatabase) {
             listOf("STREET 1" to null, "STREET 2" to "HIT", "STREET 3" to null),
             list
         )
+    }
+
+    @Test
+    fun defaultWhere() = inTransaction(db) {
+        val a = Address.meta.define { a ->
+            where { a.addressId eq 1 }
+        }
+        val list = db.runQuery { QueryDsl.from(a) }
+        assertEquals(1, list.size)
+    }
+
+    @Test
+    fun defaultWhere_update_single() = inTransaction(db) {
+        val a = Address.meta
+        val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 15 }.first() }
+        val a2 = Address.meta.define { a2 ->
+            where { a2.version eq 99 }
+        }
+        assertThrows<OptimisticLockException> {
+            runBlocking {
+                db.runQuery { QueryDsl.update(a2).single(address) }.run { }
+            }
+        }
+    }
+
+    @Test
+    fun defaultWhere_update_set() = inTransaction(db) {
+        val a = Address.meta.define { a ->
+            where { a.addressId eq 15 }
+        }
+        val count = db.runQuery { QueryDsl.update(a).set { a.street set "hello" } }
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun defaultWhere_delete_single() = inTransaction(db) {
+        val a = Address.meta
+        val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 15 }.first() }
+        val a2 = Address.meta.define { a2 ->
+            where { a2.version eq 99 }
+        }
+        assertThrows<OptimisticLockException> {
+            runBlocking {
+                db.runQuery { QueryDsl.delete(a2).single(address) }
+            }
+        }
+    }
+
+    @Test
+    fun defaultWhere_delete_all() = inTransaction(db) {
+        val a = Address.meta.define { a ->
+            where { a.addressId eq 15 }
+        }
+        val count = db.runQuery { QueryDsl.delete(a).all() }
+        assertEquals(1, count)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/EntityDeleteStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/EntityDeleteStatementBuilder.kt
@@ -5,6 +5,7 @@ import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.context.EntityDeleteContext
 import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.VersionOptions
@@ -32,8 +33,13 @@ class EntityDeleteStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTI
         val versionRequired = versionProperty != null && !option.ignoreVersion
         buf.append("delete from ")
         table(target)
-        if (identityProperties.isNotEmpty() || versionRequired) {
+        val criteria = context.getWhereCriteria()
+        if (criteria.isNotEmpty() || identityProperties.isNotEmpty() || versionRequired) {
             buf.append(" where ")
+            for ((index, criterion) in criteria.withIndex()) {
+                criterion(index, criterion)
+                buf.append(" and ")
+            }
             if (identityProperties.isNotEmpty()) {
                 for (p in identityProperties) {
                     column(p)
@@ -61,5 +67,9 @@ class EntityDeleteStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTI
 
     private fun column(expression: ColumnExpression<*, *>) {
         support.visitColumnExpression(expression)
+    }
+
+    private fun criterion(index: Int, c: Criterion) {
+        support.visitCriterion(index, c)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilderSupport.kt
@@ -41,9 +41,10 @@ internal class SelectStatementBuilderSupport(
                     buf.append(" left outer join ")
                 }
                 table(join.target)
-                if (join.on.isNotEmpty()) {
+                val on = join.on()
+                if (on.isNotEmpty()) {
                     buf.append(" on (")
-                    for ((index, criterion) in join.on.withIndex()) {
+                    for ((index, criterion) in on.withIndex()) {
                         criterion(index, criterion)
                         buf.append(" and ")
                     }
@@ -55,7 +56,7 @@ internal class SelectStatementBuilderSupport(
     }
 
     fun whereClause() {
-        val where = context.target.where() + context.where
+        val where = context.where()
         if (where.isNotEmpty()) {
             buf.append(" where ")
             for ((index, criterion) in where.withIndex()) {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilderSupport.kt
@@ -41,10 +41,10 @@ internal class SelectStatementBuilderSupport(
                     buf.append(" left outer join ")
                 }
                 table(join.target)
-                val on = join.on()
-                if (on.isNotEmpty()) {
+                val criteria = join.getOnCriteria()
+                if (criteria.isNotEmpty()) {
                     buf.append(" on (")
-                    for ((index, criterion) in on.withIndex()) {
+                    for ((index, criterion) in criteria.withIndex()) {
                         criterion(index, criterion)
                         buf.append(" and ")
                     }
@@ -56,10 +56,10 @@ internal class SelectStatementBuilderSupport(
     }
 
     fun whereClause() {
-        val where = context.where()
-        if (where.isNotEmpty()) {
+        val criteria = context.getWhereCriteria()
+        if (criteria.isNotEmpty()) {
             buf.append(" where ")
-            for ((index, criterion) in where.withIndex()) {
+            for ((index, criterion) in criteria.withIndex()) {
                 criterion(index, criterion)
                 buf.append(" and ")
             }
@@ -98,16 +98,16 @@ internal class SelectStatementBuilderSupport(
 
 internal class OrderByBuilderSupport(
     private val dialect: Dialect,
-    private val orderBy: List<SortItem>,
+    private val sortItems: List<SortItem>,
     aliasManager: AliasManager,
     private val buf: StatementBuffer
 ) {
     private val support = BuilderSupport(dialect, aliasManager, buf)
 
     fun orderByClause() {
-        if (orderBy.isNotEmpty()) {
+        if (sortItems.isNotEmpty()) {
             buf.append(" order by ")
-            for (item in orderBy) {
+            for (item in sortItems) {
                 when (item) {
                     is SortItem.Column -> {
                         val appendColumn = { column(item.expression) }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilderSupport.kt
@@ -55,9 +55,10 @@ internal class SelectStatementBuilderSupport(
     }
 
     fun whereClause() {
-        if (context.where.isNotEmpty()) {
+        val where = context.target.where() + context.where
+        if (where.isNotEmpty()) {
             buf.append(" where ")
-            for ((index, criterion) in context.where.withIndex()) {
+            for ((index, criterion) in where.withIndex()) {
                 criterion(index, criterion)
                 buf.append(" and ")
             }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlDeleteStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlDeleteStatementBuilder.kt
@@ -23,10 +23,10 @@ class SqlDeleteStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
     fun build(): Statement {
         buf.append("delete from ")
         table(context.target)
-        val where = context.where()
-        if (where.isNotEmpty()) {
+        val criteria = context.getWhereCriteria()
+        if (criteria.isNotEmpty()) {
             buf.append(" where ")
-            for ((index, criterion) in where.withIndex()) {
+            for ((index, criterion) in criteria.withIndex()) {
                 criterion(index, criterion)
                 buf.append(" and ")
             }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlDeleteStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlDeleteStatementBuilder.kt
@@ -23,9 +23,10 @@ class SqlDeleteStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
     fun build(): Statement {
         buf.append("delete from ")
         table(context.target)
-        if (context.where.isNotEmpty()) {
+        val where = context.where()
+        if (where.isNotEmpty()) {
             buf.append(" where ")
-            for ((index, criterion) in context.where.withIndex()) {
+            for ((index, criterion) in where.withIndex()) {
                 criterion(index, criterion)
                 buf.append(" and ")
             }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlInsertStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlInsertStatementBuilder.kt
@@ -24,9 +24,9 @@ class SqlInsertStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
         buf.append("insert into ")
         table(target)
         when (val values = context.values) {
-            is Values.Declarations -> {
+            is Values.Declarations<ENTITY> -> {
                 buf.append(" (")
-                val pairs = values.pairs<ENTITY>()
+                val pairs = values.pairs()
                 for (property in pairs.map { it.first }) {
                     if (property.isAutoIncrement()) {
                         continue
@@ -46,7 +46,7 @@ class SqlInsertStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
                 buf.cutBack(2)
                 buf.append(")")
             }
-            is Values.Subquery -> {
+            is Values.Subquery<ENTITY> -> {
                 buf.append(" (")
                 for (p in target.properties()) {
                     column(p)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlInsertStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlInsertStatementBuilder.kt
@@ -24,9 +24,10 @@ class SqlInsertStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
         buf.append("insert into ")
         table(target)
         when (val values = context.values) {
-            is Values.Pairs -> {
+            is Values.Declarations -> {
                 buf.append(" (")
-                for (property in values.pairs.map { it.first }) {
+                val pairs = values.pairs<ENTITY>()
+                for (property in pairs.map { it.first }) {
                     if (property.isAutoIncrement()) {
                         continue
                     }
@@ -35,7 +36,7 @@ class SqlInsertStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
                 }
                 buf.cutBack(2)
                 buf.append(") values (")
-                for ((property, operand) in values.pairs) {
+                for ((property, operand) in pairs) {
                     if (property.isAutoIncrement()) {
                         continue
                     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlInsertStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlInsertStatementBuilder.kt
@@ -26,8 +26,8 @@ class SqlInsertStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
         when (val values = context.values) {
             is Values.Declarations<ENTITY> -> {
                 buf.append(" (")
-                val pairs = values.pairs()
-                for (property in pairs.map { it.first }) {
+                val assignments = values.getAssignments()
+                for (property in assignments.map { it.first }) {
                     if (property.isAutoIncrement()) {
                         continue
                     }
@@ -36,7 +36,7 @@ class SqlInsertStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
                 }
                 buf.cutBack(2)
                 buf.append(") values (")
-                for ((property, operand) in pairs) {
+                for ((property, operand) in assignments) {
                     if (property.isAutoIncrement()) {
                         continue
                     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlSelectStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlSelectStatementBuilder.kt
@@ -62,9 +62,10 @@ class SqlSelectStatementBuilder(
     }
 
     private fun havingClause() {
-        if (context.having.isNotEmpty()) {
+        val having = context.having()
+        if (having.isNotEmpty()) {
             buf.append(" having ")
-            for ((index, criterion) in context.having.withIndex()) {
+            for ((index, criterion) in having.withIndex()) {
                 criterion(index, criterion)
                 buf.append(" and ")
             }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlSelectStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlSelectStatementBuilder.kt
@@ -62,10 +62,10 @@ class SqlSelectStatementBuilder(
     }
 
     private fun havingClause() {
-        val having = context.having()
-        if (having.isNotEmpty()) {
+        val criteria = context.getHavingCriteria()
+        if (criteria.isNotEmpty()) {
             buf.append(" having ")
-            for ((index, criterion) in having.withIndex()) {
+            for ((index, criterion) in criteria.withIndex()) {
                 criterion(index, criterion)
                 buf.append(" and ")
             }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlUpdateStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlUpdateStatementBuilder.kt
@@ -23,18 +23,18 @@ class SqlUpdateStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
         buf.append("update ")
         table(context.target)
         buf.append(" set ")
-        val set = context.set()
-        for ((left, right) in set) {
+        val assignments = context.getAssignments()
+        for ((left, right) in assignments) {
             column(left)
             buf.append(" = ")
             operand(right)
             buf.append(", ")
         }
         buf.cutBack(2)
-        val where = context.where()
-        if (where.isNotEmpty()) {
+        val criteria = context.getWhereCriteria()
+        if (criteria.isNotEmpty()) {
             buf.append(" where ")
-            for ((index, criterion) in where.withIndex()) {
+            for ((index, criterion) in criteria.withIndex()) {
                 criterion(index, criterion)
                 buf.append(" and ")
             }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlUpdateStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlUpdateStatementBuilder.kt
@@ -30,9 +30,10 @@ class SqlUpdateStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
             buf.append(", ")
         }
         buf.cutBack(2)
-        if (context.where.isNotEmpty()) {
+        val where = context.where()
+        if (where.isNotEmpty()) {
             buf.append(" where ")
-            for ((index, criterion) in context.where.withIndex()) {
+            for ((index, criterion) in where.withIndex()) {
                 criterion(index, criterion)
                 buf.append(" and ")
             }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlUpdateStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SqlUpdateStatementBuilder.kt
@@ -23,7 +23,8 @@ class SqlUpdateStatementBuilder<ENTITY : Any, ID, META : EntityMetamodel<ENTITY,
         buf.append("update ")
         table(context.target)
         buf.append(" set ")
-        for ((left, right) in context.set) {
+        val set = context.set()
+        for ((left, right) in set) {
             column(left)
             buf.append(" = ")
             operand(right)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
@@ -6,10 +6,14 @@ import org.komapper.core.dsl.context.SqlSelectContext
 import org.komapper.core.dsl.context.SqlUpdateContext
 import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.element.Join
+import org.komapper.core.dsl.element.Values
 import org.komapper.core.dsl.expression.Criterion
+import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.scope.HavingScope
 import org.komapper.core.dsl.scope.OnScope
+import org.komapper.core.dsl.scope.ValuesScope
 import org.komapper.core.dsl.scope.WhereScope
 
 internal fun SelectContext<*, *, *, *>.where(): List<Criterion> {
@@ -36,4 +40,8 @@ internal fun Join<*, *>.on(): List<Criterion> {
 
 internal fun SqlSelectContext<*, *, *>.having(): List<Criterion> {
     return HavingScope().apply { having.forEach { it() } }
+}
+
+internal fun <ENTITY : Any> Values.Declarations.pairs(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
+    return ValuesScope<ENTITY>().apply { declarations.forEach { it() } }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
@@ -1,0 +1,33 @@
+package org.komapper.core.dsl.builder
+
+import org.komapper.core.dsl.context.SelectContext
+import org.komapper.core.dsl.context.SqlDeleteContext
+import org.komapper.core.dsl.context.SqlUpdateContext
+import org.komapper.core.dsl.declaration.WhereDeclaration
+import org.komapper.core.dsl.element.Join
+import org.komapper.core.dsl.expression.Criterion
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.scope.OnScope
+import org.komapper.core.dsl.scope.WhereScope
+
+internal fun SelectContext<*, *, *, *>.where(): List<Criterion> {
+    return where(target, where)
+}
+
+internal fun SqlDeleteContext<*, *, *>.where(): List<Criterion> {
+    return where(target, where)
+}
+
+internal fun SqlUpdateContext<*, *, *>.where(): List<Criterion> {
+    return where(target, where)
+}
+
+private fun where(metamodel: EntityMetamodel<*, *, *>, where: List<WhereDeclaration>): List<Criterion> {
+    val w1 = metamodel.where()
+    val w2 = WhereScope().apply { where.forEach { it() } }
+    return w1 + w2
+}
+
+internal fun Join<*, *>.on(): List<Criterion> {
+    return OnScope().apply { on() }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
@@ -13,6 +13,7 @@ import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.scope.HavingScope
 import org.komapper.core.dsl.scope.OnScope
+import org.komapper.core.dsl.scope.SetScope
 import org.komapper.core.dsl.scope.ValuesScope
 import org.komapper.core.dsl.scope.WhereScope
 
@@ -40,6 +41,10 @@ internal fun Join<*, *>.on(): List<Criterion> {
 
 internal fun SqlSelectContext<*, *, *>.having(): List<Criterion> {
     return HavingScope().apply { having.forEach { it() } }
+}
+
+internal fun <ENTITY: Any> SqlUpdateContext<ENTITY, *, *>.set(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
+    return SetScope<ENTITY>().apply { set.forEach { it() } }
 }
 
 internal fun <ENTITY : Any> Values.Declarations.pairs(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
@@ -43,10 +43,10 @@ internal fun SqlSelectContext<*, *, *>.having(): List<Criterion> {
     return HavingScope().apply { having.forEach { it() } }
 }
 
-internal fun <ENTITY: Any> SqlUpdateContext<ENTITY, *, *>.set(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
+internal fun <ENTITY : Any> SqlUpdateContext<ENTITY, *, *>.set(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
     return SetScope<ENTITY>().apply { set.forEach { it() } }
 }
 
-internal fun <ENTITY : Any> Values.Declarations.pairs(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
+internal fun <ENTITY : Any> Values.Declarations<ENTITY>.pairs(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
     return ValuesScope<ENTITY>().apply { declarations.forEach { it() } }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
@@ -2,11 +2,13 @@ package org.komapper.core.dsl.builder
 
 import org.komapper.core.dsl.context.SelectContext
 import org.komapper.core.dsl.context.SqlDeleteContext
+import org.komapper.core.dsl.context.SqlSelectContext
 import org.komapper.core.dsl.context.SqlUpdateContext
 import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.element.Join
 import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.scope.HavingScope
 import org.komapper.core.dsl.scope.OnScope
 import org.komapper.core.dsl.scope.WhereScope
 
@@ -30,4 +32,8 @@ private fun where(metamodel: EntityMetamodel<*, *, *>, where: List<WhereDeclarat
 
 internal fun Join<*, *>.on(): List<Criterion> {
     return OnScope().apply { on() }
+}
+
+internal fun SqlSelectContext<*, *, *>.having(): List<Criterion> {
+    return HavingScope().apply { having.forEach { it() } }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/utility.kt
@@ -1,15 +1,12 @@
 package org.komapper.core.dsl.builder
 
-import org.komapper.core.dsl.context.SelectContext
-import org.komapper.core.dsl.context.SqlDeleteContext
+import org.komapper.core.dsl.context.QueryContext
 import org.komapper.core.dsl.context.SqlSelectContext
 import org.komapper.core.dsl.context.SqlUpdateContext
-import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.element.Join
 import org.komapper.core.dsl.element.Values
 import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.Operand
-import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.scope.HavingScope
 import org.komapper.core.dsl.scope.OnScope
@@ -17,36 +14,23 @@ import org.komapper.core.dsl.scope.SetScope
 import org.komapper.core.dsl.scope.ValuesScope
 import org.komapper.core.dsl.scope.WhereScope
 
-internal fun SelectContext<*, *, *, *>.where(): List<Criterion> {
-    return where(target, where)
+internal fun QueryContext.getWhereCriteria(): List<Criterion> {
+    val declarations = getWhereDeclarations()
+    return WhereScope().apply { declarations.forEach { it() } }
 }
 
-internal fun SqlDeleteContext<*, *, *>.where(): List<Criterion> {
-    return where(target, where)
-}
-
-internal fun SqlUpdateContext<*, *, *>.where(): List<Criterion> {
-    return where(target, where)
-}
-
-private fun where(metamodel: EntityMetamodel<*, *, *>, where: List<WhereDeclaration>): List<Criterion> {
-    val w1 = metamodel.where()
-    val w2 = WhereScope().apply { where.forEach { it() } }
-    return w1 + w2
-}
-
-internal fun Join<*, *>.on(): List<Criterion> {
+internal fun Join<*, *, *>.getOnCriteria(): List<Criterion> {
     return OnScope().apply { on() }
 }
 
-internal fun SqlSelectContext<*, *, *>.having(): List<Criterion> {
+internal fun SqlSelectContext<*, *, *>.getHavingCriteria(): List<Criterion> {
     return HavingScope().apply { having.forEach { it() } }
 }
 
-internal fun <ENTITY : Any> SqlUpdateContext<ENTITY, *, *>.set(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
+internal fun <ENTITY : Any> SqlUpdateContext<ENTITY, *, *>.getAssignments(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
     return SetScope<ENTITY>().apply { set.forEach { it() } }
 }
 
-internal fun <ENTITY : Any> Values.Declarations<ENTITY>.pairs(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
+internal fun <ENTITY : Any> Values.Declarations<ENTITY>.getAssignments(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
     return ValuesScope<ENTITY>().apply { declarations.forEach { it() } }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityDeleteContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityDeleteContext.kt
@@ -1,6 +1,8 @@
 package org.komapper.core.dsl.context
 
+import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.where
 
 data class EntityDeleteContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META
@@ -8,6 +10,10 @@ data class EntityDeleteContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, 
 
     override fun getEntityMetamodels(): Set<EntityMetamodel<*, *, *>> {
         return setOf(target)
+    }
+
+    override fun getWhereDeclarations(): List<WhereDeclaration> {
+        return target.where
     }
 
     fun asSqlDeleteContext(): SqlDeleteContext<ENTITY, ID, META> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntitySelectContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntitySelectContext.kt
@@ -1,9 +1,9 @@
 package org.komapper.core.dsl.context
 
+import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.element.ForUpdate
 import org.komapper.core.dsl.element.Join
 import org.komapper.core.dsl.element.Projection
-import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.SortItem
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
@@ -11,7 +11,7 @@ data class EntitySelectContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, 
     override val target: META,
     override val projection: Projection.Metamodels = Projection.Metamodels(listOf(target)),
     override val joins: List<Join<*, *>> = listOf(),
-    override val where: List<Criterion> = listOf(),
+    override val where: List<WhereDeclaration> = listOf(),
     override val orderBy: List<SortItem> = listOf(),
     override val offset: Int = -1,
     override val limit: Int = -1,
@@ -23,7 +23,7 @@ data class EntitySelectContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, 
         return copy(joins = this.joins + join)
     }
 
-    override fun addWhere(where: List<Criterion>): EntitySelectContext<ENTITY, ID, META> {
+    override fun addWhere(where: WhereDeclaration): EntitySelectContext<ENTITY, ID, META> {
         return copy(where = this.where + where)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntitySelectContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntitySelectContext.kt
@@ -10,7 +10,7 @@ import org.komapper.core.dsl.metamodel.EntityMetamodel
 data class EntitySelectContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
     override val target: META,
     override val projection: Projection.Metamodels = Projection.Metamodels(listOf(target)),
-    override val joins: List<Join<*, *>> = listOf(),
+    override val joins: List<Join<*, *, *>> = listOf(),
     override val where: List<WhereDeclaration> = listOf(),
     override val orderBy: List<SortItem> = listOf(),
     override val offset: Int = -1,
@@ -19,7 +19,7 @@ data class EntitySelectContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, 
     override val distinct: Boolean = false,
 ) : SelectContext<ENTITY, ID, META, EntitySelectContext<ENTITY, ID, META>> {
 
-    override fun addJoin(join: Join<*, *>): EntitySelectContext<ENTITY, ID, META> {
+    override fun addJoin(join: Join<*, *, *>): EntitySelectContext<ENTITY, ID, META> {
         return copy(joins = this.joins + join)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpdateContext.kt
@@ -1,7 +1,9 @@
 package org.komapper.core.dsl.context
 
+import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
+import org.komapper.core.dsl.metamodel.where
 
 data class EntityUpdateContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
@@ -11,6 +13,10 @@ data class EntityUpdateContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, 
 
     override fun getEntityMetamodels(): Set<EntityMetamodel<*, *, *>> {
         return setOf(target)
+    }
+
+    override fun getWhereDeclarations(): List<WhereDeclaration> {
+        return target.where
     }
 
     fun getTargetProperties(): List<PropertyMetamodel<ENTITY, *, *>> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
@@ -12,7 +12,8 @@ data class EntityUpsertContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, 
         catalog = "",
         schema = "",
         alwaysQuote = false,
-        disableSequenceAssignment = false
+        disableSequenceAssignment = false,
+        where = {}
     ),
     val keys: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
     val duplicateKeyType: DuplicateKeyType,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
@@ -13,7 +13,7 @@ data class EntityUpsertContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, 
         schema = "",
         alwaysQuote = false,
         disableSequenceAssignment = false,
-        where = {}
+        declarations = emptyList()
     ),
     val keys: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
     val duplicateKeyType: DuplicateKeyType,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/QueryContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/QueryContext.kt
@@ -1,9 +1,11 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 @ThreadSafe
 interface QueryContext {
     fun getEntityMetamodels(): Set<EntityMetamodel<*, *, *>>
+    fun getWhereDeclarations(): List<WhereDeclaration> = emptyList()
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SelectContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SelectContext.kt
@@ -1,9 +1,9 @@
 package org.komapper.core.dsl.context
 
+import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.element.ForUpdate
 import org.komapper.core.dsl.element.Join
 import org.komapper.core.dsl.element.Projection
-import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.SortItem
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
@@ -16,7 +16,7 @@ sealed interface SelectContext<
     val target: META
     val projection: Projection
     val joins: List<Join<*, *>>
-    val where: List<Criterion>
+    val where: List<WhereDeclaration>
     val orderBy: List<SortItem>
     val offset: Int
     val limit: Int
@@ -24,7 +24,7 @@ sealed interface SelectContext<
     val distinct: Boolean
 
     fun addJoin(join: Join<*, *>): CONTEXT
-    fun addWhere(where: List<Criterion>): CONTEXT
+    fun addWhere(where: WhereDeclaration): CONTEXT
     fun addOrderBy(orderBy: List<SortItem>): CONTEXT
     fun setLimit(limit: Int): CONTEXT
     fun setOffset(offset: Int): CONTEXT

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SelectContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SelectContext.kt
@@ -6,6 +6,7 @@ import org.komapper.core.dsl.element.Join
 import org.komapper.core.dsl.element.Projection
 import org.komapper.core.dsl.expression.SortItem
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.where
 
 sealed interface SelectContext<
     ENTITY : Any,
@@ -15,7 +16,7 @@ sealed interface SelectContext<
 
     val target: META
     val projection: Projection
-    val joins: List<Join<*, *>>
+    val joins: List<Join<*, *, *>>
     val where: List<WhereDeclaration>
     val orderBy: List<SortItem>
     val offset: Int
@@ -23,7 +24,7 @@ sealed interface SelectContext<
     val forUpdate: ForUpdate
     val distinct: Boolean
 
-    fun addJoin(join: Join<*, *>): CONTEXT
+    fun addJoin(join: Join<*, *, *>): CONTEXT
     fun addWhere(where: WhereDeclaration): CONTEXT
     fun addOrderBy(orderBy: List<SortItem>): CONTEXT
     fun setLimit(limit: Int): CONTEXT
@@ -32,5 +33,9 @@ sealed interface SelectContext<
 
     override fun getEntityMetamodels(): Set<EntityMetamodel<*, *, *>> {
         return setOf(target) + joins.map { it.target }
+    }
+
+    override fun getWhereDeclarations(): List<WhereDeclaration> {
+        return target.where + joins.flatMap { it.getWhereDeclarations() } + where
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlDeleteContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlDeleteContext.kt
@@ -2,6 +2,7 @@ package org.komapper.core.dsl.context
 
 import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.where
 
 data class SqlDeleteContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
@@ -10,5 +11,9 @@ data class SqlDeleteContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID,
 
     override fun getEntityMetamodels(): Set<EntityMetamodel<*, *, *>> {
         return setOf(target)
+    }
+
+    override fun getWhereDeclarations(): List<WhereDeclaration> {
+        return target.where + where
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlDeleteContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlDeleteContext.kt
@@ -1,11 +1,11 @@
 package org.komapper.core.dsl.context
 
-import org.komapper.core.dsl.expression.Criterion
+import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 data class SqlDeleteContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
-    val where: List<Criterion> = listOf()
+    val where: List<WhereDeclaration> = listOf()
 ) : QueryContext {
 
     override fun getEntityMetamodels(): Set<EntityMetamodel<*, *, *>> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlInsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlInsertContext.kt
@@ -5,7 +5,7 @@ import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 data class SqlInsertContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
-    val values: Values = Values.Pairs(emptyList())
+    val values: Values = Values.Declarations(emptyList())
 ) : QueryContext {
 
     override fun getEntityMetamodels(): Set<EntityMetamodel<*, *, *>> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlInsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlInsertContext.kt
@@ -5,7 +5,7 @@ import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 data class SqlInsertContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
-    val values: Values = Values.Declarations(emptyList())
+    val values: Values<ENTITY> = Values.Declarations(emptyList())
 ) : QueryContext {
 
     override fun getEntityMetamodels(): Set<EntityMetamodel<*, *, *>> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlSelectContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlSelectContext.kt
@@ -12,7 +12,7 @@ import org.komapper.core.dsl.metamodel.EntityMetamodel
 data class SqlSelectContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
     override val target: META,
     override val projection: Projection = Projection.Metamodels(listOf(target)),
-    override val joins: List<Join<*, *>> = listOf(),
+    override val joins: List<Join<*, *, *>> = listOf(),
     override val where: List<WhereDeclaration> = listOf(),
     override val orderBy: List<SortItem> = listOf(),
     override val offset: Int = -1,
@@ -31,7 +31,7 @@ data class SqlSelectContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID,
         return copy(projection = Projection.Metamodels(metamodels.toList()))
     }
 
-    override fun addJoin(join: Join<*, *>): SqlSelectContext<ENTITY, ID, META> {
+    override fun addJoin(join: Join<*, *, *>): SqlSelectContext<ENTITY, ID, META> {
         return copy(joins = this.joins + join)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlSelectContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlSelectContext.kt
@@ -1,11 +1,11 @@
 package org.komapper.core.dsl.context
 
+import org.komapper.core.dsl.declaration.HavingDeclaration
 import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.element.ForUpdate
 import org.komapper.core.dsl.element.Join
 import org.komapper.core.dsl.element.Projection
 import org.komapper.core.dsl.expression.ColumnExpression
-import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.SortItem
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
@@ -20,7 +20,7 @@ data class SqlSelectContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID,
     override val forUpdate: ForUpdate = ForUpdate(),
     override val distinct: Boolean = false,
     val groupBy: List<ColumnExpression<*, *>> = listOf(),
-    val having: List<Criterion> = listOf(),
+    val having: List<HavingDeclaration> = listOf(),
 ) : SelectContext<ENTITY, ID, META, SqlSelectContext<ENTITY, ID, META>> {
 
     fun setProjection(vararg expressions: ColumnExpression<*, *>): SqlSelectContext<ENTITY, ID, META> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlSelectContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlSelectContext.kt
@@ -1,5 +1,6 @@
 package org.komapper.core.dsl.context
 
+import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.element.ForUpdate
 import org.komapper.core.dsl.element.Join
 import org.komapper.core.dsl.element.Projection
@@ -12,7 +13,7 @@ data class SqlSelectContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID,
     override val target: META,
     override val projection: Projection = Projection.Metamodels(listOf(target)),
     override val joins: List<Join<*, *>> = listOf(),
-    override val where: List<Criterion> = listOf(),
+    override val where: List<WhereDeclaration> = listOf(),
     override val orderBy: List<SortItem> = listOf(),
     override val offset: Int = -1,
     override val limit: Int = -1,
@@ -34,7 +35,7 @@ data class SqlSelectContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID,
         return copy(joins = this.joins + join)
     }
 
-    override fun addWhere(where: List<Criterion>): SqlSelectContext<ENTITY, ID, META> {
+    override fun addWhere(where: WhereDeclaration): SqlSelectContext<ENTITY, ID, META> {
         return copy(where = this.where + where)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlUpdateContext.kt
@@ -2,8 +2,6 @@ package org.komapper.core.dsl.context
 
 import org.komapper.core.dsl.declaration.SetDeclaration
 import org.komapper.core.dsl.declaration.WhereDeclaration
-import org.komapper.core.dsl.expression.ColumnExpression
-import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 data class SqlUpdateContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlUpdateContext.kt
@@ -1,5 +1,6 @@
 package org.komapper.core.dsl.context
 
+import org.komapper.core.dsl.declaration.SetDeclaration
 import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.Operand
@@ -7,7 +8,7 @@ import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 data class SqlUpdateContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: EntityMetamodel<ENTITY, ID, META>,
-    val set: List<Pair<ColumnExpression<*, *>, Operand>> = listOf(),
+    val set: List<SetDeclaration<ENTITY>> = listOf(),
     val where: List<WhereDeclaration> = listOf()
 ) : QueryContext {
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlUpdateContext.kt
@@ -1,14 +1,14 @@
 package org.komapper.core.dsl.context
 
+import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.expression.ColumnExpression
-import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 data class SqlUpdateContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: EntityMetamodel<ENTITY, ID, META>,
     val set: List<Pair<ColumnExpression<*, *>, Operand>> = listOf(),
-    val where: List<Criterion> = listOf()
+    val where: List<WhereDeclaration> = listOf()
 ) : QueryContext {
 
     override fun getEntityMetamodels(): Set<EntityMetamodel<*, *, *>> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SqlUpdateContext.kt
@@ -3,14 +3,19 @@ package org.komapper.core.dsl.context
 import org.komapper.core.dsl.declaration.SetDeclaration
 import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.where
 
 data class SqlUpdateContext<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
-    val target: EntityMetamodel<ENTITY, ID, META>,
+    val target: META,
     val set: List<SetDeclaration<ENTITY>> = listOf(),
     val where: List<WhereDeclaration> = listOf()
 ) : QueryContext {
 
     override fun getEntityMetamodels(): Set<EntityMetamodel<*, *, *>> {
         return setOf(target)
+    }
+
+    override fun getWhereDeclarations(): List<WhereDeclaration> {
+        return target.where + where
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Join.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Join.kt
@@ -2,14 +2,20 @@ package org.komapper.core.dsl.element
 
 import org.komapper.core.ThreadSafe
 import org.komapper.core.dsl.declaration.OnDeclaration
+import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.where
 
 @ThreadSafe
-data class Join<ENTITY : Any, META : EntityMetamodel<ENTITY, *, META>>(
-    val target: EntityMetamodel<ENTITY, *, META>,
+data class Join<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>>(
+    val target: META,
     val kind: JoinKind,
     val on: OnDeclaration
-)
+) {
+    fun getWhereDeclarations(): List<WhereDeclaration> {
+        return target.where
+    }
+}
 
 enum class JoinKind {
     INNER, LEFT_OUTER

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Join.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Join.kt
@@ -1,14 +1,14 @@
 package org.komapper.core.dsl.element
 
 import org.komapper.core.ThreadSafe
-import org.komapper.core.dsl.expression.Criterion
+import org.komapper.core.dsl.declaration.OnDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 @ThreadSafe
 data class Join<ENTITY : Any, META : EntityMetamodel<ENTITY, *, META>>(
     val target: EntityMetamodel<ENTITY, *, META>,
     val kind: JoinKind,
-    val on: List<Criterion>
+    val on: OnDeclaration
 )
 
 enum class JoinKind {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Values.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Values.kt
@@ -5,7 +5,7 @@ import org.komapper.core.dsl.declaration.ValuesDeclaration
 import org.komapper.core.dsl.expression.SubqueryExpression
 
 @ThreadSafe
-sealed class Values {
-    data class Declarations(val declarations: List<ValuesDeclaration<*>>) : Values()
-    data class Subquery(val expression: SubqueryExpression<*>) : Values()
+sealed class Values<ENTITY : Any> {
+    data class Declarations<ENTITY : Any>(val declarations: List<ValuesDeclaration<ENTITY>>) : Values<ENTITY>()
+    data class Subquery<ENTITY : Any>(val expression: SubqueryExpression<*>) : Values<ENTITY>()
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Values.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Values.kt
@@ -1,12 +1,11 @@
 package org.komapper.core.dsl.element
 
 import org.komapper.core.ThreadSafe
-import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.declaration.ValuesDeclaration
 import org.komapper.core.dsl.expression.SubqueryExpression
-import org.komapper.core.dsl.metamodel.PropertyMetamodel
 
 @ThreadSafe
 sealed class Values {
-    data class Pairs(val pairs: List<Pair<PropertyMetamodel<*, *, *>, Operand>>) : Values()
+    data class Declarations(val declarations: List<ValuesDeclaration<*>>) : Values()
     data class Subquery(val expression: SubqueryExpression<*>) : Values()
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/TableExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/TableExpression.kt
@@ -10,7 +10,6 @@ interface TableExpression<T : Any> {
     fun catalogName(): String
     fun schemaName(): String
     fun alwaysQuote(): Boolean
-    fun where(): List<Criterion>
     fun getCanonicalTableName(enquote: (String) -> String): String {
         val transform = if (alwaysQuote()) {
             enquote

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/TableExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/TableExpression.kt
@@ -10,6 +10,7 @@ interface TableExpression<T : Any> {
     fun catalogName(): String
     fun schemaName(): String
     fun alwaysQuote(): Boolean
+    fun where(): List<Criterion>
     fun getCanonicalTableName(enquote: (String) -> String): String {
         val transform = if (alwaysQuote()) {
             enquote

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
@@ -1,14 +1,13 @@
 package org.komapper.core.dsl.metamodel
 
 import org.komapper.core.ThreadSafe
-import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.TableExpression
-import org.komapper.core.dsl.scope.WhereScope
 import java.time.Clock
 import kotlin.reflect.KClass
 
 @ThreadSafe
-interface EntityMetamodel<ENTITY : Any, ID, out META : EntityMetamodel<ENTITY, ID, META>> : TableExpression<ENTITY> {
+interface EntityMetamodel<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>> : TableExpression<ENTITY> {
+    fun declarations(): List<MetamodelDeclaration<ENTITY, ID, META>>
     fun idAssignment(): IdAssignment<ENTITY>?
     fun idProperties(): List<PropertyMetamodel<ENTITY, *, *>>
     fun versionProperty(): PropertyMetamodel<ENTITY, *, *>?
@@ -27,7 +26,7 @@ interface EntityMetamodel<ENTITY : Any, ID, out META : EntityMetamodel<ENTITY, I
         schema: String,
         alwaysQuote: Boolean,
         disableSequenceAssignment: Boolean,
-        where: WhereScope.(META) -> Unit
+        declarations: List<MetamodelDeclaration<ENTITY, ID, META>>
     ): META
 }
 
@@ -39,7 +38,7 @@ abstract class EntityMetamodelStub<ENTITY : Any, META : EntityMetamodelStub<ENTI
     override fun catalogName(): String = fail()
     override fun schemaName(): String = fail()
     override fun alwaysQuote(): Boolean = fail()
-    override fun where(): List<Criterion> = fail()
+    override fun declarations(): List<MetamodelDeclaration<ENTITY, Any, META>> = fail()
     override fun idAssignment(): IdAssignment<ENTITY>? = fail()
     override fun idProperties(): List<PropertyMetamodel<ENTITY, *, *>> = fail()
     override fun versionProperty(): PropertyMetamodel<ENTITY, *, *>? = fail()
@@ -58,7 +57,7 @@ abstract class EntityMetamodelStub<ENTITY : Any, META : EntityMetamodelStub<ENTI
         schema: String,
         alwaysQuote: Boolean,
         disableSequenceAssignment: Boolean,
-        where: WhereScope.(META) -> Unit
+        declarations: List<MetamodelDeclaration<ENTITY, Any, META>>
     ): META = fail()
 
     private fun fail(): Nothing {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
@@ -1,7 +1,9 @@
 package org.komapper.core.dsl.metamodel
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.TableExpression
+import org.komapper.core.dsl.scope.WhereScope
 import java.time.Clock
 import kotlin.reflect.KClass
 
@@ -19,7 +21,14 @@ interface EntityMetamodel<ENTITY : Any, ID, out META : EntityMetamodel<ENTITY, I
     fun preUpdate(e: ENTITY, c: Clock): ENTITY
     fun postUpdate(e: ENTITY): ENTITY
     fun newEntity(m: Map<PropertyMetamodel<*, *, *>, Any?>): ENTITY
-    fun newMeta(table: String, catalog: String, schema: String, alwaysQuote: Boolean, disableSequenceAssignment: Boolean): META
+    fun newMeta(
+        table: String,
+        catalog: String,
+        schema: String,
+        alwaysQuote: Boolean,
+        disableSequenceAssignment: Boolean,
+        where: WhereScope.(META) -> Unit
+    ): META
 }
 
 @Suppress("unused")
@@ -30,6 +39,7 @@ abstract class EntityMetamodelStub<ENTITY : Any, META : EntityMetamodelStub<ENTI
     override fun catalogName(): String = fail()
     override fun schemaName(): String = fail()
     override fun alwaysQuote(): Boolean = fail()
+    override fun where(): List<Criterion> = fail()
     override fun idAssignment(): IdAssignment<ENTITY>? = fail()
     override fun idProperties(): List<PropertyMetamodel<ENTITY, *, *>> = fail()
     override fun versionProperty(): PropertyMetamodel<ENTITY, *, *>? = fail()
@@ -42,7 +52,14 @@ abstract class EntityMetamodelStub<ENTITY : Any, META : EntityMetamodelStub<ENTI
     override fun preInsert(e: ENTITY, c: Clock): ENTITY = fail()
     override fun preUpdate(e: ENTITY, c: Clock): ENTITY = fail()
     override fun postUpdate(e: ENTITY): ENTITY = fail()
-    override fun newMeta(table: String, catalog: String, schema: String, alwaysQuote: Boolean, disableSequenceAssignment: Boolean): META = fail()
+    override fun newMeta(
+        table: String,
+        catalog: String,
+        schema: String,
+        alwaysQuote: Boolean,
+        disableSequenceAssignment: Boolean,
+        where: WhereScope.(META) -> Unit
+    ): META = fail()
 
     private fun fail(): Nothing {
         error("Fix google/ksp compile errors.")

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/MetamodelDeclaration.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/MetamodelDeclaration.kt
@@ -1,0 +1,3 @@
+package org.komapper.core.dsl.metamodel
+
+typealias MetamodelDeclaration<ENTITY, ID, META> = MetamodelScope<ENTITY, ID, META>.(META) -> Unit

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/MetamodelScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/MetamodelScope.kt
@@ -1,0 +1,14 @@
+package org.komapper.core.dsl.metamodel
+
+import org.komapper.core.Scope
+import org.komapper.core.dsl.declaration.WhereDeclaration
+
+@Scope
+class MetamodelScope<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>> {
+    private val _where: MutableList<WhereDeclaration> = mutableListOf()
+    internal val where: List<WhereDeclaration> get() = _where
+
+    fun where(declaration: WhereDeclaration) {
+        _where.add(declaration)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntitySelectQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntitySelectQuery.kt
@@ -20,8 +20,8 @@ import org.komapper.core.dsl.visitor.QueryVisitor
 interface EntitySelectQuery<ENTITY : Any> : FlowSubquery<ENTITY> {
 
     fun distinct(): EntitySelectQuery<ENTITY>
-    fun innerJoin(metamodel: EntityMetamodel<*, *, *>, on: OnDeclaration): EntitySelectQuery<ENTITY>
-    fun leftJoin(metamodel: EntityMetamodel<*, *, *>, on: OnDeclaration): EntitySelectQuery<ENTITY>
+    fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> innerJoin(metamodel: META2, on: OnDeclaration): EntitySelectQuery<ENTITY>
+    fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> leftJoin(metamodel: META2, on: OnDeclaration): EntitySelectQuery<ENTITY>
     fun where(declaration: WhereDeclaration): EntitySelectQuery<ENTITY>
     fun orderBy(vararg expressions: SortExpression): EntitySelectQuery<ENTITY>
     fun offset(offset: Int): EntitySelectQuery<ENTITY>
@@ -77,12 +77,18 @@ internal data class EntitySelectQueryImpl<ENTITY : Any, ID, META : EntityMetamod
         return copy(context = newContext)
     }
 
-    override fun innerJoin(metamodel: EntityMetamodel<*, *, *>, on: OnDeclaration): EntitySelectQuery<ENTITY> {
+    override fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> innerJoin(
+        metamodel: META2,
+        on: OnDeclaration
+    ): EntitySelectQuery<ENTITY> {
         val newContext = support.innerJoin(metamodel, on)
         return copy(context = newContext)
     }
 
-    override fun leftJoin(metamodel: EntityMetamodel<*, *, *>, on: OnDeclaration): EntitySelectQuery<ENTITY> {
+    override fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> leftJoin(
+        metamodel: META2,
+        on: OnDeclaration
+    ): EntitySelectQuery<ENTITY> {
         val newContext = support.leftJoin(metamodel, on)
         return copy(context = newContext)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SelectQuerySupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SelectQuerySupport.kt
@@ -10,8 +10,6 @@ import org.komapper.core.dsl.expression.SortExpression
 import org.komapper.core.dsl.expression.SortItem
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.ForUpdateOptions
-import org.komapper.core.dsl.scope.OnScope
-import org.komapper.core.dsl.scope.WhereScope
 
 internal class SelectQuerySupport<ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>, CONTEXT : SelectContext<ENTITY, ID, META, CONTEXT>>(
     private val context: CONTEXT
@@ -36,17 +34,12 @@ internal class SelectQuerySupport<ENTITY : Any, ID, META : EntityMetamodel<ENTIT
         declaration: OnDeclaration,
         kind: JoinKind
     ): CONTEXT {
-        val scope = OnScope().apply(declaration)
-        if (scope.isNotEmpty()) {
-            val join = Join(metamodel, kind, scope.toList())
-            return context.addJoin(join)
-        }
-        return context
+        val join = Join(metamodel, kind, declaration)
+        return context.addJoin(join)
     }
 
     fun where(declaration: WhereDeclaration): CONTEXT {
-        val scope = WhereScope().apply(declaration)
-        return context.addWhere(scope)
+        return context.addWhere(declaration)
     }
 
     fun orderBy(vararg expressions: SortExpression): CONTEXT {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SelectQuerySupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SelectQuerySupport.kt
@@ -15,22 +15,22 @@ internal class SelectQuerySupport<ENTITY : Any, ID, META : EntityMetamodel<ENTIT
     private val context: CONTEXT
 ) {
 
-    fun innerJoin(
-        metamodel: EntityMetamodel<*, *, *>,
+    fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> innerJoin(
+        metamodel: META2,
         declaration: OnDeclaration
     ): CONTEXT {
         return join(metamodel, declaration, JoinKind.INNER)
     }
 
-    fun leftJoin(
-        metamodel: EntityMetamodel<*, *, *>,
+    fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> leftJoin(
+        metamodel: META2,
         declaration: OnDeclaration
     ): CONTEXT {
         return join(metamodel, declaration, JoinKind.LEFT_OUTER)
     }
 
-    private fun join(
-        metamodel: EntityMetamodel<*, *, *>,
+    private fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> join(
+        metamodel: META2,
         declaration: OnDeclaration,
         kind: JoinKind
     ): CONTEXT {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlDeleteQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlDeleteQuery.kt
@@ -4,7 +4,6 @@ import org.komapper.core.dsl.context.SqlDeleteContext
 import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.SqlDeleteOptions
-import org.komapper.core.dsl.scope.WhereScope
 import org.komapper.core.dsl.visitor.QueryVisitor
 
 interface SqlDeleteQuery : Query<Int> {
@@ -18,8 +17,7 @@ internal data class SqlDeleteQueryImpl<ENTITY : Any, ID, META : EntityMetamodel<
 ) : SqlDeleteQuery {
 
     override fun where(declaration: WhereDeclaration): SqlDeleteQuery {
-        val scope = WhereScope().apply(declaration)
-        val newContext = context.copy(where = context.where + scope)
+        val newContext = context.copy(where = context.where + declaration)
         return copy(context = newContext)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlInsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlInsertQuery.kt
@@ -6,7 +6,6 @@ import org.komapper.core.dsl.element.Values
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.SqlInsertOptions
-import org.komapper.core.dsl.scope.ValuesScope
 import org.komapper.core.dsl.visitor.QueryVisitor
 
 interface SqlInsertQuery<ENTITY : Any, ID> : Query<Pair<Int, ID?>> {
@@ -21,10 +20,11 @@ internal data class SqlInsertQueryImpl<ENTITY : Any, ID, META : EntityMetamodel<
 ) : SqlInsertQuery<ENTITY, ID> {
 
     override fun values(declaration: ValuesDeclaration<ENTITY>): SqlInsertQuery<ENTITY, ID> {
-        val scope = ValuesScope<ENTITY>().apply(declaration)
+        @Suppress("UNCHECKED_CAST")
+        declaration as ValuesDeclaration<*>
         val values = when (val values = context.values) {
-            is Values.Pairs -> Values.Pairs(values.pairs + scope)
-            is Values.Subquery -> Values.Pairs(scope.toList())
+            is Values.Declarations -> Values.Declarations(values.declarations + declaration)
+            is Values.Subquery -> Values.Declarations(listOf(declaration))
         }
         val newContext = context.copy(values = values)
         return copy(context = newContext)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlInsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlInsertQuery.kt
@@ -20,8 +20,6 @@ internal data class SqlInsertQueryImpl<ENTITY : Any, ID, META : EntityMetamodel<
 ) : SqlInsertQuery<ENTITY, ID> {
 
     override fun values(declaration: ValuesDeclaration<ENTITY>): SqlInsertQuery<ENTITY, ID> {
-        @Suppress("UNCHECKED_CAST")
-        declaration as ValuesDeclaration<*>
         val values = when (val values = context.values) {
             is Values.Declarations -> Values.Declarations(values.declarations + declaration)
             is Values.Subquery -> Values.Declarations(listOf(declaration))
@@ -32,7 +30,7 @@ internal data class SqlInsertQueryImpl<ENTITY : Any, ID, META : EntityMetamodel<
 
     override fun <T : Any> select(block: () -> SubqueryExpression<T>): SqlInsertQuery<ENTITY, ID> {
         val subquery = block()
-        val values = Values.Subquery(subquery)
+        val values = Values.Subquery<ENTITY>(subquery)
         val newContext = context.copy(values = values)
         return copy(context = newContext)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlSelectQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlSelectQuery.kt
@@ -12,7 +12,6 @@ import org.komapper.core.dsl.expression.SortExpression
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.SqlSelectOptions
-import org.komapper.core.dsl.scope.HavingScope
 import org.komapper.core.dsl.visitor.FlowQueryVisitor
 import org.komapper.core.dsl.visitor.QueryVisitor
 
@@ -96,8 +95,7 @@ internal data class SqlSelectQueryImpl<ENTITY : Any, ID, META : EntityMetamodel<
     }
 
     override fun having(declaration: HavingDeclaration): SqlSelectQuery<ENTITY> {
-        val scope = HavingScope().apply(declaration)
-        val newContext = context.copy(having = context.having + scope)
+        val newContext = context.copy(having = context.having + declaration)
         return copy(context = newContext)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlSelectQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlSelectQuery.kt
@@ -18,8 +18,16 @@ import org.komapper.core.dsl.visitor.QueryVisitor
 interface SqlSelectQuery<ENTITY : Any> : FlowSubquery<ENTITY> {
 
     fun distinct(): SqlSelectQuery<ENTITY>
-    fun innerJoin(metamodel: EntityMetamodel<*, *, *>, on: OnDeclaration): SqlSelectQuery<ENTITY>
-    fun leftJoin(metamodel: EntityMetamodel<*, *, *>, on: OnDeclaration): SqlSelectQuery<ENTITY>
+    fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> innerJoin(
+        metamodel: META2,
+        on: OnDeclaration
+    ): SqlSelectQuery<ENTITY>
+
+    fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> leftJoin(
+        metamodel: META2,
+        on: OnDeclaration
+    ): SqlSelectQuery<ENTITY>
+
     fun where(declaration: WhereDeclaration): SqlSelectQuery<ENTITY>
     fun groupBy(vararg expressions: ColumnExpression<*, *>): SqlSelectQuery<ENTITY>
     fun having(declaration: HavingDeclaration): SqlSelectQuery<ENTITY>
@@ -74,12 +82,18 @@ internal data class SqlSelectQueryImpl<ENTITY : Any, ID, META : EntityMetamodel<
         return copy(context = newContext)
     }
 
-    override fun innerJoin(metamodel: EntityMetamodel<*, *, *>, on: OnDeclaration): SqlSelectQuery<ENTITY> {
+    override fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> innerJoin(
+        metamodel: META2,
+        on: OnDeclaration
+    ): SqlSelectQuery<ENTITY> {
         val newContext = support.innerJoin(metamodel, on)
         return copy(context = newContext)
     }
 
-    override fun leftJoin(metamodel: EntityMetamodel<*, *, *>, on: OnDeclaration): SqlSelectQuery<ENTITY> {
+    override fun <ENTITY2 : Any, ID2, META2 : EntityMetamodel<ENTITY2, ID2, META2>> leftJoin(
+        metamodel: META2,
+        on: OnDeclaration
+    ): SqlSelectQuery<ENTITY> {
         val newContext = support.leftJoin(metamodel, on)
         return copy(context = newContext)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlUpdateQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlUpdateQuery.kt
@@ -20,8 +20,7 @@ internal data class SqlUpdateQueryImpl<ENTITY : Any, ID, META : EntityMetamodel<
 ) : SqlUpdateQuery<ENTITY> {
 
     override fun set(declaration: SetDeclaration<ENTITY>): SqlUpdateQuery<ENTITY> {
-        val scope = SetScope<ENTITY>().apply(declaration)
-        val newContext = context.copy(set = context.set + scope)
+        val newContext = context.copy(set = context.set + declaration)
         return copy(context = newContext)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlUpdateQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlUpdateQuery.kt
@@ -6,7 +6,6 @@ import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.SqlUpdateOptions
 import org.komapper.core.dsl.scope.SetScope
-import org.komapper.core.dsl.scope.WhereScope
 import org.komapper.core.dsl.visitor.QueryVisitor
 
 interface SqlUpdateQuery<ENTITY : Any> : Query<Int> {
@@ -27,8 +26,7 @@ internal data class SqlUpdateQueryImpl<ENTITY : Any, ID, META : EntityMetamodel<
     }
 
     override fun where(declaration: WhereDeclaration): SqlUpdateQuery<ENTITY> {
-        val scope = WhereScope().apply(declaration)
-        val newContext = context.copy(where = context.where + scope)
+        val newContext = context.copy(where = context.where + declaration)
         return copy(context = newContext)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlUpdateQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SqlUpdateQuery.kt
@@ -5,7 +5,6 @@ import org.komapper.core.dsl.declaration.SetDeclaration
 import org.komapper.core.dsl.declaration.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.SqlUpdateOptions
-import org.komapper.core.dsl.scope.SetScope
 import org.komapper.core.dsl.visitor.QueryVisitor
 
 interface SqlUpdateQuery<ENTITY : Any> : Query<Int> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/utility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/utility.kt
@@ -8,6 +8,7 @@ import org.komapper.core.DryRunResult
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.VersionOptions
+import org.komapper.core.dsl.scope.WhereScope
 import org.komapper.core.dsl.visitor.DefaultQueryVisitor
 import org.komapper.core.dsl.visitor.QueryVisitor
 import org.komapper.core.toDryRunResult
@@ -92,3 +93,14 @@ fun <T, S> Query<T>.flatZip(transform: (T) -> Query<S>): Query<Pair<T, S>> = obj
 fun <T> ListQuery<T>.first(): Query<T> = collect { it.first() }
 
 fun <T> ListQuery<T>.firstOrNull(): Query<T?> = collect { it.firstOrNull() }
+
+fun <ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>> META.where(declaration: WhereScope.(META) -> Unit): META {
+    return newMeta(
+        table = tableName(),
+        catalog = catalogName(),
+        schema = schemaName(),
+        alwaysQuote = alwaysQuote(),
+        disableSequenceAssignment = false,
+        where = declaration
+    )
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/utility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/utility.kt
@@ -8,7 +8,6 @@ import org.komapper.core.DryRunResult
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.VersionOptions
-import org.komapper.core.dsl.scope.WhereScope
 import org.komapper.core.dsl.visitor.DefaultQueryVisitor
 import org.komapper.core.dsl.visitor.QueryVisitor
 import org.komapper.core.toDryRunResult
@@ -93,14 +92,3 @@ fun <T, S> Query<T>.flatZip(transform: (T) -> Query<S>): Query<Pair<T, S>> = obj
 fun <T> ListQuery<T>.first(): Query<T> = collect { it.first() }
 
 fun <T> ListQuery<T>.firstOrNull(): Query<T?> = collect { it.firstOrNull() }
-
-fun <ENTITY : Any, ID, META : EntityMetamodel<ENTITY, ID, META>> META.where(declaration: WhereScope.(META) -> Unit): META {
-    return newMeta(
-        table = tableName(),
-        catalog = catalogName(),
-        schema = schemaName(),
-        alwaysQuote = alwaysQuote(),
-        disableSequenceAssignment = false,
-        where = declaration
-    )
-}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/SqlDeleteJdbcRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/SqlDeleteJdbcRunner.kt
@@ -17,7 +17,7 @@ internal class SqlDeleteJdbcRunner<ENTITY : Any, ID, META : EntityMetamodel<ENTI
     private val runner: SqlDeleteRunner<ENTITY, ID, META> = SqlDeleteRunner(context, options)
 
     override fun run(config: JdbcDatabaseConfig): Int {
-        if (!options.allowEmptyWhereClause && context.where.isEmpty()) {
+        if (!options.allowEmptyWhereClause && context.getWhereDeclarations().isEmpty()) {
             error("Empty where clause is not allowed.")
         }
         val statement = runner.buildStatement(config)

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/SqlUpdateJdbcRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/SqlUpdateJdbcRunner.kt
@@ -17,7 +17,7 @@ internal class SqlUpdateJdbcRunner<ENTITY : Any, ID, META : EntityMetamodel<ENTI
     private val runner: SqlUpdateRunner<ENTITY, ID, META> = SqlUpdateRunner(context, options)
 
     override fun run(config: JdbcDatabaseConfig): Int {
-        if (!options.allowEmptyWhereClause && context.where.isEmpty()) {
+        if (!options.allowEmptyWhereClause && context.getWhereDeclarations().isEmpty()) {
             error("Empty where clause is not allowed.")
         }
         val statement = runner.buildStatement(config)

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/ClassNames.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/ClassNames.kt
@@ -16,5 +16,5 @@ internal object ClassNames {
     const val PropertyMetamodelStub = "org.komapper.core.dsl.metamodel.PropertyMetamodelStub"
     const val Clock = "java.time.Clock"
     const val EntityDescriptor = "__EntityDescriptor"
-    const val WhereScope = "org.komapper.core.dsl.scope.WhereScope"
+    const val MetamodelDeclaration = "org.komapper.core.dsl.metamodel.MetamodelDeclaration"
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/ClassNames.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/ClassNames.kt
@@ -16,4 +16,5 @@ internal object ClassNames {
     const val PropertyMetamodelStub = "org.komapper.core.dsl.metamodel.PropertyMetamodelStub"
     const val Clock = "java.time.Clock"
     const val EntityDescriptor = "__EntityDescriptor"
+    const val WhereScope = "org.komapper.core.dsl.scope.WhereScope"
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -9,12 +9,12 @@ import org.komapper.processor.ClassNames.EntityMetamodel
 import org.komapper.processor.ClassNames.EntityMetamodelImplementor
 import org.komapper.processor.ClassNames.IdAssignment
 import org.komapper.processor.ClassNames.IdContext
+import org.komapper.processor.ClassNames.MetamodelDeclaration
 import org.komapper.processor.ClassNames.PropertyDescriptor
 import org.komapper.processor.ClassNames.PropertyMetamodel
 import org.komapper.processor.ClassNames.PropertyMetamodelImpl
 import org.komapper.processor.ClassNames.Sequence
 import org.komapper.processor.ClassNames.UUID
-import org.komapper.processor.ClassNames.WhereScope
 import java.io.PrintWriter
 import java.time.ZonedDateTime
 
@@ -26,20 +26,20 @@ internal class EntityMetamodelGenerator(
     private val w: PrintWriter
 ) : Runnable {
 
+    private val idTypeName: String = if (entity.idProperties.size == 1) {
+        entity.idProperties[0].typeName
+    } else {
+        "List<Any>"
+    }
+
     private val constructorParamList = listOf(
         "table: String = \"${entity.table.name}\"",
         "catalog: String = \"${entity.table.catalog}\"",
         "schema: String = \"${entity.table.schema}\"",
         "alwaysQuote: Boolean = ${entity.table.alwaysQuote}",
         "disableSequenceAssignment: Boolean = false",
-        "where: $WhereScope.($simpleName) -> Unit = {}"
+        "declarations: List<$MetamodelDeclaration<$entityTypeName, $idTypeName, $simpleName>> = emptyList()"
     ).joinToString(", ")
-
-    private val idTypeName: String = if (entity.idProperties.size == 1) {
-        entity.idProperties[0].typeName
-    } else {
-        "List<Any>"
-    }
 
     override fun run() {
         w.println("@file:Suppress(\"ClassName\", \"PrivatePropertyName\", \"UNUSED_PARAMETER\", \"unused\", \"RemoveRedundantQualifierName\", \"MemberVisibilityCanBePrivate\", \"RedundantNullableReturnType\")")
@@ -56,7 +56,7 @@ internal class EntityMetamodelGenerator(
         w.println("    private val __schemaName = schema")
         w.println("    private val __alwaysQuote = alwaysQuote")
         w.println("    private val __disableSequenceAssignment = disableSequenceAssignment")
-        w.println("    private val __where = where")
+        w.println("    private val __declarations = declarations")
 
         entityDescriptor()
 
@@ -67,7 +67,7 @@ internal class EntityMetamodelGenerator(
         catalogName()
         schemaName()
         alwaysQuote()
-        where()
+        declarations()
 
         idAssignment()
         idProperties()
@@ -151,8 +151,8 @@ internal class EntityMetamodelGenerator(
         w.println("    override fun alwaysQuote() = __alwaysQuote")
     }
 
-    private fun where() {
-        w.println("    override fun where() = $WhereScope().apply { __where(this@$simpleName) }.toList()")
+    private fun declarations() {
+        w.println("    override fun declarations() = __declarations")
     }
 
     private fun idAssignment() {
@@ -327,14 +327,14 @@ internal class EntityMetamodelGenerator(
 
     private fun newMeta() {
         val paramList =
-            "table: String, catalog: String, schema: String, alwaysQuote: Boolean, disableSequenceAssignment: Boolean, where: $WhereScope.($simpleName) -> Unit"
-        w.println("    override fun newMeta($paramList) = $simpleName(table, catalog, schema, alwaysQuote, disableSequenceAssignment, where)")
+            "table: String, catalog: String, schema: String, alwaysQuote: Boolean, disableSequenceAssignment: Boolean, declarations: List<$MetamodelDeclaration<$entityTypeName, $idTypeName, $simpleName>>"
+        w.println("    override fun newMeta($paramList) = $simpleName(table, catalog, schema, alwaysQuote, disableSequenceAssignment, declarations)")
     }
 
     private fun companionObject() {
         w.println("    companion object {")
         w.println("        val meta = $simpleName()")
-        w.println("        fun newMeta($constructorParamList) = $simpleName(table, catalog, schema, alwaysQuote, disableSequenceAssignment, where)")
+        w.println("        fun newMeta($constructorParamList) = $simpleName(table, catalog, schema, alwaysQuote, disableSequenceAssignment, declarations)")
         w.println("    }")
     }
 
@@ -342,6 +342,6 @@ internal class EntityMetamodelGenerator(
         val companionObjectName = (entity.companionObject.qualifiedName ?: entity.companionObject.simpleName).asString()
         w.println("")
         w.println("val $companionObjectName.meta get() = $simpleName.meta")
-        w.println("fun $companionObjectName.newMeta($constructorParamList) = $simpleName.newMeta(table, catalog, schema, alwaysQuote, disableSequenceAssignment, where)")
+        w.println("fun $companionObjectName.newMeta($constructorParamList) = $simpleName.newMeta(table, catalog, schema, alwaysQuote, disableSequenceAssignment, declarations)")
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/SqlDeleteR2dbcRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/SqlDeleteR2dbcRunner.kt
@@ -17,7 +17,7 @@ internal class SqlDeleteR2dbcRunner<ENTITY : Any, ID, META : EntityMetamodel<ENT
     private val runner: SqlDeleteRunner<ENTITY, ID, META> = SqlDeleteRunner(context, options)
 
     override suspend fun run(config: R2dbcDatabaseConfig): Int {
-        if (!options.allowEmptyWhereClause && context.where.isEmpty()) {
+        if (!options.allowEmptyWhereClause && context.getWhereDeclarations().isEmpty()) {
             error("Empty where clause is not allowed.")
         }
         val statement = runner.buildStatement(config)

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/SqlUpdateR2dbcRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/SqlUpdateR2dbcRunner.kt
@@ -17,7 +17,7 @@ internal class SqlUpdateR2dbcRunner<ENTITY : Any, ID, META : EntityMetamodel<ENT
     private val runner: SqlUpdateRunner<ENTITY, ID, META> = SqlUpdateRunner(context, options)
 
     override suspend fun run(config: R2dbcDatabaseConfig): Int {
-        if (!options.allowEmptyWhereClause && context.where.isEmpty()) {
+        if (!options.allowEmptyWhereClause && context.getWhereDeclarations().isEmpty()) {
             error("Empty where clause is not allowed.")
         }
         val statement = runner.buildStatement(config)


### PR DESCRIPTION
This feature is similar to the scope in Ruby on Rails.

Normal query example:
```kotlin
val a = Article.meta
// select * from article
val articles = db.runQuery { QueryDsl.from(a) }
```

Query example with a default where clause:
```kotlin
// define a default where clause 
val a = Article.meta.define { a -> where { a.published eq true } }
// select * from article where published = true
val articles = db.runQuery { QueryDsl.from(a) }
```

The default where clause is available in update and delete queries:
```kotlin
// update article set published = false where published = true and author = 'Smith'
db.runQuery { QueryDsl.update(a).set { a.published set false }.where { a.author eq "Smith" } }

// delete from article where published = true and author = 'Smith'
db.runQuery { QueryDsl.delete(a).where { a.author eq "Smith" } }
```