### PR TITLE
Support to change metamodel provider class with annotation

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/entities_unit.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/entities_unit.kt
@@ -1,0 +1,36 @@
+package integration.core
+
+import org.komapper.annotation.KomapperColumn
+import org.komapper.annotation.KomapperCreatedAt
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperEntityDef
+import org.komapper.annotation.KomapperId
+import org.komapper.annotation.KomapperTable
+import org.komapper.annotation.KomapperUpdatedAt
+import org.komapper.annotation.KomapperVersion
+import java.time.LocalDateTime
+
+object MyMeta
+
+@KomapperEntity(unit = MyMeta::class)
+@KomapperTable("address")
+data class MyAddress(
+    @KomapperId @KomapperColumn(name = "address_id") val addressId: Int,
+    val street: String,
+    @KomapperVersion val version: Int
+)
+
+data class MyPerson(
+    val personId: Int,
+    val name: String,
+    val createdAt: LocalDateTime? = null,
+    val updatedAt: LocalDateTime? = null
+)
+
+@KomapperEntityDef(entity = MyPerson::class, unit = MyMeta::class)
+@KomapperTable("person")
+data class MyPersonDef(
+    @KomapperId @KomapperColumn("person_id") val personId: Nothing,
+    @KomapperCreatedAt @KomapperColumn("created_at") val createdAt: Nothing,
+    @KomapperUpdatedAt @KomapperColumn("updated_at") val updatedAt: Nothing
+)

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUnitTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUnitTest.kt
@@ -1,0 +1,24 @@
+package integration.jdbc
+
+import integration.core.MyMeta
+import integration.core.myAddress
+import integration.core.myPerson
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.jdbc.JdbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@ExtendWith(JdbcEnv::class)
+class JdbcUnitTest(private val db: JdbcDatabase) {
+
+    @Test
+    fun test() {
+        val a = MyMeta.myAddress
+        val p = MyMeta.myPerson
+        val addressList = db.runQuery { QueryDsl.from(a) }
+        val personList = db.runQuery { QueryDsl.from(p) }
+        assertEquals(15, addressList.size)
+        assertEquals(0, personList.size)
+    }
+}

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/DefaultUnit.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/DefaultUnit.kt
@@ -1,0 +1,3 @@
+package org.komapper.annotation
+
+internal class DefaultUnit

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/annotations.kt
@@ -12,11 +12,13 @@ import kotlin.reflect.KClass
  * The annotated class must be a data class.
  *
  * @param aliases the names of the entity metamodel instances
+ * @param unit the unit object class
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 annotation class KomapperEntity(
     val aliases: Array<String> = [],
+    val unit: KClass<*> = DefaultUnit::class
 )
 
 /**
@@ -212,10 +214,12 @@ annotation class KomapperAutoIncrement
  *
  * @property entity the entity class
  * @property aliases the names of the entity metamodel instances
+ * @property unit the unit object class
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 annotation class KomapperEntityDef(
     val entity: KClass<*>,
-    val aliases: Array<String> = []
+    val aliases: Array<String> = [],
+    val unit: KClass<*> = DefaultUnit::class
 )

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityAnalyzer.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityAnalyzer.kt
@@ -18,10 +18,10 @@ internal class EntityAnalyzer(
         return try {
             val entityDef = EntityDefFactory(logger, config, definitionSource).create()
             val entity = EntityFactory(logger, config, entityDef).create()
-            val model = EntityModel(definitionSource, entity)
+            val model = EntityModel(definitionSource, config.metaObject, entity)
             EntityAnalysisResult.Success(model)
         } catch (e: Exit) {
-            val model = EntityModel(definitionSource)
+            val model = EntityModel(definitionSource, config.metaObject)
             EntityAnalysisResult.Failure(model, e)
         }
     }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelStubGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelStubGenerator.kt
@@ -13,7 +13,7 @@ internal class EntityMetamodelStubGenerator(
     @Suppress("unused")
     private val logger: KSPLogger,
     private val declaration: KSClassDeclaration,
-    private val metaObject: String,
+    private val unitTypeName: String,
     private val aliases: List<String>,
     private val packageName: String,
     private val simpleName: String,
@@ -56,7 +56,7 @@ internal class EntityMetamodelStubGenerator(
         w.println("}")
         w.println("")
         for (alias in aliases) {
-            w.println("val $metaObject.`$alias` get() = $simpleName.`$alias`")
+            w.println("val $unitTypeName.`$alias` get() = $simpleName.`$alias`")
         }
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityModel.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityModel.kt
@@ -4,6 +4,7 @@ import com.google.devtools.ksp.symbol.KSFile
 
 internal class EntityModel(
     private val definitionSource: EntityDefinitionSource,
+    defaultUnitName: String,
     val entity: Entity? = null,
 ) {
     val hasStubAnnotation: Boolean = definitionSource.stubAnnotation != null
@@ -16,6 +17,8 @@ internal class EntityModel(
     }
 
     val typeName = definitionSource.entityDeclaration.qualifiedName?.asString() ?: ""
+
+    val unitTypeName = definitionSource.unitDeclaration?.qualifiedName?.asString() ?: defaultUnitName
 
     val containingFiles: List<KSFile>
         get() {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityProcessor.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityProcessor.kt
@@ -54,7 +54,7 @@ internal class EntityProcessor(private val environment: SymbolProcessorEnvironme
                     EntityMetamodelStubGenerator(
                         logger,
                         model.entityDeclaration,
-                        config.metaObject,
+                        model.unitTypeName,
                         model.aliases,
                         packageName,
                         simpleName,
@@ -65,7 +65,7 @@ internal class EntityProcessor(private val environment: SymbolProcessorEnvironme
                     EntityMetamodelGenerator(
                         logger,
                         model.entity,
-                        config.metaObject,
+                        model.unitTypeName,
                         model.aliases,
                         packageName,
                         simpleName,

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -33,4 +33,5 @@ internal object Symbols {
     const val toKotlinLocalDateTime = "kotlinx.datetime.toKotlinLocalDateTime"
     const val EnumType_NAME = "org.komapper.annotation.EnumType.NAME"
     const val EnumType_ORDINAL = "org.komapper.annotation.EnumType.ORDINAL"
+    const val DefaultUnit = "org.komapper.annotation.DefaultUnit"
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/data.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/data.kt
@@ -15,6 +15,7 @@ internal data class EntityDefinitionSource(
     val defDeclaration: KSClassDeclaration,
     val entityDeclaration: KSClassDeclaration,
     val aliases: List<String>,
+    val unitDeclaration: KSClassDeclaration?,
     val stubAnnotation: KSAnnotation?,
 )
 

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorErrorTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorErrorTest.kt
@@ -988,4 +988,41 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
         assertTrue(result.messages.contains("The property \"info.second\" must not be a star-projected type."))
     }
+
+    @Test
+    fun `The unit value of @KomapperEntity must be an object`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            @KomapperEntity(unit = String::class)
+            data class Dept(
+                @KomapperId
+                val id: Int,
+            )
+            """
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The unit value of @KomapperEntity must be an object."))
+    }
+
+    @Test
+    fun `The unit value of @KomapperEntityDef must be an object`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            data class Dept(
+                val id: Int,
+            )
+            @KomapperEntityDef(entity = Dept::class, unit = String::class)
+            data class DeptDef(
+                @KomapperId
+                val id: Int,
+            )
+            """
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The unit value of @KomapperEntityDef must be an object."))
+    }
 }


### PR DESCRIPTION
This PR allows you to get metamodels from objects other than `org.komapper.core.dsl.Meta`.

Define:

```kotlin
// define your own metamodel providers
object Db1
object Db2

// define your entity using the above provider
@KomapperEntity(unit = Db1::class)
data class Cat(
    @KomapperId
    val id: Int,
    val name: String
)

// define your entity using the above provider
@KomapperEntity(unit = Db2::class)
data class Dog(
    @KomapperId
    val id: Int,
    val name: String
)
```

Use:

```kotlin
// get metamodels from the providers
val c = Db1.cat
val d = Db2.dog
```

See also https://slack-chats.kotlinlang.org/t/8022187/hi-is-there-support-for-having-different-meta-objects-for-mu