### PR TITLE
Support for r2dbc-pool's PROTOCOL option specification

### DIFF
--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDialects.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDialects.kt
@@ -30,15 +30,16 @@ object R2dbcDialects {
         return factory?.create()
     }
 
-    fun getByOptions(options: ConnectionFactoryOptions): R2dbcDialect {
-        val driverOption = options.getValue(ConnectionFactoryOptions.DRIVER)?.toString()
-        val protocolOption = options.getValue(ConnectionFactoryOptions.PROTOCOL)?.toString()
-        val dialect = sequenceOf(driverOption, protocolOption)
+    fun getByOptions(options: ConnectionFactoryOptions, getOrNull: (String) -> R2dbcDialect? = ::getOrNull): R2dbcDialect {
+        val driver = options.getValue(ConnectionFactoryOptions.DRIVER)?.toString()
+        val protocol = options.getValue(ConnectionFactoryOptions.PROTOCOL)?.toString()
+        val driverDelegate = protocol?.split(":", limit = 2)?.first()
+        val dialect = sequenceOf(driver, driverDelegate)
             .filterNotNull()
             .firstNotNullOfOrNull { getOrNull(it) }
         return dialect ?: error(
             "The dialect is not found. " +
-                "driverOption='$driverOption', protocolOption='$protocolOption'",
+                "driver='$driver', protocol='$protocol', driverDelegate='$driverDelegate'",
         )
     }
 

--- a/komapper-r2dbc/src/test/kotlin/org/komapper/r2dbc/R2dbcDialectsTest.kt
+++ b/komapper-r2dbc/src/test/kotlin/org/komapper/r2dbc/R2dbcDialectsTest.kt
@@ -1,8 +1,16 @@
 package org.komapper.r2dbc
 
+import io.r2dbc.spi.ConnectionFactoryOptions
+import io.r2dbc.spi.R2dbcException
+import org.komapper.core.BuilderDialect
+import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
+import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 class R2dbcDialectsTest {
 
@@ -28,6 +36,85 @@ class R2dbcDialectsTest {
     fun extractR2dbcDriver_error() {
         assertFailsWith<IllegalStateException> {
             R2dbcDialects.extractR2dbcDriver("jdbc:h2:mem:///testdb")
+        }
+    }
+
+    private val myDialect = object : R2dbcDialect {
+        override val driver: String get() = "myDriver"
+        override fun isUniqueConstraintViolationError(exception: R2dbcException): Boolean = error("unsupported")
+        override fun getSequenceSql(sequenceName: String): String = error("unsupported")
+        override fun getSchemaStatementBuilder(dialect: BuilderDialect): SchemaStatementBuilder =
+            error("unsupported")
+
+        override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpsertStatementBuilder(
+            dialect: BuilderDialect,
+            context: EntityUpsertContext<ENTITY, ID, META>,
+            entities: List<ENTITY>,
+        ): EntityUpsertStatementBuilder<ENTITY> = error("unsupported")
+    }
+
+    private fun getMyDialectOrNull(driver: String): R2dbcDialect? {
+        return if (driver == myDialect.driver) myDialect else null
+    }
+
+    @Test
+    fun getByOptions_found_from_driver() {
+        val options = ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "myDriver")
+            .build()
+        val dialect = R2dbcDialects.getByOptions(options, ::getMyDialectOrNull)
+        assertSame(myDialect, dialect)
+    }
+
+    @Test
+    fun getByOptions_not_found_from_driver() {
+        val options = ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "driver")
+            .build()
+        assertFailsWith<java.lang.IllegalStateException> {
+            R2dbcDialects.getByOptions(options, ::getMyDialectOrNull)
+        }
+    }
+
+    @Test
+    fun getByOptions_found_from_protocol() {
+        val options = ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "pool")
+            .option(ConnectionFactoryOptions.PROTOCOL, "myDriver")
+            .build()
+        val dialect = R2dbcDialects.getByOptions(options, ::getMyDialectOrNull)
+        assertSame(myDialect, dialect)
+    }
+
+    @Test
+    fun getByOptions_not_found_from_protocol() {
+        val options = ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "pool")
+            .option(ConnectionFactoryOptions.PROTOCOL, "driver")
+            .build()
+        assertFailsWith<java.lang.IllegalStateException> {
+            R2dbcDialects.getByOptions(options, ::getMyDialectOrNull)
+        }
+    }
+
+    @Test
+    fun getByOptions_found_from_colonIncludedProtocol() {
+        val options = ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "pool")
+            .option(ConnectionFactoryOptions.PROTOCOL, "myDriver:myProtocol")
+            .build()
+        val dialect = R2dbcDialects.getByOptions(options, ::getMyDialectOrNull)
+        assertSame(myDialect, dialect)
+    }
+
+    @Test
+    fun getByOptions_not_found_from_colonIncludedProtocol() {
+        val options = ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "pool")
+            .option(ConnectionFactoryOptions.PROTOCOL, "driver:myProtocol")
+            .build()
+        assertFailsWith<java.lang.IllegalStateException> {
+            R2dbcDialects.getByOptions(options, ::getMyDialectOrNull)
         }
     }
 }


### PR DESCRIPTION
See https://github.com/r2dbc/r2dbc-pool/blob/v1.0.0.RELEASE/src/main/java/io/r2dbc/pool/PoolingConnectionFactoryProvider.java#L176-L186

If the PROTOCOL option contains a colon, the value before the colon means a driver.