### PR TITLE
Remove sqlcommenter dependency from the WebFlux example project.

### DIFF
--- a/example-spring-boot-r2dbc/build.gradle.kts
+++ b/example-spring-boot-r2dbc/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation(project(":komapper-spring-boot-starter-r2dbc"))
-    implementation(project(":komapper-sqlcommenter"))
     runtimeOnly(project(":komapper-dialect-h2-r2dbc"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/example-spring-boot-r2dbc/src/main/kotlin/example/spring/boot/r2dbc/WebConfig.kt
+++ b/example-spring-boot-r2dbc/src/main/kotlin/example/spring/boot/r2dbc/WebConfig.kt
@@ -1,22 +1,9 @@
 package example.spring.boot.r2dbc
 
-import com.google.cloud.sqlcommenter.interceptors.SpringSQLCommenterInterceptor
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.servlet.config.annotation.EnableWebMvc
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import org.springframework.web.reactive.config.EnableWebFlux
+import org.springframework.web.reactive.config.WebFluxConfigurer
 
-@EnableWebMvc
+@EnableWebFlux
 @Configuration
-class WebConfig : WebMvcConfigurer {
-
-    @Bean
-    fun sqlInterceptor(): SpringSQLCommenterInterceptor {
-        return SpringSQLCommenterInterceptor()
-    }
-
-    override fun addInterceptors(registry: InterceptorRegistry) {
-        registry.addInterceptor(sqlInterceptor())
-    }
-}
+class WebConfig : WebFluxConfigurer


### PR DESCRIPTION
Because sqlcommenter depends on Web MVC.