### PR TITLE
Map multiple SQL types  to the same Kotlin type by KomapperColumn's alternate type property

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -1,7 +1,5 @@
 package integration.core
 
-import org.komapper.annotation.KomapperAlternate
-import org.komapper.annotation.KomapperAlternateOverride
 import org.komapper.annotation.KomapperAutoIncrement
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperColumnOverride
@@ -236,8 +234,7 @@ data class Machine(
     val employeeId: Int,
     @KomapperEmbedded
     @KomapperColumnOverride("employeeNo", KomapperColumn("employee_no"))
-    @KomapperColumnOverride("employeeName", KomapperColumn("employee_name"))
-    @KomapperAlternateOverride("employeeName", KomapperAlternate(ClobString::class))
+    @KomapperColumnOverride("employeeName", KomapperColumn("employee_name", alternateType = ClobString::class))
     val info1: MachineInfo1,
     @KomapperEmbedded
     val info2: MachineInfo2?,

--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -1,5 +1,7 @@
 package integration.core
 
+import org.komapper.annotation.KomapperAlternate
+import org.komapper.annotation.KomapperAlternateOverride
 import org.komapper.annotation.KomapperAutoIncrement
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperColumnOverride
@@ -13,6 +15,7 @@ import org.komapper.annotation.KomapperSequence
 import org.komapper.annotation.KomapperTable
 import org.komapper.annotation.KomapperUpdatedAt
 import org.komapper.annotation.KomapperVersion
+import org.komapper.core.alternate.ClobString
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -213,6 +216,35 @@ data class CyborgDef(
     @KomapperColumn("department_id") val departmentId: Nothing,
     @KomapperColumn("address_id") val addressId: Nothing,
     @KomapperVersion val version: Nothing,
+)
+
+data class MachineInfo1(
+    val employeeNo: Int,
+    val employeeName: String,
+)
+
+data class MachineInfo2(
+    val hiredate: LocalDate? = null,
+    val salary: BigDecimal? = null,
+)
+
+@KomapperEntity
+@KomapperTable("employee")
+data class Machine(
+    @KomapperId
+    @KomapperColumn("employee_id")
+    val employeeId: Int,
+    @KomapperEmbedded
+    @KomapperColumnOverride("employeeNo", KomapperColumn("employee_no"))
+    @KomapperColumnOverride("employeeName", KomapperColumn("employee_name"))
+    @KomapperAlternateOverride("employeeName", KomapperAlternate(ClobString::class))
+    val info1: MachineInfo1,
+    @KomapperEmbedded
+    val info2: MachineInfo2?,
+    @KomapperColumn("manager_id") val managerId: Int?,
+    @KomapperColumn("department_id") val departmentId: Int,
+    @KomapperColumn("address_id") val addressId: Int,
+    @KomapperVersion val version: Int,
 )
 
 @KomapperEntity

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/Entities.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/Entities.kt
@@ -1,6 +1,5 @@
 package integration.jdbc
 
-import org.komapper.annotation.KomapperAlternate
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperId
@@ -27,8 +26,7 @@ data class ClobData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true)
 @KomapperTable("clob_data")
 data class ClobStringData(
     @KomapperId val id: Int,
-    @KomapperAlternate(ClobString::class)
-    @KomapperColumn(alwaysQuote = true)
+    @KomapperColumn(alwaysQuote = true, alternateType = ClobString::class)
     val value: String?,
 )
 

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/Entities.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/Entities.kt
@@ -1,9 +1,11 @@
 package integration.jdbc
 
+import org.komapper.annotation.KomapperAlternate
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperId
 import org.komapper.annotation.KomapperTable
+import org.komapper.core.alternate.ClobString
 import java.sql.Array
 import java.sql.Blob
 import java.sql.Clob
@@ -20,6 +22,15 @@ data class BlobData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true)
 @KomapperEntity
 @KomapperTable("clob_data")
 data class ClobData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Clob?)
+
+@KomapperEntity
+@KomapperTable("clob_data")
+data class ClobStringData(
+    @KomapperId val id: Int,
+    @KomapperAlternate(ClobString::class)
+    @KomapperColumn(alwaysQuote = true)
+    val value: String?,
+)
 
 @KomapperEntity
 @KomapperTable("sqlxml_data")

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDataTypeTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDataTypeTest.kt
@@ -330,6 +330,28 @@ class JdbcDataTypeTest(val db: JdbcDatabase) {
     }
 
     @Test
+    fun clobString() {
+        val m = Meta.clobStringData
+        val data = ClobStringData(1, "abc")
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun clobString_null() {
+        val m = Meta.clobStringData
+        val data = ClobStringData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
     fun double() {
         val m = Meta.doubleData
         val data = DoubleData(1, 10.0)

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
@@ -10,6 +10,8 @@ import integration.core.EmbeddedIdAddress
 import integration.core.GenericEmbeddedIdAddress
 import integration.core.Human
 import integration.core.IdentityStrategy
+import integration.core.Machine
+import integration.core.MachineInfo1
 import integration.core.Man
 import integration.core.Person
 import integration.core.Robot
@@ -24,6 +26,7 @@ import integration.core.embeddedIdAddress
 import integration.core.genericEmbeddedIdAddress
 import integration.core.human
 import integration.core.identityStrategy
+import integration.core.machine
 import integration.core.man
 import integration.core.person
 import integration.core.robot
@@ -154,6 +157,30 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
             }.first()
         }
         assertEquals(cyborg, cyborg2)
+    }
+
+    @Test
+    fun embedded_alternate() {
+        val m = Meta.machine
+        val robot = Machine(
+            employeeId = 99,
+            managerId = null,
+            departmentId = 1,
+            addressId = 1,
+            version = 0,
+            info1 = MachineInfo1(
+                employeeNo = 9999,
+                employeeName = "a",
+            ),
+            info2 = null,
+        )
+        db.runQuery { QueryDsl.insert(m).single(robot) }
+        val robot2 = db.runQuery {
+            QueryDsl.from(m).where {
+                m.employeeId eq 99
+            }.first()
+        }
+        assertEquals(robot, robot2)
     }
 
     @Test

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/EntityDataType.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/EntityDataType.kt
@@ -2,10 +2,12 @@ package integration.r2dbc
 
 import io.r2dbc.spi.Blob
 import io.r2dbc.spi.Clob
+import org.komapper.annotation.KomapperAlternate
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperId
 import org.komapper.annotation.KomapperTable
+import org.komapper.core.alternate.ClobString
 
 @Suppress("ArrayInDataClass")
 @KomapperEntity
@@ -19,8 +21,17 @@ data class ArrayOfNullableData(@KomapperId val id: Int, @KomapperColumn(alwaysQu
 
 @KomapperEntity
 @KomapperTable("blob_data")
-data class BlobData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true)val value: Blob?)
+data class BlobData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Blob?)
 
 @KomapperEntity
 @KomapperTable("clob_data")
-data class ClobData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true)val value: Clob?)
+data class ClobData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Clob?)
+
+@KomapperEntity
+@KomapperTable("clob_data")
+data class ClobStringData(
+    @KomapperId val id: Int,
+    @KomapperAlternate(ClobString::class)
+    @KomapperColumn(alwaysQuote = true)
+    val value: String?,
+)

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/EntityDataType.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/EntityDataType.kt
@@ -2,7 +2,6 @@ package integration.r2dbc
 
 import io.r2dbc.spi.Blob
 import io.r2dbc.spi.Clob
-import org.komapper.annotation.KomapperAlternate
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperId
@@ -31,7 +30,6 @@ data class ClobData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true)
 @KomapperTable("clob_data")
 data class ClobStringData(
     @KomapperId val id: Int,
-    @KomapperAlternate(ClobString::class)
-    @KomapperColumn(alwaysQuote = true)
+    @KomapperColumn(alwaysQuote = true, alternateType = ClobString::class)
     val value: String?,
 )

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
@@ -344,6 +344,32 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
     }
 
     @Test
+    fun clobString(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.clobStringData
+        val data = ClobStringData(1, "abc")
+        db.runQuery {
+            QueryDsl.insert(m).single(data)
+        }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun clobString_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.clobStringData
+        val data = ClobStringData(1, null)
+        db.runQuery {
+            QueryDsl.insert(m).single(data)
+        }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
     fun double(info: TestInfo) = inTransaction(db, info) {
         val m = Meta.doubleData
         val data = DoubleData(1, 10.0)

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleTest.kt
@@ -8,6 +8,8 @@ import integration.core.Department
 import integration.core.EmbeddedIdAddress
 import integration.core.Human
 import integration.core.IdentityStrategy
+import integration.core.Machine
+import integration.core.MachineInfo1
 import integration.core.Man
 import integration.core.Person
 import integration.core.Robot
@@ -20,6 +22,7 @@ import integration.core.department
 import integration.core.embeddedIdAddress
 import integration.core.human
 import integration.core.identityStrategy
+import integration.core.machine
 import integration.core.man
 import integration.core.person
 import integration.core.robot
@@ -116,6 +119,30 @@ class R2dbcInsertSingleTest(private val db: R2dbcDatabase) {
             }.first()
         }
         assertEquals(android, android2)
+    }
+
+    @Test
+    fun embedded_alternate(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.machine
+        val robot = Machine(
+            employeeId = 99,
+            managerId = null,
+            departmentId = 1,
+            addressId = 1,
+            version = 0,
+            info1 = MachineInfo1(
+                employeeNo = 9999,
+                employeeName = "a",
+            ),
+            info2 = null,
+        )
+        db.runQuery { QueryDsl.insert(m).single(robot) }
+        val robot2 = db.runQuery {
+            QueryDsl.from(m).where {
+                m.employeeId eq 99
+            }.first()
+        }
+        assertEquals(robot, robot2)
     }
 
     @Test

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
@@ -71,15 +71,6 @@ annotation class KomapperEnum(val type: EnumType, val hint: String = HINT) {
 annotation class KomapperEmbedded
 
 /**
- * Indicates that the `valueClass` is used for mapping as an alternative to the annotated property type.
- *
- * @property valueClass the value class
- */
-@Target(AnnotationTarget.VALUE_PARAMETER)
-@Retention(AnnotationRetention.SOURCE)
-annotation class KomapperAlternate(val valueClass: KClass<*>)
-
-/**
  * Indicates that the annotated property is an embedded value for composite identifiers.
  *
  * @property virtual If `true`, the annotated property does not actually map to composite primary keys
@@ -113,16 +104,6 @@ annotation class KomapperColumnOverride(val name: String, val column: KomapperCo
 annotation class KomapperEnumOverride(val name: String, val enum: KomapperEnum)
 
 /**
- * Used to override the alternate of an embeddable class`s property.
- *
- * @property name the property name
- * @property alternate the alternate
- */
-@Target(AnnotationTarget.VALUE_PARAMETER)
-@Retention(AnnotationRetention.SOURCE)
-annotation class KomapperAlternateOverride(val name: String, val alternate: KomapperAlternate)
-
-/**
  * Adds table information.
  *
  * @property name the table name
@@ -152,6 +133,7 @@ annotation class KomapperTable(
  * @property name the table name
  * @property alwaysQuote whether to quote the [name]
  * @property masking whether to mask the value that corresponds to the annotated property in logs
+ * @property alternateType the alternate type. This type must be a value class.
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.SOURCE)
@@ -159,6 +141,7 @@ annotation class KomapperColumn(
     val name: String = NAME,
     val alwaysQuote: Boolean = ALWAYS_QUOTE,
     val masking: Boolean = MASKING,
+    val alternateType: KClass<*> = Void::class,
 ) {
     companion object {
         const val NAME = ""

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
@@ -71,6 +71,15 @@ annotation class KomapperEnum(val type: EnumType, val hint: String = HINT) {
 annotation class KomapperEmbedded
 
 /**
+ * Indicates that the `valueClass` is used for mapping as an alternative to the annotated property type.
+ *
+ * @property valueClass the value class
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.SOURCE)
+annotation class KomapperAlternate(val valueClass: KClass<*>)
+
+/**
  * Indicates that the annotated property is an embedded value for composite identifiers.
  *
  * @property virtual If `true`, the annotated property does not actually map to composite primary keys
@@ -102,6 +111,16 @@ annotation class KomapperColumnOverride(val name: String, val column: KomapperCo
 @Retention(AnnotationRetention.SOURCE)
 @Repeatable
 annotation class KomapperEnumOverride(val name: String, val enum: KomapperEnum)
+
+/**
+ * Used to override the alternate of an embeddable class`s property.
+ *
+ * @property name the property name
+ * @property alternate the alternate
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.SOURCE)
+annotation class KomapperAlternateOverride(val name: String, val alternate: KomapperAlternate)
 
 /**
  * Adds table information.

--- a/komapper-core/src/main/kotlin/org/komapper/core/alternate/ClobString.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/alternate/ClobString.kt
@@ -1,0 +1,4 @@
+package org.komapper.core.alternate
+
+@JvmInline
+value class ClobString(val value: String)

--- a/komapper-dialect-h2-jdbc/src/main/kotlin/org/komapper/dialect/h2/jdbc/H2JdbcDataTypeProvider.kt
+++ b/komapper-dialect-h2-jdbc/src/main/kotlin/org/komapper/dialect/h2/jdbc/H2JdbcDataTypeProvider.kt
@@ -9,6 +9,7 @@ import org.komapper.jdbc.JdbcBlobType
 import org.komapper.jdbc.JdbcBooleanType
 import org.komapper.jdbc.JdbcByteArrayType
 import org.komapper.jdbc.JdbcByteType
+import org.komapper.jdbc.JdbcClobStringType
 import org.komapper.jdbc.JdbcClobType
 import org.komapper.jdbc.JdbcDataType
 import org.komapper.jdbc.JdbcDataTypeProvider
@@ -44,6 +45,7 @@ class H2JdbcDataTypeProvider(next: JdbcDataTypeProvider) :
             JdbcByteArrayType("binary"),
             JdbcDoubleType("double"),
             JdbcClobType("clob"),
+            JdbcClobStringType("clob"),
             JdbcFloatType("float"),
             JdbcInstantType("timestamp with time zone"),
             JdbcIntType("integer"),

--- a/komapper-dialect-h2-r2dbc/src/main/kotlin/org/komapper/dialect/h2/r2dbc/H2R2dbcDataTypeProvider.kt
+++ b/komapper-dialect-h2-r2dbc/src/main/kotlin/org/komapper/dialect/h2/r2dbc/H2R2dbcDataTypeProvider.kt
@@ -7,6 +7,7 @@ import org.komapper.r2dbc.R2dbcBlobType
 import org.komapper.r2dbc.R2dbcBooleanType
 import org.komapper.r2dbc.R2dbcByteArrayType
 import org.komapper.r2dbc.R2dbcByteType
+import org.komapper.r2dbc.R2dbcClobStringType
 import org.komapper.r2dbc.R2dbcClobType
 import org.komapper.r2dbc.R2dbcDataType
 import org.komapper.r2dbc.R2dbcDataTypeProvider
@@ -37,6 +38,7 @@ class H2R2dbcDataTypeProvider(next: R2dbcDataTypeProvider) :
             R2dbcByteType("tinyint"),
             R2dbcByteArrayType("binary"),
             R2dbcClobType("clob"),
+            R2dbcClobStringType("clob"),
             R2dbcDoubleType("double"),
             R2dbcFloatType("float"),
             R2dbcInstantType("timestamp with time zone"),

--- a/komapper-dialect-mariadb-jdbc/src/main/kotlin/org/komapper/dialect/mariadb/jdbc/MariaDbJdbcDataTypeProvider.kt
+++ b/komapper-dialect-mariadb-jdbc/src/main/kotlin/org/komapper/dialect/mariadb/jdbc/MariaDbJdbcDataTypeProvider.kt
@@ -7,6 +7,7 @@ import org.komapper.jdbc.JdbcBlobType
 import org.komapper.jdbc.JdbcBooleanType
 import org.komapper.jdbc.JdbcByteArrayType
 import org.komapper.jdbc.JdbcByteType
+import org.komapper.jdbc.JdbcClobStringType
 import org.komapper.jdbc.JdbcClobType
 import org.komapper.jdbc.JdbcDataType
 import org.komapper.jdbc.JdbcDataTypeProvider
@@ -38,6 +39,7 @@ class MariaDbJdbcDataTypeProvider(next: JdbcDataTypeProvider) : AbstractJdbcData
             JdbcByteArrayType("varbinary(500)"),
             JdbcDoubleType("double precision"),
             JdbcClobType("text"),
+            JdbcClobStringType("text"),
             JdbcFloatType("real"),
             JdbcInstantAsTimestampType("timestamp"),
             JdbcIntType("integer"),

--- a/komapper-dialect-mariadb-r2dbc/src/main/kotlin/org/komapper/dialect/mariadb/r2dbc/MariaDbR2dbcDataTypeProvider.kt
+++ b/komapper-dialect-mariadb-r2dbc/src/main/kotlin/org/komapper/dialect/mariadb/r2dbc/MariaDbR2dbcDataTypeProvider.kt
@@ -7,6 +7,7 @@ import org.komapper.r2dbc.R2dbcBlobType
 import org.komapper.r2dbc.R2dbcBooleanType
 import org.komapper.r2dbc.R2dbcByteArrayType
 import org.komapper.r2dbc.R2dbcByteType
+import org.komapper.r2dbc.R2dbcClobStringType
 import org.komapper.r2dbc.R2dbcClobType
 import org.komapper.r2dbc.R2dbcDataType
 import org.komapper.r2dbc.R2dbcDataTypeProvider
@@ -36,6 +37,7 @@ class MariaDbR2dbcDataTypeProvider(next: R2dbcDataTypeProvider) :
             R2dbcByteType("tinyint"),
             R2dbcByteArrayType("bytea"),
             R2dbcClobType("text"),
+            R2dbcClobStringType("text"),
             R2dbcDoubleType("double precision"),
             R2dbcFloatType("real"),
             R2dbcInstantAsTimestampType("timestamp(6)"),

--- a/komapper-dialect-mysql-jdbc/src/main/kotlin/org/komapper/dialect/mysql/jdbc/MySqlJdbcDataTypeProvider.kt
+++ b/komapper-dialect-mysql-jdbc/src/main/kotlin/org/komapper/dialect/mysql/jdbc/MySqlJdbcDataTypeProvider.kt
@@ -7,6 +7,7 @@ import org.komapper.jdbc.JdbcBlobType
 import org.komapper.jdbc.JdbcBooleanType
 import org.komapper.jdbc.JdbcByteArrayType
 import org.komapper.jdbc.JdbcByteType
+import org.komapper.jdbc.JdbcClobStringType
 import org.komapper.jdbc.JdbcClobType
 import org.komapper.jdbc.JdbcDataType
 import org.komapper.jdbc.JdbcDataTypeProvider
@@ -39,6 +40,7 @@ class MySqlJdbcDataTypeProvider(next: JdbcDataTypeProvider) : AbstractJdbcDataTy
             JdbcByteArrayType("varbinary(500)"),
             JdbcDoubleType("double precision"),
             JdbcClobType("text"),
+            JdbcClobStringType("text"),
             JdbcFloatType("real"),
             JdbcInstantAsTimestampType("timestamp(6)"),
             JdbcIntType("integer"),

--- a/komapper-dialect-mysql-r2dbc/src/main/kotlin/org/komapper/dialect/mysql/r2dbc/MySqlR2dbcDataTypeProvider.kt
+++ b/komapper-dialect-mysql-r2dbc/src/main/kotlin/org/komapper/dialect/mysql/r2dbc/MySqlR2dbcDataTypeProvider.kt
@@ -7,6 +7,7 @@ import org.komapper.r2dbc.R2dbcBlobType
 import org.komapper.r2dbc.R2dbcBooleanType
 import org.komapper.r2dbc.R2dbcByteArrayType
 import org.komapper.r2dbc.R2dbcByteType
+import org.komapper.r2dbc.R2dbcClobStringType
 import org.komapper.r2dbc.R2dbcClobType
 import org.komapper.r2dbc.R2dbcDataType
 import org.komapper.r2dbc.R2dbcDataTypeProvider
@@ -37,6 +38,7 @@ class MySqlR2dbcDataTypeProvider(next: R2dbcDataTypeProvider) :
             R2dbcByteType("tinyint"),
             R2dbcByteArrayType("bytea"),
             R2dbcClobType("text"),
+            R2dbcClobStringType("text"),
             R2dbcDoubleType("double precision"),
             R2dbcFloatType("real"),
             R2dbcInstantAsTimestampType("timestamp"),

--- a/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDataTypeProvider.kt
+++ b/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDataTypeProvider.kt
@@ -6,6 +6,7 @@ import org.komapper.jdbc.JdbcBigIntegerType
 import org.komapper.jdbc.JdbcBlobType
 import org.komapper.jdbc.JdbcByteArrayType
 import org.komapper.jdbc.JdbcByteType
+import org.komapper.jdbc.JdbcClobStringType
 import org.komapper.jdbc.JdbcClobType
 import org.komapper.jdbc.JdbcDataType
 import org.komapper.jdbc.JdbcDataTypeProvider
@@ -34,6 +35,7 @@ class OracleJdbcDataTypeProvider(next: JdbcDataTypeProvider) : AbstractJdbcDataT
             JdbcByteType("integer"),
             JdbcByteArrayType("raw"),
             JdbcClobType("clob"),
+            JdbcClobStringType("clob"),
             JdbcDoubleType("float"),
             JdbcFloatType("float"),
             JdbcInstantAsTimestampWithTimezoneType("timestamp with time zone"),

--- a/komapper-dialect-oracle-r2dbc/src/main/kotlin/org/komapper/dialect/oracle/r2dbc/OracleR2dbcDataTypeProvider.kt
+++ b/komapper-dialect-oracle-r2dbc/src/main/kotlin/org/komapper/dialect/oracle/r2dbc/OracleR2dbcDataTypeProvider.kt
@@ -6,6 +6,7 @@ import org.komapper.r2dbc.R2dbcBigIntegerType
 import org.komapper.r2dbc.R2dbcBlobType
 import org.komapper.r2dbc.R2dbcByteArrayType
 import org.komapper.r2dbc.R2dbcByteType
+import org.komapper.r2dbc.R2dbcClobStringType
 import org.komapper.r2dbc.R2dbcClobType
 import org.komapper.r2dbc.R2dbcDataType
 import org.komapper.r2dbc.R2dbcDataTypeProvider
@@ -35,6 +36,7 @@ class OracleR2dbcDataTypeProvider(next: R2dbcDataTypeProvider) :
             R2dbcByteType("integer"),
             R2dbcByteArrayType("raw"),
             R2dbcClobType("clob"),
+            R2dbcClobStringType("clob"),
             R2dbcDoubleType("float"),
             R2dbcFloatType("float"),
             R2dbcInstantAsTimestampWithTimezoneType("timestamp with time zone"),

--- a/komapper-dialect-postgresql-jdbc/src/main/kotlin/org/komapper/dialect/postgresql/jdbc/PostgreSqlJdbcDataTypeProvider.kt
+++ b/komapper-dialect-postgresql-jdbc/src/main/kotlin/org/komapper/dialect/postgresql/jdbc/PostgreSqlJdbcDataTypeProvider.kt
@@ -7,6 +7,7 @@ import org.komapper.jdbc.JdbcBigIntegerType
 import org.komapper.jdbc.JdbcBooleanType
 import org.komapper.jdbc.JdbcByteArrayType
 import org.komapper.jdbc.JdbcByteType
+import org.komapper.jdbc.JdbcClobStringType
 import org.komapper.jdbc.JdbcDataType
 import org.komapper.jdbc.JdbcDataTypeProvider
 import org.komapper.jdbc.JdbcDoubleType
@@ -36,6 +37,7 @@ class PostgreSqlJdbcDataTypeProvider(next: JdbcDataTypeProvider) :
             JdbcBooleanType("boolean"),
             JdbcByteType("smallint"),
             JdbcByteArrayType("bytea"),
+            JdbcClobStringType("text"),
             JdbcDoubleType("double precision"),
             JdbcFloatType("real"),
             JdbcInstantAsTimestampWithTimezoneType("timestamp with time zone"),

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcDataTypeProvider.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcDataTypeProvider.kt
@@ -6,6 +6,7 @@ import org.komapper.r2dbc.R2dbcBlobType
 import org.komapper.r2dbc.R2dbcBooleanType
 import org.komapper.r2dbc.R2dbcByteArrayType
 import org.komapper.r2dbc.R2dbcByteType
+import org.komapper.r2dbc.R2dbcClobStringType
 import org.komapper.r2dbc.R2dbcClobType
 import org.komapper.r2dbc.R2dbcDataType
 import org.komapper.r2dbc.R2dbcDataTypeProvider
@@ -37,6 +38,7 @@ class PostgreSqlR2dbcDataTypeProvider(private val next: R2dbcDataTypeProvider) :
             R2dbcByteType("smallint"),
             R2dbcByteArrayType("bytea"),
             R2dbcClobType("text"),
+            R2dbcClobStringType("text"),
             R2dbcDoubleType("double precision"),
             R2dbcFloatType("real"),
             R2dbcInstantAsTimestampWithTimezoneType("timestamp with time zone"),

--- a/komapper-dialect-sqlserver-jdbc/src/main/kotlin/org/komapper/dialect/sqlserver/jdbc/SqlServerJdbcDataTypeProvider.kt
+++ b/komapper-dialect-sqlserver-jdbc/src/main/kotlin/org/komapper/dialect/sqlserver/jdbc/SqlServerJdbcDataTypeProvider.kt
@@ -6,6 +6,7 @@ import org.komapper.jdbc.JdbcBigIntegerType
 import org.komapper.jdbc.JdbcBlobType
 import org.komapper.jdbc.JdbcByteArrayType
 import org.komapper.jdbc.JdbcByteType
+import org.komapper.jdbc.JdbcClobStringType
 import org.komapper.jdbc.JdbcClobType
 import org.komapper.jdbc.JdbcDataType
 import org.komapper.jdbc.JdbcDataTypeProvider
@@ -37,6 +38,7 @@ class SqlServerJdbcDataTypeProvider(next: JdbcDataTypeProvider) :
             JdbcByteType("tinyint"),
             JdbcByteArrayType("varbinary(1000)"),
             JdbcClobType("text"),
+            JdbcClobStringType("text"),
             JdbcDoubleType("float"),
             JdbcFloatType("real"),
             JdbcInstantAsTimestampWithTimezoneType("datetimeoffset"),

--- a/komapper-dialect-sqlserver-r2dbc/src/main/kotlin/org/komapper/dialect/sqlserver/r2dbc/SqlServerR2dbcDataTypeProvider.kt
+++ b/komapper-dialect-sqlserver-r2dbc/src/main/kotlin/org/komapper/dialect/sqlserver/r2dbc/SqlServerR2dbcDataTypeProvider.kt
@@ -7,6 +7,7 @@ import org.komapper.r2dbc.R2dbcBlobType
 import org.komapper.r2dbc.R2dbcBooleanType
 import org.komapper.r2dbc.R2dbcByteArrayType
 import org.komapper.r2dbc.R2dbcByteType
+import org.komapper.r2dbc.R2dbcClobStringType
 import org.komapper.r2dbc.R2dbcClobType
 import org.komapper.r2dbc.R2dbcDataType
 import org.komapper.r2dbc.R2dbcDataTypeProvider
@@ -37,6 +38,7 @@ class SqlServerR2dbcDataTypeProvider(next: R2dbcDataTypeProvider) :
             R2dbcByteType("smallint"),
             R2dbcByteArrayType("varbinary(1000)"),
             R2dbcClobType("text"),
+            R2dbcClobStringType("text"),
             R2dbcDoubleType("real"),
             R2dbcFloatType("float"),
             R2dbcInstantAsTimestampWithTimezoneType("datetimeoffset"),

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataType.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataType.kt
@@ -2,6 +2,7 @@ package org.komapper.jdbc
 
 import org.komapper.core.ThreadSafe
 import org.komapper.core.spi.DataTypeConverter
+import org.komapper.core.alternate.ClobString
 import org.komapper.jdbc.spi.JdbcUserDefinedDataType
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -261,6 +262,27 @@ class JdbcClobType(override val name: String) : AbstractJdbcDataType<Clob>(Clob:
 
     override fun doSetValue(ps: PreparedStatement, index: Int, value: Clob) {
         ps.setClob(index, value)
+    }
+}
+
+class JdbcClobStringType(override val name: String) : AbstractJdbcDataType<ClobString>(ClobString::class, JDBCType.CLOB) {
+
+    override fun doGetValue(rs: ResultSet, index: Int): ClobString? {
+        val text = rs.getString(index)
+        return if (text == null) null else ClobString(text)
+    }
+
+    override fun doGetValue(rs: ResultSet, columnLabel: String): ClobString? {
+        val text = rs.getString(columnLabel)
+        return if (text == null) null else ClobString(text)
+    }
+
+    override fun doSetValue(ps: PreparedStatement, index: Int, value: ClobString) {
+        ps.setString(index, value.value)
+    }
+
+    override fun doToString(value: ClobString): String {
+        return value.value
     }
 }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataType.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataType.kt
@@ -1,8 +1,8 @@
 package org.komapper.jdbc
 
 import org.komapper.core.ThreadSafe
-import org.komapper.core.spi.DataTypeConverter
 import org.komapper.core.alternate.ClobString
+import org.komapper.core.spi.DataTypeConverter
 import org.komapper.jdbc.spi.JdbcUserDefinedDataType
 import java.math.BigDecimal
 import java.math.BigInteger

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/AnnotationSupport.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/AnnotationSupport.kt
@@ -6,8 +6,6 @@ import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueParameter
-import org.komapper.annotation.KomapperAlternate
-import org.komapper.annotation.KomapperAlternateOverride
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperColumnOverride
 import org.komapper.annotation.KomapperEnum
@@ -46,7 +44,52 @@ internal class AnnotationSupport(
             columnAnnotation?.findValue("alwaysQuote")?.toString()?.toBooleanStrict() ?: config.alwaysQuote
         val masking =
             columnAnnotation?.findValue("masking")?.toString()?.toBooleanStrict() ?: KomapperColumn.MASKING
-        return Column(name, alwaysQuote, masking)
+        val alternateType = columnAnnotation?.findValue("alternateType")?.let { type ->
+            if (type !is KSType) report("The alternateType is not KSType.", columnAnnotation)
+            val classDeclaration = type.declaration.accept(ClassDeclarationVisitor(), Unit)
+            when {
+                classDeclaration == null ->
+                    report("The alternateType property is illegal.", columnAnnotation)
+                classDeclaration.qualifiedName?.asString() == Symbols.Void ->
+                    null
+                !classDeclaration.isValueClass() ->
+                    report("The alternateType property must be a value class. ${classDeclaration.qualifiedName?.asString()}", columnAnnotation)
+                else -> {
+                    val constructor = classDeclaration.primaryConstructor
+                    val isPublic = constructor?.isPublic() ?: false
+                    if (!isPublic) {
+                        report(
+                            "The constructor of \"${classDeclaration.qualifiedName?.asString()}\" must be public.",
+                            columnAnnotation,
+                        )
+                    }
+                    val parameter = constructor?.parameters?.firstOrNull()
+                        ?: error("No parameter is found in the class \"${classDeclaration.qualifiedName?.asString()}\"")
+                    val declaration = classDeclaration.getDeclaredProperties().firstOrNull()
+                        ?: error("No property is found in the class \"${classDeclaration.qualifiedName?.asString()}\"")
+                    if (!declaration.isPublic()) {
+                        report(
+                            "The property parameter of \"${classDeclaration.qualifiedName?.asString()}\" must be public.",
+                            columnAnnotation,
+                        )
+                    }
+                    val propertyType = declaration.type.resolve()
+                    if (propertyType.isMarkedNullable) {
+                        report(
+                            "The property parameter of \"${classDeclaration.qualifiedName?.asString()}\" must not be nullable.",
+                            columnAnnotation,
+                        )
+                    }
+                    val typeName = propertyType.name
+                    val literalTag = resolveLiteralTag(typeName)
+                    val nullability = propertyType.nullability
+                    val property =
+                        ValueClassProperty(propertyType, parameter, declaration, typeName, literalTag, nullability)
+                    ValueClass(type, property, null)
+                }
+            }
+        }
+        return Column(name, alwaysQuote, masking, alternateType)
     }
 
     fun getColumns(parameter: KSValueParameter): List<Triple<String, Column, KSAnnotation>> {
@@ -97,51 +140,5 @@ internal class AnnotationSupport(
                 val enumStrategy = getEnumStrategy(it.second)
                 Triple(it.first!!, enumStrategy, it.third)
             }.toList()
-    }
-
-    fun getAlternate(parameter: KSValueParameter): ValueClass? {
-        val annotation = parameter.findAnnotation(KomapperAlternate::class)
-        return getAlternate(annotation)
-    }
-
-    private fun getAlternate(annotation: KSAnnotation?): ValueClass? {
-        if (annotation == null) return null
-        val type = annotation.findValue("valueClass")
-        if (type !is KSType) report("The valueClass is not KSType.", annotation)
-        val classDeclaration = type.declaration.accept(ClassDeclarationVisitor(), Unit)
-        if (classDeclaration == null || !classDeclaration.isValueClass()) {
-            report("The valueClass property must be a value class.", annotation)
-        }
-        val constructor = classDeclaration.primaryConstructor
-        val isPublic = constructor?.isPublic() ?: false
-        if (!isPublic) report("The constructor of \"${classDeclaration.qualifiedName?.asString()}\" must be public.", annotation)
-        val parameter = constructor?.parameters?.firstOrNull()
-            ?: error("No parameter is found in the class \"${classDeclaration.qualifiedName?.asString()}\"")
-        val declaration = classDeclaration.getDeclaredProperties().firstOrNull()
-            ?: error("No property is found in the class \"${classDeclaration.qualifiedName?.asString()}\"")
-        if (!declaration.isPublic()) report("The property parameter of \"${classDeclaration.qualifiedName?.asString()}\" must be public.", annotation)
-        val propertyType = declaration.type.resolve()
-        if (propertyType.isMarkedNullable) report("The property parameter of \"${classDeclaration.qualifiedName?.asString()}\" must not be nullable.", annotation)
-        val typeName = propertyType.name
-        val literalTag = resolveLiteralTag(typeName)
-        val nullability = propertyType.nullability
-        val property = ValueClassProperty(propertyType, parameter, declaration, typeName, literalTag, nullability)
-        return ValueClass(type, property, null)
-    }
-
-    fun getAlternates(parameter: KSValueParameter): List<Triple<String, ValueClass, KSAnnotation>> {
-        return parameter.annotations
-            .filter { it.shortName.asString() == KomapperAlternateOverride::class.simpleName }
-            .map {
-                val name = it.findValue("name")?.toString()
-                val alternateNode = it.findValue("alternate") as? KSNode
-                val alternateAnnotation = alternateNode?.accept(AnnotationVisitor(), Unit)
-                Triple(name, alternateAnnotation, it)
-            }.filter {
-                it.first != null && it.second != null
-            }.map {
-                val alternate = getAlternate(it.second)
-                if (alternate == null) null else Triple(it.first!!, alternate, it.third)
-            }.filterNotNull().toList()
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
@@ -37,6 +37,7 @@ internal data class LeafPropertyDef(
     override val kind: PropertyKind?,
     val column: Column,
     val enumStrategy: EnumStrategy?,
+    val alternate: ValueClass?,
 ) : PropertyDef
 
 internal data class CompositePropertyDef(
@@ -131,13 +132,19 @@ internal data class EnumClass(
 internal data class ValueClass(
     override val type: KSType,
     val property: ValueClassProperty,
+    val alternate: ValueClass?,
 ) : KotlinClass {
-    override val interiorTypeName: String get() = property.typeName
+    override val interiorTypeName: String
+        get() {
+            return alternate?.exteriorTypeName ?: property.typeName
+        }
+
     override fun toString(): String = exteriorTypeName
 }
 
 internal data class PlainClass(
     override val type: KSType,
+    val alternate: ValueClass?,
 ) : KotlinClass {
     val isArray: Boolean = declaration.qualifiedName?.asString() == "kotlin.Array"
 
@@ -156,7 +163,11 @@ internal data class PlainClass(
             }
         }
 
-    override val interiorTypeName: String get() = exteriorTypeName
+    override val interiorTypeName: String
+        get() {
+            return alternate?.exteriorTypeName ?: exteriorTypeName
+        }
+
     override fun toString(): String = exteriorTypeName
 }
 
@@ -180,6 +191,7 @@ sealed interface EnumStrategy {
 }
 
 internal data class ValueClassProperty(
+    val type: KSType,
     val parameter: KSValueParameter,
     val declaration: KSPropertyDeclaration,
     val typeName: String,

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
@@ -37,7 +37,6 @@ internal data class LeafPropertyDef(
     override val kind: PropertyKind?,
     val column: Column,
     val enumStrategy: EnumStrategy?,
-    val alternate: ValueClass?,
 ) : PropertyDef
 
 internal data class CompositePropertyDef(
@@ -132,11 +131,11 @@ internal data class EnumClass(
 internal data class ValueClass(
     override val type: KSType,
     val property: ValueClassProperty,
-    val alternate: ValueClass?,
+    val alternateType: ValueClass?,
 ) : KotlinClass {
     override val interiorTypeName: String
         get() {
-            return alternate?.exteriorTypeName ?: property.typeName
+            return alternateType?.exteriorTypeName ?: property.typeName
         }
 
     override fun toString(): String = exteriorTypeName
@@ -247,4 +246,5 @@ internal data class Column(
     val name: String,
     val alwaysQuote: Boolean,
     val masking: Boolean,
+    val alternateType: ValueClass?,
 )

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
@@ -52,7 +52,8 @@ internal class EntityDefFactory(
         val kind = createPropertyKind(parameter, idKind)
         val column = annotationSupport.getColumn(parameter)
         val enumStrategy = annotationSupport.getEnumStrategy(parameter)
-        return LeafPropertyDef(parameter, declaration, kind, column, enumStrategy)
+        val alternate = annotationSupport.getAlternate(parameter)
+        return LeafPropertyDef(parameter, declaration, kind, column, enumStrategy, alternate)
     }
 
     private fun validateCompositeProperties(properties: List<CompositePropertyDef>) {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
@@ -52,8 +52,7 @@ internal class EntityDefFactory(
         val kind = createPropertyKind(parameter, idKind)
         val column = annotationSupport.getColumn(parameter)
         val enumStrategy = annotationSupport.getEnumStrategy(parameter)
-        val alternate = annotationSupport.getAlternate(parameter)
-        return LeafPropertyDef(parameter, declaration, kind, column, enumStrategy, alternate)
+        return LeafPropertyDef(parameter, declaration, kind, column, enumStrategy)
     }
 
     private fun validateCompositeProperties(properties: List<CompositePropertyDef>) {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -180,7 +180,7 @@ internal class EntityMetamodelGenerator(
                     }
                 }
                 is ValueClass -> {
-                    val alternate = p.kotlinClass.alternate
+                    val alternate = p.kotlinClass.alternateType
                     if (alternate != null) {
                         "{ ${p.kotlinClass}(it.${alternate.property.declaration.simpleName.asString()}) }"
                     } else {
@@ -199,7 +199,7 @@ internal class EntityMetamodelGenerator(
             val unwrap = when (p.kotlinClass) {
                 is EnumClass -> "{ it.${p.kotlinClass.strategy.propertyName} }"
                 is ValueClass -> {
-                    val alternate = p.kotlinClass.alternate
+                    val alternate = p.kotlinClass.alternateType
                     if (alternate != null) {
                         "{ ${alternate.exteriorTypeName}(it.${p.kotlinClass.property}) }"
                     } else {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/ProcessorUtility.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/ProcessorUtility.kt
@@ -142,3 +142,11 @@ internal fun toCamelCase(text: String): String {
     }
     return builder.toString()
 }
+
+internal fun resolveLiteralTag(typeName: String): String {
+    return when (typeName) {
+        "kotlin.Long" -> "L"
+        "kotlin.UInt" -> "u"
+        else -> ""
+    }
+}

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -36,4 +36,5 @@ internal object Symbols {
     const val EnumType_PROPERTY = "org.komapper.annotation.EnumType.PROPERTY"
     const val DefaultUnit = "org.komapper.annotation.DefaultUnit"
     const val EnumMappingException = "org.komapper.core.dsl.runner.EnumMappingException"
+    const val Void = "java.lang.Void"
 }

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorErrorTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorErrorTest.kt
@@ -1048,7 +1048,7 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
     }
 
     @Test
-    fun `The valueClass property must be a value class`() {
+    fun `The alternateType property must be a value class`() {
         val result = compile(
             """
             package test
@@ -1058,13 +1058,13 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
             data class Dept(
                 @KomapperAutoIncrement @KomapperId
                 val id: Int,
-                @KomapperAlternate(ClobString::class)
+                @KomapperColumn(alternateType = ClobString::class)
                 val description: String
             )
             """,
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("The valueClass property must be a value class."))
+        assertTrue(result.messages.contains("The alternateType property must be a value class."))
     }
 
     @Test
@@ -1078,7 +1078,7 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
             data class Dept(
                 @KomapperAutoIncrement @KomapperId
                 val id: Int,
-                @KomapperAlternate(ClobString::class)
+                @KomapperColumn(alternateType = ClobString::class)
                 val description: String
             )
             """,
@@ -1098,7 +1098,7 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
             data class Dept(
                 @KomapperAutoIncrement @KomapperId
                 val id: Int,
-                @KomapperAlternate(ClobString::class)
+                @KomapperColumn(alternateType = ClobString::class)
                 val description: String
             )
             """,
@@ -1118,7 +1118,7 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
             data class Dept(
                 @KomapperAutoIncrement @KomapperId
                 val id: Int,
-                @KomapperAlternate(ClobString::class)
+                @KomapperColumn(alternateType = ClobString::class)
                 val description: String
             )
             """,
@@ -1138,7 +1138,7 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
             data class Dept(
                 @KomapperAutoIncrement @KomapperId
                 val id: Int,
-                @KomapperAlternate(ClobString::class)
+                @KomapperColumn(alternateType = ClobString::class)
                 val number: Int
             )
             """,
@@ -1148,7 +1148,7 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
     }
 
     @Test
-    fun `KomapperAlternate is invalid for enum property types`() {
+    fun `KomapperColumn alternateType is invalid for enum property types`() {
         val result = compile(
             """
             package test
@@ -1159,13 +1159,13 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
             data class Dept(
                 @KomapperAutoIncrement @KomapperId
                 val id: Int,
-                @KomapperAlternate(ClobString::class)
+                @KomapperColumn(alternateType = ClobString::class)
                 val color: Color
             )
             """,
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("@KomapperAlternate is invalid for enum property types."))
+        assertTrue(result.messages.contains("@KomapperColumn.alternateType is invalid for enum property types."))
     }
 
     @Test
@@ -1180,7 +1180,7 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
             data class Dept(
                 @KomapperAutoIncrement @KomapperId
                 val id: Int,
-                @KomapperAlternate(ClobString::class)
+                @KomapperColumn(alternateType = ClobString::class)
                 val color: Color
             )
             """,

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorErrorTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorErrorTest.kt
@@ -1046,4 +1046,146 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
         assertTrue(result.messages.contains("The property \"unknown\" is not found in the test.Color. KomapperEnum's hint property is incorrect."))
     }
+
+    @Test
+    fun `The valueClass property must be a value class`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            data class ClobString(val value: String)
+            @KomapperEntity
+            data class Dept(
+                @KomapperAutoIncrement @KomapperId
+                val id: Int,
+                @KomapperAlternate(ClobString::class)
+                val description: String
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The valueClass property must be a value class."))
+    }
+
+    @Test
+    fun `The constructor must be public`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            value class ClobString private constructor(val value: String)
+            @KomapperEntity
+            data class Dept(
+                @KomapperAutoIncrement @KomapperId
+                val id: Int,
+                @KomapperAlternate(ClobString::class)
+                val description: String
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The constructor of \"test.ClobString\" must be public."))
+    }
+
+    @Test
+    fun `The property parameter must be public`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            value class ClobString (private val value: String)
+            @KomapperEntity
+            data class Dept(
+                @KomapperAutoIncrement @KomapperId
+                val id: Int,
+                @KomapperAlternate(ClobString::class)
+                val description: String
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The property parameter of \"test.ClobString\" must be public."))
+    }
+
+    @Test
+    fun `The property parameter must not be nullable`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            value class ClobString (val value: String?)
+            @KomapperEntity
+            data class Dept(
+                @KomapperAutoIncrement @KomapperId
+                val id: Int,
+                @KomapperAlternate(ClobString::class)
+                val description: String
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The property parameter of \"test.ClobString\" must not be nullable."))
+    }
+
+    @Test
+    fun `The property type does not match the parameter property type in the value class`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            value class ClobString (val value: String)
+            @KomapperEntity
+            data class Dept(
+                @KomapperAutoIncrement @KomapperId
+                val id: Int,
+                @KomapperAlternate(ClobString::class)
+                val number: Int
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The property \"number\" is invalid. The property type does not match the parameter property type in \"test.ClobString\"."))
+    }
+
+    @Test
+    fun `KomapperAlternate is invalid for enum property types`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            value class ClobString (val value: String)
+            enum class Color { RED }
+            @KomapperEntity
+            data class Dept(
+                @KomapperAutoIncrement @KomapperId
+                val id: Int,
+                @KomapperAlternate(ClobString::class)
+                val color: Color
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("@KomapperAlternate is invalid for enum property types."))
+    }
+
+    @Test
+    fun `The parameter property type does not match between value classes`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            value class ClobString (val value: String)
+            value class Color(val value: ClobString)
+            @KomapperEntity
+            data class Dept(
+                @KomapperAutoIncrement @KomapperId
+                val id: Int,
+                @KomapperAlternate(ClobString::class)
+                val color: Color
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The property \"color\" is invalid. The parameter property type does not match between \"test.Color\" and \"test.ClobString\"."))
+    }
 }

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorOkTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorOkTest.kt
@@ -174,7 +174,7 @@ class EntityProcessorOkTest : AbstractKspTest(EntityProcessorProvider()) {
             data class Dept(
                 @KomapperAutoIncrement @KomapperId
                 val id: Int,
-                @KomapperAlternate(ClobString::class)
+                @KomapperColumn(alternateType = ClobString::class)
                 val description: String
             )
             """,
@@ -193,7 +193,7 @@ class EntityProcessorOkTest : AbstractKspTest(EntityProcessorProvider()) {
             data class Dept(
                 @KomapperAutoIncrement @KomapperId
                 val id: Int,
-                @KomapperAlternate(ClobString::class)
+                @KomapperColumn(alternateType = ClobString::class)
                 val description: String?
             )
             """,

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorOkTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorOkTest.kt
@@ -162,4 +162,42 @@ class EntityProcessorOkTest : AbstractKspTest(EntityProcessorProvider()) {
         )
         assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK, result.messages)
     }
+
+    @Test
+    fun `Allow alternate type mapping`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            value class ClobString(val value: String)
+            @KomapperEntity
+            data class Dept(
+                @KomapperAutoIncrement @KomapperId
+                val id: Int,
+                @KomapperAlternate(ClobString::class)
+                val description: String
+            )
+            """,
+        )
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK, result.messages)
+    }
+
+    @Test
+    fun `Allow alternate type mapping - nullable`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            value class ClobString(val value: String)
+            @KomapperEntity
+            data class Dept(
+                @KomapperAutoIncrement @KomapperId
+                val id: Int,
+                @KomapperAlternate(ClobString::class)
+                val description: String?
+            )
+            """,
+        )
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK, result.messages)
+    }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataType.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataType.kt
@@ -5,8 +5,8 @@ import io.r2dbc.spi.Clob
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
 import org.komapper.core.ThreadSafe
-import org.komapper.core.spi.DataTypeConverter
 import org.komapper.core.alternate.ClobString
+import org.komapper.core.spi.DataTypeConverter
 import org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
 import java.math.BigDecimal
 import java.math.BigInteger

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataType.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataType.kt
@@ -6,6 +6,7 @@ import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
 import org.komapper.core.ThreadSafe
 import org.komapper.core.spi.DataTypeConverter
+import org.komapper.core.alternate.ClobString
 import org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -230,6 +231,28 @@ class R2dbcClobType(override val name: String) :
 
     override fun getValue(row: Row, columnLabel: String): Clob? {
         return row.get(columnLabel, Clob::class.java)
+    }
+}
+
+class R2dbcClobStringType(override val name: String) :
+    AbstractR2dbcDataType<ClobString>(ClobString::class, Clob::class.javaObjectType) {
+
+    override fun getValue(row: Row, index: Int): ClobString? {
+        val text = row.get(index, String::class.java)
+        return if (text == null) null else ClobString(text)
+    }
+
+    override fun getValue(row: Row, columnLabel: String): ClobString? {
+        val text = row.get(columnLabel, String::class.java)
+        return if (text == null) null else ClobString(text)
+    }
+
+    override fun convertBeforeBinding(value: ClobString): Any {
+        return value.value
+    }
+
+    override fun doToString(value: ClobString): String {
+        return value.value
     }
 }
 


### PR DESCRIPTION
The KomapperAlternate annotation allows you to map multiple sql types to the same kotlin type.

Without `@KomapperAlternate`, Komapper maps SQL VARCHAR to Kotlin String by default:
```kotlin
@KomapperEntity
data class Something(
    @KomapperId
    val id: Int,
    val description: String?,
)
```

With `@KomapperAlternate(ClobString::class)`, Komapper maps SQL CLOB(TEXT in some dialects) to Kotlin String:
```kotlin
@KomapperEntity
data class Something(
    @KomapperId
    val id: Int,
    @KomapperAlternate(ClobString::class)
    val description: String?,
)
```

The KomapperAlternate annotation only accepts a value class. The value class must meet the following requirements:

- the constructor must be public
- the parameter property must be public and  non-nullable
- the parameter property type must match the property type annotated with `@KomapperAlternate` 
- the corresponding data type must exist

Komapper provides the data type corresponding to the `ClobString`. However, if a user specifies a different value class to the KomapperAlternate annotation, the user must create a [user defined data type](https://www.komapper.org/docs/reference/data-type/#user-defined-data-types).