### PR TITLE
Support for registering user-defined data types

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/entities_dataType.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/entities_dataType.kt
@@ -159,3 +159,15 @@ data class UnsignedSequenceStrategy(
     @KomapperId @KomapperSequence(name = "sequence_strategy_id", incrementBy = 100) val id: UInt,
     @KomapperColumn(alwaysQuote = true) val value: String
 )
+
+@KomapperEntity
+@KomapperTable("int_data")
+data class UserIntData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UserInt?)
+
+data class UserInt(val value: Int)
+
+@KomapperEntity
+@KomapperTable("string_data")
+data class UserStringData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UserString?)
+
+data class UserString(val value: String)

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/UserIntType.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/UserIntType.kt
@@ -1,0 +1,32 @@
+package integration.jdbc
+
+import integration.core.UserInt
+import org.komapper.jdbc.spi.JdbcUserDataType
+import java.sql.JDBCType
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import kotlin.reflect.KClass
+
+class UserIntType : JdbcUserDataType<UserInt> {
+    override val name: String = "integer"
+
+    override val klass: KClass<UserInt> = UserInt::class
+
+    override val jdbcType: JDBCType = JDBCType.INTEGER
+
+    override fun getValue(rs: ResultSet, index: Int): UserInt {
+        return UserInt(rs.getInt(index))
+    }
+
+    override fun getValue(rs: ResultSet, columnLabel: String): UserInt {
+        return UserInt(rs.getInt(columnLabel))
+    }
+
+    override fun setValue(ps: PreparedStatement, index: Int, value: UserInt) {
+        ps.setInt(index, value.value)
+    }
+
+    override fun toString(value: UserInt): String {
+        return value.value.toString()
+    }
+}

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/UserStringType.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/UserStringType.kt
@@ -1,0 +1,32 @@
+package integration.jdbc
+
+import integration.core.UserString
+import org.komapper.jdbc.spi.JdbcUserDataType
+import java.sql.JDBCType
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import kotlin.reflect.KClass
+
+class UserStringType : JdbcUserDataType<UserString> {
+    override val name: String = "varchar(100)"
+
+    override val klass: KClass<UserString> = UserString::class
+
+    override val jdbcType: JDBCType = JDBCType.VARCHAR
+
+    override fun getValue(rs: ResultSet, index: Int): UserString? {
+        return rs.getString(index)?.let { UserString(it) }
+    }
+
+    override fun getValue(rs: ResultSet, columnLabel: String): UserString? {
+        return rs.getString(columnLabel)?.let { UserString(it) }
+    }
+
+    override fun setValue(ps: PreparedStatement, index: Int, value: UserString) {
+        ps.setString(index, value.value)
+    }
+
+    override fun toString(value: UserString): String {
+        return value.value
+    }
+}

--- a/integration-test-jdbc/src/main/resources/META-INF/services/org.komapper.jdbc.spi.JdbcUserDataType
+++ b/integration-test-jdbc/src/main/resources/META-INF/services/org.komapper.jdbc.spi.JdbcUserDataType
@@ -1,0 +1,2 @@
+integration.jdbc.UserIntType
+integration.jdbc.UserStringType

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDataTypeTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDataTypeTest.kt
@@ -31,6 +31,10 @@ import integration.core.UnsignedAddress
 import integration.core.UnsignedAddress2
 import integration.core.UnsignedIdentityStrategy
 import integration.core.UnsignedSequenceStrategy
+import integration.core.UserInt
+import integration.core.UserIntData
+import integration.core.UserString
+import integration.core.UserStringData
 import integration.core.anyData
 import integration.core.bigDecimalData
 import integration.core.bigIntegerData
@@ -58,6 +62,8 @@ import integration.core.unsignedAddress
 import integration.core.unsignedAddress2
 import integration.core.unsignedIdentityStrategy
 import integration.core.unsignedSequenceStrategy
+import integration.core.userIntData
+import integration.core.userStringData
 import integration.core.uuidData
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.dsl.Meta
@@ -848,6 +854,50 @@ class JdbcDataTypeTest(val db: JdbcDatabase) {
     fun uuid_null() {
         val m = Meta.uuidData
         val data = UUIDData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun userInt() {
+        val m = Meta.userIntData
+        val data = UserIntData(1, UserInt(123))
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun userInt_null() {
+        val m = Meta.userIntData
+        val data = UserIntData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun userString() {
+        val m = Meta.userStringData
+        val data = UserStringData(1, UserString("ABC"))
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun userString_null() {
+        val m = Meta.userStringData
+        val data = UserStringData(1, null)
         db.runQuery { QueryDsl.insert(m).single(data) }
         val data2 = db.runQuery {
             QueryDsl.from(m).where { m.id eq 1 }.first()

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/UserIntType.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/UserIntType.kt
@@ -1,0 +1,36 @@
+package integration.r2dbc
+
+import integration.core.UserInt
+import io.r2dbc.spi.Row
+import io.r2dbc.spi.Statement
+import org.komapper.r2dbc.spi.R2dbcUserDataType
+import kotlin.reflect.KClass
+
+class UserIntType : R2dbcUserDataType<UserInt> {
+
+    override val name: String = "integer"
+
+    override val klass: KClass<UserInt> = UserInt::class
+
+    override val javaObjectType: Class<*> = Int::class.javaObjectType
+
+    override fun getValue(row: Row, index: Int): UserInt? {
+        return row.get(index, Int::class.javaObjectType)?.let { UserInt(it) }
+    }
+
+    override fun getValue(row: Row, columnLabel: String): UserInt? {
+        return row.get(columnLabel, Int::class.javaObjectType)?.let { UserInt(it) }
+    }
+
+    override fun setValue(statement: Statement, index: Int, value: UserInt) {
+        statement.bind(index, value.value)
+    }
+
+    override fun setValue(statement: Statement, name: String, value: UserInt) {
+        statement.bind(name, value.value)
+    }
+
+    override fun toString(value: UserInt): String {
+        return value.value.toString()
+    }
+}

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/UserStringType.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/UserStringType.kt
@@ -1,0 +1,35 @@
+package integration.r2dbc
+
+import integration.core.UserString
+import io.r2dbc.spi.Row
+import io.r2dbc.spi.Statement
+import org.komapper.r2dbc.spi.R2dbcUserDataType
+import kotlin.reflect.KClass
+
+class UserStringType : R2dbcUserDataType<UserString> {
+    override val name: String = "varchar(100)"
+
+    override val klass: KClass<*> = UserString::class
+
+    override val javaObjectType: Class<*> = String::class.javaObjectType
+
+    override fun getValue(row: Row, index: Int): UserString? {
+        return row.get(index, String::class.javaObjectType)?.let { UserString(it) }
+    }
+
+    override fun getValue(row: Row, columnLabel: String): UserString? {
+        return row.get(columnLabel, String::class.javaObjectType)?.let { UserString(it) }
+    }
+
+    override fun setValue(statement: Statement, index: Int, value: UserString) {
+        statement.bind(index, value.value)
+    }
+
+    override fun setValue(statement: Statement, name: String, value: UserString) {
+        statement.bind(name, value.value)
+    }
+
+    override fun toString(value: UserString): String {
+        return value.value
+    }
+}

--- a/integration-test-r2dbc/src/main/resources/META-INF/services/org.komapper.r2dbc.spi.R2dbcUserDataType
+++ b/integration-test-r2dbc/src/main/resources/META-INF/services/org.komapper.r2dbc.spi.R2dbcUserDataType
@@ -1,0 +1,2 @@
+integration.r2dbc.UserIntType
+integration.r2dbc.UserStringType

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
@@ -29,6 +29,10 @@ import integration.core.UnsignedAddress
 import integration.core.UnsignedAddress2
 import integration.core.UnsignedIdentityStrategy
 import integration.core.UnsignedSequenceStrategy
+import integration.core.UserInt
+import integration.core.UserIntData
+import integration.core.UserString
+import integration.core.UserStringData
 import integration.core.bigDecimalData
 import integration.core.bigIntegerData
 import integration.core.booleanData
@@ -55,6 +59,8 @@ import integration.core.unsignedAddress
 import integration.core.unsignedAddress2
 import integration.core.unsignedIdentityStrategy
 import integration.core.unsignedSequenceStrategy
+import integration.core.userIntData
+import integration.core.userStringData
 import integration.core.uuidData
 import io.r2dbc.spi.Blob
 import io.r2dbc.spi.Clob
@@ -799,6 +805,50 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
     fun uuid_null(info: TestInfo) = inTransaction(db, info) {
         val m = Meta.uuidData
         val data = UUIDData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun userInt(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.userIntData
+        val data = UserIntData(1, UserInt(123))
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun userInt_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.userIntData
+        val data = UserIntData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun userString(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.userStringData
+        val data = UserStringData(1, UserString("ABC"))
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun userString_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.userStringData
+        val data = UserStringData(1, null)
         db.runQuery { QueryDsl.insert(m).single(data) }
         val data2 = db.runQuery {
             QueryDsl.from(m).where { m.id eq 1 }.first()

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataTypeProviders.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataTypeProviders.kt
@@ -1,6 +1,7 @@
 package org.komapper.jdbc
 
 import org.komapper.jdbc.spi.JdbcDataTypeProviderFactory
+import org.komapper.jdbc.spi.JdbcUserDataType
 import java.util.ServiceLoader
 import kotlin.reflect.KClass
 
@@ -11,14 +12,24 @@ object JdbcDataTypeProviders {
      * @return the [JdbcDataTypeProvider]
      */
     fun get(driver: String, firstProvider: JdbcDataTypeProvider? = null): JdbcDataTypeProvider {
+        val secondProvider = JdbcUserDataTypeProvider
         val loader = ServiceLoader.load(JdbcDataTypeProviderFactory::class.java)
         val factories = loader.filter { it.supports(driver) }.sortedBy { it.priority }
         val lastProvider: JdbcDataTypeProvider = EmptyJdbcDataTypeProvider
-        val nextProvider = factories.fold(lastProvider) { acc, factory -> factory.create(acc) }
+        val chainedProviders = factories.fold(lastProvider) { acc, factory -> factory.create(acc) }
         return object : JdbcDataTypeProvider {
             override fun <T : Any> get(klass: KClass<out T>): JdbcDataType<T>? {
-                return firstProvider?.get(klass) ?: nextProvider.get(klass)
+                return firstProvider?.get(klass) ?: secondProvider.get(klass) ?: chainedProviders.get(klass)
             }
         }
+    }
+}
+
+private object JdbcUserDataTypeProvider : JdbcDataTypeProvider {
+    val userDataTypes = JdbcUserDataTypes.get().associateBy { it.klass }
+    override fun <T : Any> get(klass: KClass<out T>): JdbcDataType<T>? {
+        @Suppress("UNCHECKED_CAST")
+        val userDataType = userDataTypes[klass] as JdbcUserDataType<T>?
+        return if (userDataType == null) null else JdbcUserDataTypeAdapter(userDataType)
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcUserDataTypes.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcUserDataTypes.kt
@@ -1,0 +1,12 @@
+package org.komapper.jdbc
+
+import org.komapper.jdbc.spi.JdbcUserDataType
+import java.util.ServiceLoader
+
+object JdbcUserDataTypes {
+
+    fun get(): List<JdbcUserDataType<*>> {
+        val loader = ServiceLoader.load(JdbcUserDataType::class.java)
+        return loader.toList()
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/spi/JdbcUserDataType.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/spi/JdbcUserDataType.kt
@@ -1,0 +1,58 @@
+package org.komapper.jdbc.spi
+
+import org.komapper.core.ThreadSafe
+import java.sql.JDBCType
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import kotlin.reflect.KClass
+
+@ThreadSafe
+interface JdbcUserDataType<T : Any> {
+    /**
+     * The data type name.
+     */
+    val name: String
+
+    /**
+     * The corresponding class.
+     */
+    val klass: KClass<T>
+
+    /**
+     * The JDBC type defined in the standard library.
+     */
+    val jdbcType: JDBCType
+
+    /**
+     * Returns the value.
+     *
+     * @param rs the result set
+     * @param index the index
+     * @return the value
+     */
+    fun getValue(rs: ResultSet, index: Int): T?
+
+    /**
+     * Returns the value.
+     * @param rs the result set
+     * @param columnLabel the column label
+     * @return the value
+     */
+    fun getValue(rs: ResultSet, columnLabel: String): T?
+
+    /**
+     * Sets the value.
+     *
+     * @param ps the prepared statement
+     * @param index the index
+     */
+    fun setValue(ps: PreparedStatement, index: Int, value: T)
+
+    /**
+     * Returns the string presentation of the value.
+     *
+     * @param value the value
+     * @return the string presentation of the value
+     */
+    fun toString(value: T): String
+}

--- a/komapper-quarkus-jdbc-deployment/src/main/java/org/komapper/quarkus/jdbc/deployment/KomapperProcessor.java
+++ b/komapper-quarkus-jdbc-deployment/src/main/java/org/komapper/quarkus/jdbc/deployment/KomapperProcessor.java
@@ -59,7 +59,8 @@ public class KomapperProcessor {
             "org.komapper.core.spi.StatementInspectorFactory",
             "org.komapper.core.spi.TemplateStatementBuilderFactory",
             "org.komapper.jdbc.spi.JdbcDataTypeProviderFactory",
-            "org.komapper.jdbc.spi.JdbcDialectFactory");
+            "org.komapper.jdbc.spi.JdbcDialectFactory",
+            "org.komapper.jdbc.spi.JdbcUserDataType");
     for (var interfase : serviceInterfaces) {
       var item = ServiceProviderBuildItem.allProvidersFromClassPath(interfase);
       serviceProvider.produce(item);

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataTypeProviders.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataTypeProviders.kt
@@ -1,6 +1,7 @@
 package org.komapper.r2dbc
 
 import org.komapper.r2dbc.spi.R2dbcDataTypeProviderFactory
+import org.komapper.r2dbc.spi.R2dbcUserDataType
 import java.util.ServiceLoader
 import kotlin.reflect.KClass
 
@@ -11,14 +12,23 @@ object R2dbcDataTypeProviders {
      * @return the [R2dbcDataTypeProvider]
      */
     fun get(driver: String, firstProvider: R2dbcDataTypeProvider? = null): R2dbcDataTypeProvider {
+        val secondProvider = R2dbcUserDataTypeProvider
         val loader = ServiceLoader.load(R2dbcDataTypeProviderFactory::class.java)
         val factories = loader.filter { it.supports(driver) }.sortedBy { it.priority }
         val lastProvider: R2dbcDataTypeProvider = R2dbcEmptyDataTypeProvider
-        val nextProvider = factories.fold(lastProvider) { acc, factory -> factory.create(acc) }
+        val chainedProviders = factories.fold(lastProvider) { acc, factory -> factory.create(acc) }
         return object : R2dbcDataTypeProvider {
             override fun <T : Any> get(klass: KClass<out T>): R2dbcDataType<T>? {
-                return firstProvider?.get(klass) ?: nextProvider.get(klass)
+                return firstProvider?.get(klass) ?: secondProvider.get(klass) ?: chainedProviders.get(klass)
             }
         }
+    }
+}
+
+private object R2dbcUserDataTypeProvider : R2dbcDataTypeProvider {
+    val userDataTypes = R2dbcUserDataTypes.get().associateBy { it.klass }
+    override fun <T : Any> get(klass: KClass<out T>): R2dbcDataType<T>? {
+        @Suppress("UNCHECKED_CAST") val userDataType = userDataTypes[klass] as R2dbcUserDataType<T>?
+        return if (userDataType == null) null else R2dbcUserDataTypeAdapter(userDataType)
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcUserDataTypes.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcUserDataTypes.kt
@@ -1,0 +1,12 @@
+package org.komapper.r2dbc
+
+import org.komapper.r2dbc.spi.R2dbcUserDataType
+import java.util.ServiceLoader
+
+object R2dbcUserDataTypes {
+
+    fun get(): List<R2dbcUserDataType<*>> {
+        val loader = ServiceLoader.load(R2dbcUserDataType::class.java)
+        return loader.toList()
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/spi/R2dbcUserDataType.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/spi/R2dbcUserDataType.kt
@@ -1,0 +1,68 @@
+package org.komapper.r2dbc.spi
+
+import io.r2dbc.spi.Row
+import io.r2dbc.spi.Statement
+import org.komapper.core.ThreadSafe
+import kotlin.reflect.KClass
+
+@ThreadSafe
+interface R2dbcUserDataType<T : Any> {
+    /**
+     * The data type name.
+     */
+    val name: String
+
+    /**
+     * The corresponding class.
+     */
+    val klass: KClass<*>
+
+    /**
+     * The java object type. The type must be a nullable type.
+     */
+    val javaObjectType: Class<*>
+
+    /**
+     * Returns the value.
+     *
+     * @param row the row
+     * @param index the index
+     * @return the value
+     */
+    fun getValue(row: Row, index: Int): T?
+
+    /**
+     * Returns the value.
+     *
+     * @param row the row
+     * @param columnLabel the column label
+     * @return the value
+     */
+    fun getValue(row: Row, columnLabel: String): T?
+
+    /**
+     * Sets the value.
+     *
+     * @param statement the statement
+     * @param index the index
+     * @param value the value
+     */
+    fun setValue(statement: Statement, index: Int, value: T)
+
+    /**
+     * Sets the value.
+     *
+     * @param statement the statement
+     * @param name the name of identifier to bind to
+     * @param value the value
+     */
+    fun setValue(statement: Statement, name: String, value: T)
+
+    /**
+     * Returns the string presentation of the value.
+     *
+     * @param value the value
+     * @return the string presentation of the value
+     */
+    fun toString(value: T): String
+}


### PR DESCRIPTION
The following shows how to use user-defined data classes as Entity property classes in JDBC access.

### Step 1: Define a user-defined data class

UserString.kt
```kotlin
data class UserString(val value: String)
```

### Step 2: Define a handler class for the UserString class

UserStringType.kt
```kotlin
class UserStringType : JdbcUserDataType<UserString> {
    override val name: String = "varchar(100)"

    override val klass: KClass<UserString> = UserString::class

    override val jdbcType: JDBCType = JDBCType.VARCHAR

    override fun getValue(rs: ResultSet, index: Int): UserString? {
        return rs.getString(index)?.let { UserString(it) }
    }

    override fun getValue(rs: ResultSet, columnLabel: String): UserString? {
        return rs.getString(columnLabel)?.let { UserString(it) }
    }

    override fun setValue(ps: PreparedStatement, index: Int, value: UserString) {
        ps.setString(index, value.value)
    }

    override fun toString(value: UserString): String {
        return value.value
    }
}
```

### Step 3: Register the UserStringType class in a provider-configuration file

META-INF/services/org.komapper.jdbc.spi.JdbcUserDataType
```
integration.jdbc.UserStringType
```

You can register multiple classes in the same file.

### Step 4: Use the UserString class in an Entity class

Employee.kt
```kotlin
@KomapperEntity
data class Employee(@KomapperId val id: Int, val name: UserString)
```