### PR TITLE
Add the `virtual` property to `@KomapperId` and `@KomapperEmbeddedId` 

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/entities_virtual.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/entities_virtual.kt
@@ -1,0 +1,21 @@
+package integration.core
+
+import org.komapper.annotation.KomapperEmbeddedId
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperId
+
+@KomapperEntity
+data class Belonging(
+    @KomapperId(virtual = true) val employeeId: Int,
+    @KomapperId(virtual = true) val departmentId: Int
+)
+
+@KomapperEntity
+data class Assignment(
+    @KomapperEmbeddedId(virtual = true) val id: AssignmentId
+)
+
+data class AssignmentId(
+    val employeeId: Int,
+    val taskId: Int
+)

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSchemaTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSchemaTest.kt
@@ -1,17 +1,21 @@
 package integration.jdbc
 
 import integration.core.aaa
+import integration.core.assignment
 import integration.core.autoIncrementTable
 import integration.core.bbb
+import integration.core.belonging
 import integration.core.ccc
 import integration.core.compositeKey
 import integration.core.sequenceTable
 import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dryRunQuery
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.query.andThen
 import org.komapper.jdbc.JdbcDatabase
 import kotlin.test.Test
+import kotlin.test.assertFalse
 
 @ExtendWith(JdbcEnv::class)
 class JdbcSchemaTest(private val db: JdbcDatabase) {
@@ -68,6 +72,34 @@ class JdbcSchemaTest(private val db: JdbcDatabase) {
         // tear down
         db.runQuery {
             QueryDsl.drop(metamodels)
+        }
+    }
+
+    @Test
+    fun virtualId() {
+        val result = db.dryRunQuery {
+            QueryDsl.create(Meta.belonging)
+        }
+        assertFalse(result.sql.contains("primary key"))
+        db.runQuery {
+            QueryDsl.create(Meta.belonging)
+        }
+        db.runQuery {
+            QueryDsl.drop(Meta.belonging)
+        }
+    }
+
+    @Test
+    fun virtualEmbeddedId() {
+        val result = db.dryRunQuery {
+            QueryDsl.create(Meta.assignment)
+        }
+        assertFalse(result.sql.contains("primary key"))
+        db.runQuery {
+            QueryDsl.create(Meta.assignment)
+        }
+        db.runQuery {
+            QueryDsl.drop(Meta.assignment)
         }
     }
 }

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/annotations.kt
@@ -23,10 +23,13 @@ annotation class KomapperEntity(
 
 /**
  * Indicates that the annotated property is a primary key.
+ * @param virtual If `true`, the annotated property does not actually map to a primary key
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.SOURCE)
-annotation class KomapperId
+annotation class KomapperId(
+    val virtual: Boolean = false
+)
 
 /**
  * Indicates that the annotated property is a version number of the optimistic lock.
@@ -58,10 +61,13 @@ annotation class KomapperEmbedded
 
 /**
  * Indicates that the annotated property is an embedded value for composite identifiers.
+ * @param virtual If `true`, the annotated property does not actually map to composite primary keys
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.SOURCE)
-annotation class KomapperEmbeddedId
+annotation class KomapperEmbeddedId(
+    val virtual: Boolean = false
+)
 
 /**
  * Used to override the column of an embeddable class`s property.

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/annotations.kt
@@ -11,8 +11,8 @@ import kotlin.reflect.KClass
  *
  * The annotated class must be a data class.
  *
- * @param aliases the names of the entity metamodel instances
- * @param unit the unit object class
+ * @property aliases the names of the entity metamodel instances
+ * @property unit the unit object class
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
@@ -23,7 +23,7 @@ annotation class KomapperEntity(
 
 /**
  * Indicates that the annotated property is a primary key.
- * @param virtual If `true`, the annotated property does not actually map to a primary key
+ * @property virtual If `true`, the annotated property does not actually map to a primary key
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.SOURCE)
@@ -46,7 +46,7 @@ annotation class KomapperVersion
 
 /**
  * Indicates that the annotated property is an enum class.
- * * @property type the mapping strategy
+ * @property type the mapping strategy
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.SOURCE)
@@ -61,7 +61,8 @@ annotation class KomapperEmbedded
 
 /**
  * Indicates that the annotated property is an embedded value for composite identifiers.
- * @param virtual If `true`, the annotated property does not actually map to composite primary keys
+ * 
+ * @property virtual If `true`, the annotated property does not actually map to composite primary keys
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.SOURCE)
@@ -71,7 +72,8 @@ annotation class KomapperEmbeddedId(
 
 /**
  * Used to override the column of an embeddable class`s property.
- * * @property name the property name
+ * 
+ * @property name the property name
  * @property column the column
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
@@ -81,7 +83,8 @@ annotation class KomapperColumnOverride(val name: String, val column: KomapperCo
 
 /**
  * Used to override the enum of an embeddable class`s property.
- * * @property name the property name
+ * 
+ * @property name the property name
  * @property enum the enum
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/annotations.kt
@@ -46,6 +46,7 @@ annotation class KomapperVersion
 
 /**
  * Indicates that the annotated property is an enum class.
+ *
  * @property type the mapping strategy
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
@@ -61,7 +62,7 @@ annotation class KomapperEmbedded
 
 /**
  * Indicates that the annotated property is an embedded value for composite identifiers.
- * 
+ *
  * @property virtual If `true`, the annotated property does not actually map to composite primary keys
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
@@ -72,7 +73,7 @@ annotation class KomapperEmbeddedId(
 
 /**
  * Used to override the column of an embeddable class`s property.
- * 
+ *
  * @property name the property name
  * @property column the column
  */
@@ -83,7 +84,7 @@ annotation class KomapperColumnOverride(val name: String, val column: KomapperCo
 
 /**
  * Used to override the enum of an embeddable class`s property.
- * 
+ *
  * @property name the property name
  * @property enum the enum
  */

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SchemaStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SchemaStatementBuilder.kt
@@ -51,14 +51,18 @@ abstract class AbstractSchemaStatementBuilder(
             "$columnName ${dataTypeName}$identity$notNull"
         }
         buf.append(columnDefinition)
-        buf.append(", ")
-        val primaryKeyName = "pk_${metamodel.tableName()}"
-        buf.append("constraint $primaryKeyName primary key(")
-        val idList = metamodel.idProperties().joinToString { p ->
-            p.getCanonicalColumnName(dialect::enquote)
+        val primaryKeys = metamodel.idProperties() - metamodel.virtualIdProperties().toSet()
+        if (primaryKeys.isNotEmpty()) {
+            buf.append(", ")
+            val primaryKeyName = "pk_${metamodel.tableName()}"
+            buf.append("constraint $primaryKeyName primary key(")
+            val pkList = primaryKeys.joinToString { p ->
+                p.getCanonicalColumnName(dialect::enquote)
+            }
+            buf.append(pkList)
+            buf.append(")")
         }
-        buf.append(idList)
-        buf.append("))")
+        buf.append(")")
         return listOf(buf.toStatement())
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
@@ -18,6 +18,7 @@ interface EntityMetamodel<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY,
     fun declaration(): EntityMetamodelDeclaration<META>
     fun idGenerator(): IdGenerator<ENTITY, ID>?
     fun idProperties(): List<PropertyMetamodel<ENTITY, *, *>>
+    fun virtualIdProperties(): List<PropertyMetamodel<ENTITY, *, *>> = emptyList()
     fun versionProperty(): PropertyMetamodel<ENTITY, *, *>?
     fun createdAtProperty(): PropertyMetamodel<ENTITY, *, *>?
     fun updatedAtProperty(): PropertyMetamodel<ENTITY, *, *>?

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
@@ -128,8 +128,14 @@ internal class EntityDefFactory(
         for (a in parameter.annotations) {
             when (a.shortName.asString()) {
                 KomapperEmbedded::class.simpleName -> embedded = PropertyKind.Embedded(a)
-                KomapperEmbeddedId::class.simpleName -> embeddedId = PropertyKind.EmbeddedId(a)
-                KomapperId::class.simpleName -> id = PropertyKind.Id(a, idKind)
+                KomapperEmbeddedId::class.simpleName -> {
+                    val virtual = a.findValue("virtual")
+                    embeddedId = PropertyKind.EmbeddedId(a, virtual == true)
+                }
+                KomapperId::class.simpleName -> {
+                    val virtual = a.findValue("virtual")
+                    id = PropertyKind.Id(a, idKind, virtual == true)
+                }
                 KomapperVersion::class.simpleName -> version = PropertyKind.Version(a)
                 KomapperCreatedAt::class.simpleName -> createdAt = PropertyKind.CreatedAt(a)
                 KomapperUpdatedAt::class.simpleName -> updatedAt = PropertyKind.UpdatedAt(a)

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
@@ -40,7 +40,9 @@ internal class EntityFactory(
         val topLevelLeafProperties = allProperties.filterIsInstance<LeafProperty>()
         val compositeProperties = allProperties.filterIsInstance<CompositeProperty>()
         val embeddedIdProperty = compositeProperties.firstOrNull { it.kind is PropertyKind.EmbeddedId }
+        val virtualEmbeddedIdProperty = embeddedIdProperty?.let { if (it.kind is PropertyKind.EmbeddedId && it.kind.virtual) it else null }
         val idProperties = topLevelLeafProperties.filter { it.kind is PropertyKind.Id }
+        val virtualIdProperties = idProperties.filter { it.kind is PropertyKind.Id && it.kind.virtual }
         val versionProperty: LeafProperty? = topLevelLeafProperties.firstOrNull { it.kind is PropertyKind.Version }
         val createdAtProperty: LeafProperty? = topLevelLeafProperties.firstOrNull { it.kind is PropertyKind.CreatedAt }
         val updatedAtProperty: LeafProperty? = topLevelLeafProperties.firstOrNull { it.kind is PropertyKind.UpdatedAt }
@@ -54,7 +56,9 @@ internal class EntityFactory(
             entityDef.table,
             properties,
             embeddedIdProperty,
+            virtualEmbeddedIdProperty,
             idProperties,
+            virtualIdProperties,
             versionProperty,
             createdAtProperty,
             updatedAtProperty,

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -94,6 +94,7 @@ internal class EntityMetamodelGenerator(
 
         idGenerator()
         idProperties()
+        virtualIdProperties()
         versionProperty()
         createdAtProperty()
         updatedAtProperty()
@@ -315,6 +316,16 @@ internal class EntityMetamodelGenerator(
             entity.idProperties.joinToString { "`$it`" }
         }
         w.println("    override fun idProperties(): List<$PropertyMetamodel<$entityTypeName, *, *>> = listOf($idNameList)")
+    }
+
+    private fun virtualIdProperties() {
+        val idNameList = if (entity.virtualEmbeddedIdProperty != null) {
+            val p = entity.virtualEmbeddedIdProperty
+            p.embeddable.properties.joinToString { "`$p`.`$it`" }
+        } else {
+            entity.virtualIdProperties.joinToString { "`$it`" }
+        }
+        w.println("    override fun virtualIdProperties(): List<$PropertyMetamodel<$entityTypeName, *, *>> = listOf($idNameList)")
     }
 
     private fun versionProperty() {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/data.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/data.kt
@@ -50,7 +50,9 @@ internal data class Entity(
     val table: Table,
     val properties: List<Property>,
     val embeddedIdProperty: CompositeProperty?,
+    val virtualEmbeddedIdProperty: CompositeProperty?,
     val idProperties: List<LeafProperty>,
+    val virtualIdProperties: List<LeafProperty>,
     val versionProperty: LeafProperty?,
     val createdAtProperty: LeafProperty?,
     val updatedAtProperty: LeafProperty?,
@@ -179,8 +181,8 @@ internal sealed class PropertyKind {
     abstract val annotation: KSAnnotation
 
     data class Embedded(override val annotation: KSAnnotation) : PropertyKind()
-    data class EmbeddedId(override val annotation: KSAnnotation) : PropertyKind()
-    data class Id(override val annotation: KSAnnotation, val idKind: IdKind?) : PropertyKind()
+    data class EmbeddedId(override val annotation: KSAnnotation, val virtual: Boolean) : PropertyKind()
+    data class Id(override val annotation: KSAnnotation, val idKind: IdKind?, val virtual: Boolean) : PropertyKind()
     data class Version(override val annotation: KSAnnotation) : PropertyKind()
     data class UpdatedAt(override val annotation: KSAnnotation) : PropertyKind()
     data class CreatedAt(override val annotation: KSAnnotation) : PropertyKind()


### PR DESCRIPTION
By setting the `virtual` property to `true`, we can treat tables with no primary key as entities.

Define a linker entity that has virtual IDs:
```kotlin
@KomapperEntity
data class Belonging(
    @KomapperId(virtual = true) val employeeId: Int,
    @KomapperId(virtual = true) val departmentId: Int
)
```

`QueryDsl.create` does not generate primary keys for virtual IDs:
```kotlin
db.runQuery {
    // create table if not exists belonging (employee_id integer not null, department_id integer not null)
    QueryDsl.create(Meta.belonging)
}
```

In other operations, virtual IDs are treated like normal IDs:
```kotlin
db.runQuery {
    // delete from belonging as t0_ where t0_.employee_id = 1 and t0_.department_id = 1
    QueryDsl.delete(Meta.belonging).single(Belonging(1,1))
}
```