### PR TITLE
Add the KSP option "komapper.enableEntityMetamodelListing"

### DIFF
--- a/integration-test-core/build.gradle.kts
+++ b/integration-test-core/build.gradle.kts
@@ -24,4 +24,5 @@ idea {
 
 ksp {
     arg("komapper.namingStrategy", "lower_snake_case")
+    arg("komapper.enableEntityMetamodelListing", "true")
 }

--- a/integration-test-jdbc/build.gradle.kts
+++ b/integration-test-jdbc/build.gradle.kts
@@ -25,6 +25,10 @@ idea {
     }
 }
 
+ksp {
+    arg("komapper.enableEntityMetamodelListing", "true")
+}
+
 tasks {
     test {
         enabled = false

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcEntityMetamodels.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcEntityMetamodels.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.EntityMetamodels
 import org.komapper.core.dsl.Meta
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -15,7 +16,7 @@ import kotlin.test.assertTrue
 class JdbcEntityMetamodels {
 
     @Test
-    fun list() {
+    fun all() {
         val list = EntityMetamodels.all().map { it.second }
         assertTrue(Meta.address in list)
         assertTrue(Meta.sqlXmlData in list)
@@ -30,5 +31,10 @@ class JdbcEntityMetamodels {
         assertFalse(Meta.sqlXmlData in list)
         assertTrue(MyMeta.myAddress in list)
         assertTrue(MyMeta.myPerson in list)
+    }
+
+    @Test
+    fun all_Meta() {
+        assertEquals(EntityMetamodels.list(Meta), Meta.all())
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcEntityMetamodels.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcEntityMetamodels.kt
@@ -1,0 +1,34 @@
+package integration.jdbc
+
+import integration.core.MyMeta
+import integration.core.address
+import integration.core.myAddress
+import integration.core.myPerson
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.EntityMetamodels
+import org.komapper.core.dsl.Meta
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExtendWith(JdbcEnv::class)
+class JdbcEntityMetamodels {
+
+    @Test
+    fun list() {
+        val list = EntityMetamodels.all().map { it.second }
+        assertTrue(Meta.address in list)
+        assertTrue(Meta.sqlXmlData in list)
+        assertTrue(MyMeta.myAddress in list)
+        assertTrue(MyMeta.myPerson in list)
+    }
+
+    @Test
+    fun listByEntityUnit() {
+        val list = EntityMetamodels.list(MyMeta)
+        assertFalse(Meta.address in list)
+        assertFalse(Meta.sqlXmlData in list)
+        assertTrue(MyMeta.myAddress in list)
+        assertTrue(MyMeta.myPerson in list)
+    }
+}

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcEntityMetamodels.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcEntityMetamodels.kt
@@ -1,0 +1,20 @@
+package integration.r2dbc
+
+import integration.core.address
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.EntityMetamodels
+import org.komapper.core.dsl.Meta
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExtendWith(R2dbcEnv::class)
+class R2dbcEntityMetamodels {
+
+    @Test
+    fun list() {
+        val list = EntityMetamodels.all().map { it.second }
+        assertTrue(Meta.address in list)
+        assertFalse(Meta.clobData in list)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/EntityMetamodels.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/EntityMetamodels.kt
@@ -1,0 +1,39 @@
+package org.komapper.core
+
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.spi.EntityMetamodelFactory
+import java.util.ServiceLoader
+
+/**
+ * The provider of [EntityMetamodel].
+ *
+ * This class requires the following configuration in build.gradle.kts:
+ *
+ * ```
+ * ksp {
+ *   arg("komapper.enableEntityMetamodelListing", "true")
+ * }
+ * ```
+ */
+object EntityMetamodels {
+
+    /**
+     * Returns a list of entity metamodel unit and entity metamodel pairs.
+     *
+     * @return a list
+     */
+    fun all(): List<Pair<Any, EntityMetamodel<*, *, *>>> {
+        val loader = ServiceLoader.load(EntityMetamodelFactory::class.java)
+        return loader.map { it.create() }.flatten()
+    }
+
+    /**
+     * Returns a list of entity metamodels belonging to a specific unit.
+     *
+     * @param unit the entity metamodel unit such as [org.komapper.core.dsl.Meta]
+     * @return a list of entity metamodels
+     */
+    fun list(unit: Any): List<EntityMetamodel<*, *, *>> {
+        return all().filter { it.first == unit }.map { it.second }
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/Meta.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/Meta.kt
@@ -1,9 +1,15 @@
 package org.komapper.core.dsl
 
+import org.komapper.core.EntityMetamodels
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 /**
  * The entry point for entity metamodels.
  */
 @ThreadSafe
-object Meta
+object Meta {
+    fun all(): List<EntityMetamodel<*, *, *>> {
+        return EntityMetamodels.list(Meta)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodelFactory.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodelFactory.kt
@@ -1,0 +1,5 @@
+package org.komapper.core.dsl.metamodel
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class EntityMetamodelFactory

--- a/komapper-core/src/main/kotlin/org/komapper/core/spi/EntityMetamodelFactory.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/spi/EntityMetamodelFactory.kt
@@ -1,0 +1,7 @@
+package org.komapper.core.spi
+
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+interface EntityMetamodelFactory {
+    fun create(): List<Pair<Any, EntityMetamodel<*, *, *>>>
+}

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Config.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Config.kt
@@ -12,6 +12,7 @@ internal data class Config(
     val namingStrategy: NamingStrategy,
     val metaObject: String,
     val alwaysQuote: Boolean,
+    val enableEntityMetamodelListing: Boolean,
 ) {
     companion object {
         private const val PREFIX = "komapper.prefix"
@@ -20,6 +21,7 @@ internal data class Config(
         private const val NAMING_STRATEGY = "komapper.namingStrategy"
         private const val META_OBJECT = "komapper.metaObject"
         private const val ALWAYS_QUOTE = "komapper.alwaysQuote"
+        private const val ENABLE_ENTITY_METAMODEL_LISTING = "komapper.enableEntityMetamodelListing"
 
         fun create(options: Map<String, String>): Config {
             val prefix = options.getOrDefault(PREFIX, "_")
@@ -41,7 +43,8 @@ internal data class Config(
             }
             val metaObject = options.getOrDefault(META_OBJECT, Symbols.Meta)
             val alwaysQuote = options[ALWAYS_QUOTE]?.toBooleanStrict() ?: false
-            return Config(prefix, suffix, enumStrategy, namingStrategy, metaObject, alwaysQuote)
+            val enableEntityMetamodelListing = options[ENABLE_ENTITY_METAMODEL_LISTING]?.toBooleanStrict() ?: false
+            return Config(prefix, suffix, enumStrategy, namingStrategy, metaObject, alwaysQuote, enableEntityMetamodelListing)
         }
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EmptySymbolProcessor.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EmptySymbolProcessor.kt
@@ -1,0 +1,9 @@
+package org.komapper.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.KSAnnotated
+
+object EmptySymbolProcessor : SymbolProcessor {
+    override fun process(resolver: Resolver): List<KSAnnotated> = emptyList()
+}

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelFactoryProcessor.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelFactoryProcessor.kt
@@ -10,17 +10,17 @@ import org.komapper.processor.Symbols.EntityMetamodelFactory
 import org.komapper.processor.Symbols.EntityMetamodelFactorySpi
 import java.io.PrintWriter
 
-internal class EntityMetamodelFactoryProcessor(private val environment: SymbolProcessorEnvironment, private val config: Config) :
+internal class EntityMetamodelFactoryProcessor(
+    private val environment: SymbolProcessorEnvironment,
+) :
     SymbolProcessor {
 
     private val classDeclarations: MutableList<KSClassDeclaration> = mutableListOf()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        if (config.enableEntityMetamodelListing) {
-            val symbols = resolver.getSymbolsWithAnnotation(EntityMetamodelFactory)
-            val declarations = symbols.map { it.accept(ClassDeclarationVisitor(), Unit) }.filterNotNull().toList()
-            classDeclarations.addAll(declarations)
-        }
+        val symbols = resolver.getSymbolsWithAnnotation(EntityMetamodelFactory)
+        val declarations = symbols.map { it.accept(ClassDeclarationVisitor(), Unit) }.filterNotNull().toList()
+        classDeclarations.addAll(declarations)
         return emptyList()
     }
 

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelFactoryProcessor.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelFactoryProcessor.kt
@@ -1,0 +1,46 @@
+package org.komapper.processor
+
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import org.komapper.processor.Symbols.EntityMetamodelFactory
+import org.komapper.processor.Symbols.EntityMetamodelFactorySpi
+import java.io.PrintWriter
+
+internal class EntityMetamodelFactoryProcessor(private val environment: SymbolProcessorEnvironment, private val config: Config) :
+    SymbolProcessor {
+
+    private val classDeclarations: MutableList<KSClassDeclaration> = mutableListOf()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (config.enableEntityMetamodelListing) {
+            val symbols = resolver.getSymbolsWithAnnotation(EntityMetamodelFactory)
+            val declarations = symbols.map { it.accept(ClassDeclarationVisitor(), Unit) }.filterNotNull().toList()
+            classDeclarations.addAll(declarations)
+        }
+        return emptyList()
+    }
+
+    override fun finish() {
+        val files = classDeclarations.mapNotNull { it.containingFile }
+        val dependencies = Dependencies(true, *files.toTypedArray())
+        environment.codeGenerator.createNewFile(
+            dependencies,
+            "META-INF/services",
+            EntityMetamodelFactorySpi,
+            "",
+        ).use { out ->
+            PrintWriter(out).use { writer ->
+                for (classDeclaration in classDeclarations) {
+                    val name = classDeclaration.qualifiedName?.asString()
+                    if (name != null) {
+                        writer.println(name)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelFactoryProcessorProvider.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelFactoryProcessorProvider.kt
@@ -10,7 +10,7 @@ class EntityMetamodelFactoryProcessorProvider : SymbolProcessorProvider {
     override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
         val config = Config.create(environment.options)
         return if (config.enableEntityMetamodelListing) {
-            EntityMetamodelFactoryProcessor(environment, config)
+            EntityMetamodelFactoryProcessor(environment)
         } else {
             EmptySymbolProcessor
         }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelFactoryProcessorProvider.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelFactoryProcessorProvider.kt
@@ -6,9 +6,13 @@ import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import org.komapper.core.ThreadSafe
 
 @ThreadSafe
-class EntityProcessorProvider : SymbolProcessorProvider {
+class EntityMetamodelFactoryProcessorProvider : SymbolProcessorProvider {
     override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
         val config = Config.create(environment.options)
-        return EntityProcessor(environment, config)
+        return if (config.enableEntityMetamodelListing) {
+            EntityMetamodelFactoryProcessor(environment, config)
+        } else {
+            EmptySymbolProcessor
+        }
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -11,6 +11,8 @@ import org.komapper.processor.Symbols.EmbeddedMetamodel
 import org.komapper.processor.Symbols.EntityDescriptor
 import org.komapper.processor.Symbols.EntityMetamodel
 import org.komapper.processor.Symbols.EntityMetamodelDeclaration
+import org.komapper.processor.Symbols.EntityMetamodelFactory
+import org.komapper.processor.Symbols.EntityMetamodelFactorySpi
 import org.komapper.processor.Symbols.EntityMetamodelImplementor
 import org.komapper.processor.Symbols.EnumMappingException
 import org.komapper.processor.Symbols.IdContext
@@ -34,7 +36,7 @@ import java.time.ZonedDateTime
 internal class EntityMetamodelGenerator(
     @Suppress("unused") private val logger: KSPLogger,
     private val entity: Entity,
-    private val metaObject: String,
+    private val unitTypeName: String,
     private val aliases: List<String>,
     private val packageName: String,
     private val simpleName: String,
@@ -119,6 +121,7 @@ internal class EntityMetamodelGenerator(
         w.println()
 
         utils()
+        provider()
     }
 
     private fun importStatements() {
@@ -569,7 +572,15 @@ internal class EntityMetamodelGenerator(
 
     private fun utils() {
         for (alias in aliases) {
-            w.println("val $metaObject.`$alias` get() = $simpleName.`$alias`")
+            w.println("val $unitTypeName.`$alias` get() = $simpleName.`$alias`")
         }
+        w.println()
+    }
+
+    private fun provider() {
+        w.println("@$EntityMetamodelFactory")
+        w.println("class ${simpleName}_Factory: $EntityMetamodelFactorySpi {")
+        w.println("    override fun create() = listOf(${aliases.joinToString { "$unitTypeName to $simpleName.`$it`" }})")
+        w.println("}")
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityProcessor.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityProcessor.kt
@@ -10,10 +10,9 @@ import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperEntityDef
 import java.io.PrintWriter
 
-internal class EntityProcessor(private val environment: SymbolProcessorEnvironment) : SymbolProcessor {
+internal class EntityProcessor(private val environment: SymbolProcessorEnvironment, private val config: Config) : SymbolProcessor {
 
     private val logger: KSPLogger = environment.logger
-    private val config: Config = Config.create(environment.options)
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val pairs = listOf(

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -7,6 +7,8 @@ internal object Symbols {
     const val EntityMetamodel = "org.komapper.core.dsl.metamodel.EntityMetamodel"
     const val EntityMetamodelStub = "org.komapper.core.dsl.metamodel.EntityMetamodelStub"
     const val EntityMetamodelImplementor = "org.komapper.core.dsl.metamodel.EntityMetamodelImplementor"
+    const val EntityMetamodelFactory = "org.komapper.core.dsl.metamodel.EntityMetamodelFactory"
+    const val EntityMetamodelFactorySpi = "org.komapper.core.spi.EntityMetamodelFactory"
     const val IdGenerator = "org.komapper.core.dsl.metamodel.IdGenerator"
     const val AutoIncrement = "org.komapper.core.dsl.metamodel.IdGenerator.AutoIncrement"
     const val Sequence = "org.komapper.core.dsl.metamodel.IdGenerator.Sequence"

--- a/komapper-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/komapper-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,1 +1,2 @@
 org.komapper.processor.EntityProcessorProvider
+org.komapper.processor.EntityMetamodelFactoryProcessorProvider

--- a/komapper-quarkus-jdbc-deployment/src/main/java/org/komapper/quarkus/jdbc/deployment/KomapperProcessor.java
+++ b/komapper-quarkus-jdbc-deployment/src/main/java/org/komapper/quarkus/jdbc/deployment/KomapperProcessor.java
@@ -55,6 +55,7 @@ public class KomapperProcessor {
     var serviceInterfaces =
         List.of(
             "org.komapper.core.spi.DataTypeConverter",
+            "org.komapper.core.spi.EntityMetamodelFactory",
             "org.komapper.core.spi.LoggerFactory",
             "org.komapper.core.spi.LoggerFacadeFactory",
             "org.komapper.core.spi.StatementInspectorFactory",


### PR DESCRIPTION
If the KSP option "komapper.enableEntityMetamodelListing" is enabled, entity metamodels can be retrieved as a list.

build.gradle.kts:

```kotlin
ksp {
    arg("komapper.enableEntityMetamodelListing", "true")
}
```

Sample.kt:

```kotlin
// get metamodels
val metamodels: List<EntityMetamodel<*, *, *>> = EntityMetamodels.list(Meta)

val db = JdbcDatabase("jdbc:h2:mem:example;DB_CLOSE_DELAY=-1")

// create tables using metamodels 
db.runQuery {
    QueryDsl.create(metamodels)
}
```