### PR TITLE
Fix bugs in programmatic transaction management

### DIFF
--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcSession.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcSession.kt
@@ -17,6 +17,11 @@ interface JdbcSession {
      * Returns a JDBC connection.
      */
     fun getConnection(): Connection
+
+    /**
+     * Releases a JDBC connection.
+     */
+    fun releaseConnection(connection: Connection)
 }
 
 class DefaultJdbcSession(private val dataSource: DataSource) : JdbcSession {
@@ -25,5 +30,9 @@ class DefaultJdbcSession(private val dataSource: DataSource) : JdbcSession {
 
     override fun getConnection(): Connection {
         return dataSource.connection
+    }
+
+    override fun releaseConnection(connection: Connection) {
+        connection.close()
     }
 }

--- a/komapper-quarkus-jdbc/src/main/kotlin/org/komapper/quarkus/jdbc/JtaTransactionSession.kt
+++ b/komapper-quarkus-jdbc/src/main/kotlin/org/komapper/quarkus/jdbc/JtaTransactionSession.kt
@@ -15,4 +15,8 @@ class JtaTransactionSession(
     override fun getConnection(): Connection {
         return dataSource.connection
     }
+
+    override fun releaseConnection(connection: Connection) {
+        connection.close()
+    }
 }

--- a/komapper-quarkus-jdbc/src/main/kotlin/org/komapper/quarkus/jdbc/JtaTransactionSession.kt
+++ b/komapper-quarkus-jdbc/src/main/kotlin/org/komapper/quarkus/jdbc/JtaTransactionSession.kt
@@ -6,7 +6,7 @@ import java.sql.Connection
 import javax.sql.DataSource
 import javax.transaction.TransactionManager
 
-internal class JtaTransactionSession(
+class JtaTransactionSession(
     transactionManager: TransactionManager,
     private val dataSource: DataSource
 ) : JdbcSession {

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcExecutor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcExecutor.kt
@@ -142,10 +142,10 @@ internal class R2dbcExecutor(
         return runCatching {
             block(con)
         }.onSuccess {
-            con.closeIfAutoCommitEnabled()
+            config.session.releaseConnection(con)
         }.onFailure { cause ->
             runCatching {
-                con.closeIfAutoCommitEnabled()
+                config.session.releaseConnection(con)
             }.onFailure {
                 cause.addSuppressed(cause)
             }
@@ -213,16 +213,5 @@ internal class R2dbcExecutor(
                 else -> error("Generated value is not Number. generatedColumn=$generatedColumn, value=$value, valueType=${value::class.qualifiedName}")
             }
         }
-    }
-}
-
-private object Null
-
-// TODO: Remove "isAutoCommit" check in the future.
-// This is a workaround to avoid Spring's IllegalTransactionStateException
-// See https://github.com/spring-projects/spring-framework/issues/28133
-private suspend fun Connection.closeIfAutoCommitEnabled() {
-    if (isAutoCommit) {
-        close().collect {}
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcExecutor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcExecutor.kt
@@ -16,6 +16,7 @@ import org.komapper.core.ExecutionOptionsProvider
 import org.komapper.core.Statement
 import org.komapper.core.UniqueConstraintException
 import org.reactivestreams.Publisher
+import java.util.Optional
 
 internal class R2dbcExecutor(
     private val config: R2dbcDatabaseConfig,
@@ -39,12 +40,11 @@ internal class R2dbcExecutor(
                 bind(r2dbcStmt, statement)
                 r2dbcStmt.execute().collect { result ->
                     result.map { row, _ ->
-                        transform(config.dialect, row) ?: Null
+                        val value = transform(config.dialect, row)
+                        Optional.ofNullable(value)
                     }.collect {
-                        val nullable = if (it is Null) null else it
-                        @Suppress("UNCHECKED_CAST")
-                        nullable as T
-                        emit(nullable)
+                        val value = it.orElse(null)
+                        emit(value)
                     }
                 }
             }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcSession.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcSession.kt
@@ -4,6 +4,7 @@ import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ConnectionFactory
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactive.collect
 import org.komapper.core.ThreadSafe
 import org.komapper.tx.core.CoroutineTransactionOperator
 import org.komapper.tx.core.FlowTransactionOperator
@@ -22,6 +23,11 @@ interface R2dbcSession {
      * Returns a R2DBC connection.
      */
     suspend fun getConnection(): Connection
+
+    /**
+     * Releases a R2DBC connection.
+     */
+    suspend fun releaseConnection(connection: Connection)
 }
 
 class DefaultR2dbcSession(private val connectionFactory: ConnectionFactory) : R2dbcSession {
@@ -34,5 +40,9 @@ class DefaultR2dbcSession(private val connectionFactory: ConnectionFactory) : R2
 
     override suspend fun getConnection(): Connection {
         return connectionFactory.create().asFlow().single()
+    }
+
+    override suspend fun releaseConnection(connection: Connection) {
+        connection.close().collect { }
     }
 }

--- a/komapper-spring-jdbc/build.gradle.kts
+++ b/komapper-spring-jdbc/build.gradle.kts
@@ -1,5 +1,27 @@
+plugins {
+    idea
+    id("com.google.devtools.ksp")
+}
+
 dependencies {
     val springVersion: String by project
     implementation("org.springframework:spring-jdbc:$springVersion")
     implementation(project(":komapper-jdbc"))
+    testImplementation(project(":komapper-annotation"))
+    testImplementation(project(":komapper-slf4j"))
+    testRuntimeOnly("ch.qos.logback:logback-classic:1.2.11")
+    testImplementation(project(":komapper-dialect-h2-jdbc"))
+    ksp(project(":komapper-processor"))
+}
+
+idea {
+    module {
+        sourceDirs = sourceDirs + file("build/generated/ksp/main/kotlin")
+        testSourceDirs = testSourceDirs + file("build/generated/ksp/test/kotlin")
+        generatedSourceDirs = generatedSourceDirs + file("build/generated/ksp/main/kotlin") + file("build/generated/ksp/test/kotlin")
+    }
+}
+
+ksp {
+    arg("komapper.namingStrategy", "UPPER_SNAKE_CASE")
 }

--- a/komapper-spring-jdbc/src/main/kotlin/org/komapper/spring/jdbc/PlatformTransactionSession.kt
+++ b/komapper-spring-jdbc/src/main/kotlin/org/komapper/spring/jdbc/PlatformTransactionSession.kt
@@ -2,22 +2,24 @@ package org.komapper.spring.jdbc
 
 import org.komapper.jdbc.JdbcSession
 import org.komapper.tx.core.TransactionOperator
-import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy
+import org.springframework.jdbc.datasource.DataSourceUtils
 import org.springframework.transaction.PlatformTransactionManager
 import java.sql.Connection
 import javax.sql.DataSource
 
-class PlatformTransactionSession(transactionManager: PlatformTransactionManager, dataSource: DataSource) :
+class PlatformTransactionSession(
+    transactionManager: PlatformTransactionManager,
+    private val dataSource: DataSource
+) :
     JdbcSession {
-
-    private val dataSourceProxy = when (dataSource) {
-        is TransactionAwareDataSourceProxy -> dataSource
-        else -> TransactionAwareDataSourceProxy(dataSource)
-    }
 
     override val transactionOperator: TransactionOperator = PlatformTransactionOperator(transactionManager)
 
     override fun getConnection(): Connection {
-        return dataSourceProxy.connection
+        return DataSourceUtils.getConnection(dataSource)
+    }
+
+    override fun releaseConnection(connection: Connection) {
+        DataSourceUtils.releaseConnection(connection, dataSource)
     }
 }

--- a/komapper-spring-jdbc/src/test/kotlin/org/komapper/spring/jdbc/Address.kt
+++ b/komapper-spring-jdbc/src/test/kotlin/org/komapper/spring/jdbc/Address.kt
@@ -1,0 +1,14 @@
+package org.komapper.spring.jdbc
+
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperId
+import org.komapper.annotation.KomapperVersion
+
+@KomapperEntity
+data class Address(
+    @KomapperId
+    val addressId: Int,
+    val street: String,
+    @KomapperVersion
+    val version: Int,
+)

--- a/komapper-spring-r2dbc/build.gradle.kts
+++ b/komapper-spring-r2dbc/build.gradle.kts
@@ -1,7 +1,29 @@
+plugins {
+    idea
+    id("com.google.devtools.ksp")
+}
+
 dependencies {
     val kotlinCoroutinesVersion: String by project
     val springVersion: String by project
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion")
     implementation("org.springframework:spring-r2dbc:$springVersion")
     implementation(project(":komapper-r2dbc"))
+    testImplementation(project(":komapper-annotation"))
+    testImplementation(project(":komapper-slf4j"))
+    testRuntimeOnly("ch.qos.logback:logback-classic:1.2.11")
+    testImplementation(project(":komapper-dialect-h2-r2dbc"))
+    ksp(project(":komapper-processor"))
+}
+
+idea {
+    module {
+        sourceDirs = sourceDirs + file("build/generated/ksp/main/kotlin")
+        testSourceDirs = testSourceDirs + file("build/generated/ksp/test/kotlin")
+        generatedSourceDirs = generatedSourceDirs + file("build/generated/ksp/main/kotlin") + file("build/generated/ksp/test/kotlin")
+    }
+}
+
+ksp {
+    arg("komapper.namingStrategy", "UPPER_SNAKE_CASE")
 }

--- a/komapper-spring-r2dbc/build.gradle.kts
+++ b/komapper-spring-r2dbc/build.gradle.kts
@@ -1,5 +1,7 @@
 dependencies {
+    val kotlinCoroutinesVersion: String by project
     val springVersion: String by project
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion")
     implementation("org.springframework:spring-r2dbc:$springVersion")
     implementation(project(":komapper-r2dbc"))
 }

--- a/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/Null.kt
+++ b/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/Null.kt
@@ -1,3 +1,0 @@
-package org.komapper.spring.r2dbc
-
-internal object Null

--- a/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/ReactiveCoroutineTransactionOperator.kt
+++ b/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/ReactiveCoroutineTransactionOperator.kt
@@ -10,6 +10,7 @@ import org.komapper.tx.core.TransactionAttribute
 import org.komapper.tx.core.TransactionProperty
 import org.springframework.transaction.ReactiveTransactionManager
 import org.springframework.transaction.reactive.TransactionalOperator
+import java.util.Optional
 import kotlin.coroutines.coroutineContext
 
 internal class ReactiveCoroutineTransactionOperator(private val transactionManager: ReactiveTransactionManager) :
@@ -49,11 +50,9 @@ internal class ReactiveCoroutineTransactionOperator(private val transactionManag
                     }
                 })
                 emit(value)
-            }.map { it ?: Null }.asFlux(context)
+            }.map { Optional.ofNullable(it) }.asFlux(context)
         }
-        val value = flux.asFlow().map { if (it == Null) null else it }.single()
-        @Suppress("UNCHECKED_CAST")
-        return value as R
+        return flux.asFlow().map { it.orElse(null) }.single()
     }
 
     override suspend fun setRollbackOnly() {

--- a/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/ReactiveFlowTransactionOperator.kt
+++ b/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/ReactiveFlowTransactionOperator.kt
@@ -11,6 +11,7 @@ import org.komapper.tx.core.TransactionAttribute
 import org.komapper.tx.core.TransactionProperty
 import org.springframework.transaction.ReactiveTransactionManager
 import org.springframework.transaction.reactive.TransactionalOperator
+import java.util.Optional
 import kotlin.coroutines.coroutineContext
 
 internal class ReactiveFlowTransactionOperator(private val transactionManager: ReactiveTransactionManager) :
@@ -50,12 +51,10 @@ internal class ReactiveFlowTransactionOperator(private val transactionManager: R
                             return tx.isRollbackOnly
                         }
                     })
-                }.map { it ?: Null }.asFlux(context)
+                }.map { Optional.ofNullable(it) }.asFlux(context)
             }
             flux.collect {
-                val value = if (it == Null) null else it
-                @Suppress("UNCHECKED_CAST")
-                value as R
+                val value = it.orElse(null)
                 emit(value)
             }
         }

--- a/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/ReactiveTransactionSession.kt
+++ b/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/ReactiveTransactionSession.kt
@@ -7,19 +7,14 @@ import kotlinx.coroutines.reactive.asFlow
 import org.komapper.r2dbc.R2dbcSession
 import org.komapper.tx.core.CoroutineTransactionOperator
 import org.komapper.tx.core.FlowTransactionOperator
-import org.springframework.r2dbc.connection.TransactionAwareConnectionFactoryProxy
+import org.springframework.r2dbc.connection.ConnectionFactoryUtils
 import org.springframework.transaction.ReactiveTransactionManager
 
 class ReactiveTransactionSession(
     transactionManager: ReactiveTransactionManager,
-    connectionFactory: ConnectionFactory
+    private val connectionFactory: ConnectionFactory
 ) :
     R2dbcSession {
-
-    private val connectionFactoryProxy = when (connectionFactory) {
-        is TransactionAwareConnectionFactoryProxy -> connectionFactory
-        else -> TransactionAwareConnectionFactoryProxy(connectionFactory)
-    }
 
     override val coroutineTransactionOperator: CoroutineTransactionOperator =
         ReactiveCoroutineTransactionOperator(transactionManager)
@@ -28,6 +23,6 @@ class ReactiveTransactionSession(
         ReactiveFlowTransactionOperator(transactionManager)
 
     override suspend fun getConnection(): Connection {
-        return connectionFactoryProxy.create().asFlow().single()
+        return ConnectionFactoryUtils.getConnection(connectionFactory).asFlow().single()
     }
 }

--- a/komapper-spring-r2dbc/src/test/kotlin/org/komapper/spring/r2dbc/Address.kt
+++ b/komapper-spring-r2dbc/src/test/kotlin/org/komapper/spring/r2dbc/Address.kt
@@ -1,0 +1,14 @@
+package org.komapper.spring.r2dbc
+
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperId
+import org.komapper.annotation.KomapperVersion
+
+@KomapperEntity
+data class Address(
+    @KomapperId
+    val addressId: Int,
+    val street: String,
+    @KomapperVersion
+    val version: Int,
+)

--- a/komapper-spring-r2dbc/src/test/kotlin/org/komapper/spring/r2dbc/ReactiveCoroutineTransactionOperatorTest.kt
+++ b/komapper-spring-r2dbc/src/test/kotlin/org/komapper/spring/r2dbc/ReactiveCoroutineTransactionOperatorTest.kt
@@ -1,4 +1,4 @@
-package org.komapper.tx.r2dbc
+package org.komapper.spring.r2dbc
 
 import io.r2dbc.spi.ConnectionFactories
 import kotlinx.coroutines.runBlocking
@@ -9,6 +9,7 @@ import org.komapper.dialect.h2.r2dbc.R2dbcH2Dialect
 import org.komapper.r2dbc.DefaultR2dbcDatabaseConfig
 import org.komapper.r2dbc.R2dbcDatabase
 import org.komapper.r2dbc.R2dbcSession
+import org.springframework.r2dbc.connection.R2dbcTransactionManager
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -16,13 +17,12 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-internal class R2dbcCoroutineTransactionOperatorTest {
+internal class ReactiveCoroutineTransactionOperatorTest {
 
     private val connectionFactory = ConnectionFactories.get("r2dbc:h2:mem:///transaction-test;DB_CLOSE_DELAY=-1")
+    private val transactionManager = R2dbcTransactionManager(connectionFactory)
     private val config = object : DefaultR2dbcDatabaseConfig(connectionFactory, R2dbcH2Dialect()) {
-        override val session: R2dbcSession by lazy {
-            R2dbcTransactionSession(connectionFactory, loggerFacade)
-        }
+        override val session: R2dbcSession = ReactiveTransactionSession(transactionManager, connectionFactory)
     }
     private val db = R2dbcDatabase(config)
 

--- a/komapper-spring-r2dbc/src/test/kotlin/org/komapper/spring/r2dbc/ReactiveFlowTransactionOperatorTest.kt
+++ b/komapper-spring-r2dbc/src/test/kotlin/org/komapper/spring/r2dbc/ReactiveFlowTransactionOperatorTest.kt
@@ -1,6 +1,8 @@
-package org.komapper.tx.r2dbc
+package org.komapper.spring.r2dbc
 
 import io.r2dbc.spi.ConnectionFactories
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.runBlocking
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
@@ -9,6 +11,7 @@ import org.komapper.dialect.h2.r2dbc.R2dbcH2Dialect
 import org.komapper.r2dbc.DefaultR2dbcDatabaseConfig
 import org.komapper.r2dbc.R2dbcDatabase
 import org.komapper.r2dbc.R2dbcSession
+import org.springframework.r2dbc.connection.R2dbcTransactionManager
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -16,24 +19,24 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-internal class R2dbcCoroutineTransactionOperatorTest {
+internal class ReactiveFlowTransactionOperatorTest {
 
     private val connectionFactory = ConnectionFactories.get("r2dbc:h2:mem:///transaction-test;DB_CLOSE_DELAY=-1")
+    private val transactionManager = R2dbcTransactionManager(connectionFactory)
     private val config = object : DefaultR2dbcDatabaseConfig(connectionFactory, R2dbcH2Dialect()) {
-        override val session: R2dbcSession by lazy {
-            R2dbcTransactionSession(connectionFactory, loggerFacade)
-        }
+        override val session: R2dbcSession = ReactiveTransactionSession(transactionManager, connectionFactory)
     }
     private val db = R2dbcDatabase(config)
 
     @Test
     fun commit() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             assertFalse(tx.isRollbackOnly())
             val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address.copy(street = "TOKYO")) }
-        }
+            Unit
+        }.collect()
         val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         assertEquals("TOKYO", address.street)
     }
@@ -41,12 +44,13 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun setRollbackOnly() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             tx.setRollbackOnly()
             assertTrue(tx.isRollbackOnly())
             val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address.copy(street = "TOKYO")) }
-        }
+            Unit
+        }.collect()
         val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         assertEquals("STREET 1", address.street)
     }
@@ -54,17 +58,18 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun setRollbackOnly_required() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             tx.setRollbackOnly()
             assertTrue(tx.isRollbackOnly())
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.required {
+            val requiredFlow = tx.required<Unit> {
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                 Unit
             }
-        }
+            emitAll(requiredFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("STREET 1", address1.street)
@@ -74,17 +79,18 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun setRollbackOnly_requiresNew() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             tx.setRollbackOnly()
             assertTrue(tx.isRollbackOnly())
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.requiresNew {
+            val requiresNewFlow = tx.requiresNew<Unit> {
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                 Unit
             }
-        }
+            emitAll(requiresNewFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("STREET 1", address1.street)
@@ -95,11 +101,11 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     fun throwRuntimeException() = runBlocking {
         val a = Meta.address
         try {
-            db.withTransaction {
+            db.flowTransaction<Unit> {
                 val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address.copy(street = "TOKYO")) }
                 throw RuntimeException()
-            }
+            }.collect()
         } catch (ignored: Exception) {
         }
         val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
@@ -110,11 +116,11 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     fun throwException() = runBlocking {
         val a = Meta.address
         try {
-            db.withTransaction {
+            db.flowTransaction<Unit> {
                 val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address.copy(street = "TOKYO")) }
                 throw Exception()
-            }
+            }.collect()
         } catch (ignored: Exception) {
         }
         val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
@@ -124,14 +130,16 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun required_commit() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.required {
+            val requiredFlow = tx.required<Unit> {
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
+                Unit
             }
-        }
+            emitAll(requiredFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -141,16 +149,18 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun required_setRollbackOnly() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.required { tx2 ->
+            val requiredFlow = tx.required<Unit> { tx2 ->
                 tx2.setRollbackOnly()
                 assertTrue(tx2.isRollbackOnly())
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
+                Unit
             }
-        }
+            emitAll(requiredFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("STREET 1", address1.street)
@@ -160,18 +170,19 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun required_throwRuntimeException() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
             try {
-                tx.required {
+                val requiredFlow = tx.required<Unit> {
                     val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                     db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                     throw RuntimeException()
                 }
+                emitAll(requiredFlow)
             } catch (ignored: Exception) {
             }
-        }
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -181,18 +192,19 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun required_throwException() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
             try {
-                tx.required {
+                val requiredFlow = tx.required<Unit> {
                     val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                     db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                     throw Exception()
                 }
+                emitAll(requiredFlow)
             } catch (ignored: Exception) {
             }
-        }
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -202,14 +214,16 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun requiresNew_commit() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.requiresNew {
+            val requiresNewFlow = tx.requiresNew<Unit> {
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
+                Unit
             }
-        }
+            emitAll(requiresNewFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -219,16 +233,18 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun requiresNew_setRollbackOnly() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.requiresNew { tx2 ->
+            val requiresNewFlow = tx.requiresNew<Unit> { tx2 ->
                 tx2.setRollbackOnly()
                 assertTrue(tx2.isRollbackOnly())
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
+                Unit
             }
-        }
+            emitAll(requiresNewFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -238,18 +254,19 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun requiresNew_throwRuntimeException() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
             try {
-                tx.requiresNew {
+                val requiresNewFlow = tx.requiresNew<Unit> {
                     val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                     db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                     throw RuntimeException()
                 }
+                emitAll(requiresNewFlow)
             } catch (ignored: Exception) {
             }
-        }
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -259,18 +276,19 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun requiresNew_throwException() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
             try {
-                tx.requiresNew {
+                val requiresNewFlow = tx.requiresNew<Unit> {
                     val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                     db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                     throw Exception()
                 }
+                emitAll(requiresNewFlow)
             } catch (ignored: Exception) {
             }
-        }
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)

--- a/komapper-tx-jdbc/build.gradle.kts
+++ b/komapper-tx-jdbc/build.gradle.kts
@@ -1,4 +1,25 @@
+plugins {
+    idea
+    id("com.google.devtools.ksp")
+}
+
 dependencies {
     api(project(":komapper-jdbc"))
-    testRuntimeOnly("com.h2database:h2:2.1.210")
+    testImplementation(project(":komapper-annotation"))
+    testImplementation(project(":komapper-slf4j"))
+    testRuntimeOnly("ch.qos.logback:logback-classic:1.2.11")
+    testImplementation(project(":komapper-dialect-h2-jdbc"))
+    ksp(project(":komapper-processor"))
+}
+
+idea {
+    module {
+        sourceDirs = sourceDirs + file("build/generated/ksp/main/kotlin")
+        testSourceDirs = testSourceDirs + file("build/generated/ksp/test/kotlin")
+        generatedSourceDirs = generatedSourceDirs + file("build/generated/ksp/main/kotlin") + file("build/generated/ksp/test/kotlin")
+    }
+}
+
+ksp {
+    arg("komapper.namingStrategy", "UPPER_SNAKE_CASE")
 }

--- a/komapper-tx-jdbc/src/main/kotlin/org/komapper/tx/jdbc/JdbcTransactionSession.kt
+++ b/komapper-tx-jdbc/src/main/kotlin/org/komapper/tx/jdbc/JdbcTransactionSession.kt
@@ -26,4 +26,8 @@ class JdbcTransactionSession(
     override fun getConnection(): Connection {
         return transactionManager.getConnection()
     }
+
+    override fun releaseConnection(connection: Connection) {
+        connection.close()
+    }
 }

--- a/komapper-tx-jdbc/src/test/kotlin/org/komapper/tx/jdbc/Address.kt
+++ b/komapper-tx-jdbc/src/test/kotlin/org/komapper/tx/jdbc/Address.kt
@@ -1,0 +1,14 @@
+package org.komapper.tx.jdbc
+
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperId
+import org.komapper.annotation.KomapperVersion
+
+@KomapperEntity
+data class Address(
+    @KomapperId
+    val addressId: Int,
+    val street: String,
+    @KomapperVersion
+    val version: Int,
+)

--- a/komapper-tx-r2dbc/build.gradle.kts
+++ b/komapper-tx-r2dbc/build.gradle.kts
@@ -1,6 +1,26 @@
+plugins {
+    idea
+    id("com.google.devtools.ksp")
+}
+
 dependencies {
     val r2dbcVersion: String by project
     api(project(":komapper-r2dbc"))
-    testImplementation(platform("io.r2dbc:r2dbc-bom:$r2dbcVersion"))
-    testRuntimeOnly("io.r2dbc:r2dbc-h2")
+    testImplementation(project(":komapper-annotation"))
+    testImplementation(project(":komapper-slf4j"))
+    testRuntimeOnly("ch.qos.logback:logback-classic:1.2.11")
+    testImplementation(project(":komapper-dialect-h2-r2dbc"))
+    ksp(project(":komapper-processor"))
+}
+
+idea {
+    module {
+        sourceDirs = sourceDirs + file("build/generated/ksp/main/kotlin")
+        testSourceDirs = testSourceDirs + file("build/generated/ksp/test/kotlin")
+        generatedSourceDirs = generatedSourceDirs + file("build/generated/ksp/main/kotlin") + file("build/generated/ksp/test/kotlin")
+    }
+}
+
+ksp {
+    arg("komapper.namingStrategy", "UPPER_SNAKE_CASE")
 }

--- a/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcTransactionSession.kt
+++ b/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcTransactionSession.kt
@@ -2,6 +2,7 @@ package org.komapper.tx.r2dbc
 
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ConnectionFactory
+import kotlinx.coroutines.reactive.collect
 import org.komapper.core.LoggerFacade
 import org.komapper.r2dbc.R2dbcSession
 import org.komapper.tx.core.CoroutineTransactionOperator
@@ -29,5 +30,9 @@ class R2dbcTransactionSession(
 
     override suspend fun getConnection(): Connection {
         return transactionManager.getConnection()
+    }
+
+    override suspend fun releaseConnection(connection: Connection) {
+        connection.close().collect { }
     }
 }

--- a/komapper-tx-r2dbc/src/test/kotlin/org/komapper/tx/r2dbc/Address.kt
+++ b/komapper-tx-r2dbc/src/test/kotlin/org/komapper/tx/r2dbc/Address.kt
@@ -1,0 +1,14 @@
+package org.komapper.tx.r2dbc
+
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperId
+import org.komapper.annotation.KomapperVersion
+
+@KomapperEntity
+data class Address(
+    @KomapperId
+    val addressId: Int,
+    val street: String,
+    @KomapperVersion
+    val version: Int,
+)

--- a/komapper-tx-r2dbc/src/test/kotlin/org/komapper/tx/r2dbc/R2dbcFlowTransactionOperatorTest.kt
+++ b/komapper-tx-r2dbc/src/test/kotlin/org/komapper/tx/r2dbc/R2dbcFlowTransactionOperatorTest.kt
@@ -1,6 +1,8 @@
 package org.komapper.tx.r2dbc
 
 import io.r2dbc.spi.ConnectionFactories
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.runBlocking
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
@@ -16,7 +18,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-internal class R2dbcCoroutineTransactionOperatorTest {
+internal class R2dbcFlowTransactionOperatorTest {
 
     private val connectionFactory = ConnectionFactories.get("r2dbc:h2:mem:///transaction-test;DB_CLOSE_DELAY=-1")
     private val config = object : DefaultR2dbcDatabaseConfig(connectionFactory, R2dbcH2Dialect()) {
@@ -29,11 +31,12 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun commit() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             assertFalse(tx.isRollbackOnly())
             val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address.copy(street = "TOKYO")) }
-        }
+            Unit
+        }.collect()
         val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         assertEquals("TOKYO", address.street)
     }
@@ -41,12 +44,13 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun setRollbackOnly() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             tx.setRollbackOnly()
             assertTrue(tx.isRollbackOnly())
             val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address.copy(street = "TOKYO")) }
-        }
+            Unit
+        }.collect()
         val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         assertEquals("STREET 1", address.street)
     }
@@ -54,17 +58,18 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun setRollbackOnly_required() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             tx.setRollbackOnly()
             assertTrue(tx.isRollbackOnly())
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.required {
+            val requiredFlow = tx.required<Unit> {
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                 Unit
             }
-        }
+            emitAll(requiredFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("STREET 1", address1.street)
@@ -74,17 +79,18 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun setRollbackOnly_requiresNew() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             tx.setRollbackOnly()
             assertTrue(tx.isRollbackOnly())
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.requiresNew {
+            val requiresNewFlow = tx.requiresNew<Unit> {
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                 Unit
             }
-        }
+            emitAll(requiresNewFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("STREET 1", address1.street)
@@ -95,11 +101,11 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     fun throwRuntimeException() = runBlocking {
         val a = Meta.address
         try {
-            db.withTransaction {
+            db.flowTransaction<Unit> {
                 val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address.copy(street = "TOKYO")) }
                 throw RuntimeException()
-            }
+            }.collect()
         } catch (ignored: Exception) {
         }
         val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
@@ -110,11 +116,11 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     fun throwException() = runBlocking {
         val a = Meta.address
         try {
-            db.withTransaction {
+            db.flowTransaction<Unit> {
                 val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address.copy(street = "TOKYO")) }
                 throw Exception()
-            }
+            }.collect()
         } catch (ignored: Exception) {
         }
         val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
@@ -124,14 +130,16 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun required_commit() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.required {
+            val requiredFlow = tx.required<Unit> {
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
+                Unit
             }
-        }
+            emitAll(requiredFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -141,16 +149,18 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun required_setRollbackOnly() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.required { tx2 ->
+            val requiredFlow = tx.required<Unit> { tx2 ->
                 tx2.setRollbackOnly()
                 assertTrue(tx2.isRollbackOnly())
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
+                Unit
             }
-        }
+            emitAll(requiredFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("STREET 1", address1.street)
@@ -160,18 +170,19 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun required_throwRuntimeException() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
             try {
-                tx.required {
+                val requiredFlow = tx.required<Unit> {
                     val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                     db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                     throw RuntimeException()
                 }
+                emitAll(requiredFlow)
             } catch (ignored: Exception) {
             }
-        }
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -181,18 +192,19 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun required_throwException() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
             try {
-                tx.required {
+                val requiredFlow = tx.required<Unit> {
                     val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                     db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                     throw Exception()
                 }
+                emitAll(requiredFlow)
             } catch (ignored: Exception) {
             }
-        }
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -202,14 +214,16 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun requiresNew_commit() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.requiresNew {
+            val requiresNewFlow = tx.requiresNew<Unit> {
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
+                Unit
             }
-        }
+            emitAll(requiresNewFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -219,16 +233,18 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun requiresNew_setRollbackOnly() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
-            tx.requiresNew { tx2 ->
+            val requiresNewFlow = tx.requiresNew<Unit> { tx2 ->
                 tx2.setRollbackOnly()
                 assertTrue(tx2.isRollbackOnly())
                 val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                 db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
+                Unit
             }
-        }
+            emitAll(requiresNewFlow)
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -238,18 +254,19 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun requiresNew_throwRuntimeException() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
             try {
-                tx.requiresNew {
+                val requiresNewFlow = tx.requiresNew<Unit> {
                     val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                     db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                     throw RuntimeException()
                 }
+                emitAll(requiresNewFlow)
             } catch (ignored: Exception) {
             }
-        }
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)
@@ -259,18 +276,19 @@ internal class R2dbcCoroutineTransactionOperatorTest {
     @Test
     fun requiresNew_throwException() = runBlocking {
         val a = Meta.address
-        db.withTransaction { tx ->
+        db.flowTransaction<Unit> { tx ->
             val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
             db.runQuery { QueryDsl.update(a).single(address1.copy(street = "TOKYO")) }
             try {
-                tx.requiresNew {
+                val requiresNewFlow = tx.requiresNew<Unit> {
                     val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
                     db.runQuery { QueryDsl.update(a).single(address2.copy(street = "OSAKA")) }
                     throw Exception()
                 }
+                emitAll(requiresNewFlow)
             } catch (ignored: Exception) {
             }
-        }
+        }.collect()
         val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.single() }
         val address2 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 2 }.single() }
         assertEquals("TOKYO", address1.street)


### PR DESCRIPTION
The following transaction operators should have the same behavior:

- JdbcTransactionOperator
- PlatformTransactionOperator
- JtaTransactionOperator
- R2dbcCoroutineTransactionOperator
- R2dbcFlowTransactionOperator
- ReactiveCoroutineTransactionOperator
- ReactiveFlowTransactionOperator
