### PR TITLE
Explicitly generate import statements.

### DIFF
--- a/komapper-codegen/src/main/kotlin/org/komapper/codegen/CodeGenerator.kt
+++ b/komapper-codegen/src/main/kotlin/org/komapper/codegen/CodeGenerator.kt
@@ -67,7 +67,11 @@ class CodeGenerator(
                 p.println("package $packageName")
                 p.println()
             }
-            p.println("import org.komapper.annotation.*")
+            p.println("import org.komapper.annotation.KomapperAutoIncrement")
+            p.println("import org.komapper.annotation.KomapperColumn")
+            p.println("import org.komapper.annotation.KomapperEntityDef")
+            p.println("import org.komapper.annotation.KomapperId")
+            p.println("import org.komapper.annotation.KomapperTable")
             for (table in tables) {
                 p.println()
                 val className = SnakeToUpperCamelCase.apply(table.name)

--- a/komapper-codegen/src/test/kotlin/org/komapper/codegen/CodeGeneratorTest.kt
+++ b/komapper-codegen/src/test/kotlin/org/komapper/codegen/CodeGeneratorTest.kt
@@ -98,7 +98,11 @@ class CodeGeneratorTest {
         val expected = """
             package entity
 
-            import org.komapper.annotation.*
+            import org.komapper.annotation.KomapperAutoIncrement
+            import org.komapper.annotation.KomapperColumn
+            import org.komapper.annotation.KomapperEntityDef
+            import org.komapper.annotation.KomapperId
+            import org.komapper.annotation.KomapperTable
             
             @KomapperEntityDef(Address::class)
             @KomapperTable("ADDRESS")


### PR DESCRIPTION
Because some code formatters may refuse to import wildcards.