### PR TITLE
Throws an understandable exception when a bind variable is not found in Template Queries

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcTemplateTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcTemplateTest.kt
@@ -158,7 +158,7 @@ class JdbcTemplateTest(private val db: JdbcDatabase) {
         val message = ex.message!!
         assertEquals("The expression evaluation was failed at <select * from address where street = /*street*/'test'>:1:47.", message)
         val causeMessage = ex.cause!!.message
-        assertEquals("The variable \"street\" is not found. Make sure the variable name is correct. <street>:6", causeMessage)
+        assertEquals("The template variable \"street\" is not bound to a value. Make sure the variable name is correct. <street>:6", causeMessage)
     }
 
     @Test

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcTemplateTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcTemplateTest.kt
@@ -16,6 +16,7 @@ import org.komapper.core.dsl.query.getNotNull
 import org.komapper.jdbc.JdbcDatabase
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 @ExtendWith(JdbcEnv::class)
@@ -141,6 +142,23 @@ class JdbcTemplateTest(private val db: JdbcDatabase) {
                 .select(asAddress)
         }
         assertEquals(15, list.size)
+    }
+
+    @Test
+    fun bind_unknownBindVariable() {
+        val ex = assertFailsWith<Exception> {
+            db.runQuery {
+                val sql = "select * from address where street = /*street*/'test'"
+                QueryDsl.fromTemplate(sql)
+                    .bind("unknown", "STREET 10")
+                    .select(asAddress)
+            }
+            Unit
+        }
+        val message = ex.message!!
+        assertEquals("The expression evaluation was failed at <select * from address where street = /*street*/'test'>:1:47.", message)
+        val causeMessage = ex.cause!!.message
+        assertEquals("The variable \"street\" is not found. Make sure the variable name is correct. <street>:6", causeMessage)
     }
 
     @Test

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcTemplateTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcTemplateTest.kt
@@ -102,7 +102,7 @@ class R2dbcTemplateTest(private val db: R2dbcDatabase) {
         val message = ex.message!!
         assertEquals("The expression evaluation was failed at <select * from address where street = /*street*/'test'>:1:47.", message)
         val causeMessage = ex.cause!!.message
-        assertEquals("The variable \"street\" is not found. Make sure the variable name is correct. <street>:6", causeMessage)
+        assertEquals("The template variable \"street\" is not bound to a value. Make sure the variable name is correct. <street>:6", causeMessage)
     }
 
     @Test

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataOperator.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataOperator.kt
@@ -43,6 +43,14 @@ interface JdbcDataOperator : DataOperator {
      * @return the data type
      */
     fun <T : Any> getDataType(klass: KClass<out T>): JdbcDataType<T>
+
+    /**
+     * Returns the data type or null.
+     *
+     * @param klass the value class
+     * @return the data type or null
+     */
+    fun <T : Any> getDataTypeOrNull(klass: KClass<out T>): JdbcDataType<T>?
 }
 
 class DefaultJdbcDataOperator(private val dialect: JdbcDialect, private val dataTypeProvider: JdbcDataTypeProvider) :
@@ -66,8 +74,8 @@ class DefaultJdbcDataOperator(private val dialect: JdbcDialect, private val data
         return if (masking) {
             dialect.mask
         } else {
-            val dataType = getDataType(valueClass)
-            dataType.toString(value)
+            val dataType = getDataTypeOrNull(valueClass)
+            dataType?.toString(value) ?: value.toString()
         }
     }
 
@@ -77,8 +85,12 @@ class DefaultJdbcDataOperator(private val dialect: JdbcDialect, private val data
     }
 
     override fun <T : Any> getDataType(klass: KClass<out T>): JdbcDataType<T> {
-        return dataTypeProvider.get(klass) ?: error(
+        return getDataTypeOrNull(klass) ?: error(
             "The dataType is not found for the type \"${klass.qualifiedName}\".",
         )
+    }
+
+    override fun <T : Any> getDataTypeOrNull(klass: KClass<out T>): JdbcDataType<T>? {
+        return dataTypeProvider.get(klass)
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataOperator.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataOperator.kt
@@ -44,6 +44,14 @@ interface R2dbcDataOperator : DataOperator {
      * @return the data type
      */
     fun <T : Any> getDataType(klass: KClass<out T>): R2dbcDataType<T>
+
+    /**
+     * Returns the data type or null.
+     *
+     * @param klass the value class
+     * @return the data type or null
+     */
+    fun <T : Any> getDataTypeOrNull(klass: KClass<out T>): R2dbcDataType<T>?
 }
 
 class DefaultR2dbcDataOperator(private val dialect: R2dbcDialect, private val dataTypeProvider: R2dbcDataTypeProvider) :
@@ -69,15 +77,19 @@ class DefaultR2dbcDataOperator(private val dialect: R2dbcDialect, private val da
         return if (masking) {
             dialect.mask
         } else {
-            val dataType = getDataType(valueClass)
-            return dataType.toString(value)
+            val dataType = getDataTypeOrNull(valueClass)
+            dataType?.toString(value) ?: value.toString()
         }
     }
 
     override fun <T : Any> getDataType(klass: KClass<out T>): R2dbcDataType<T> {
-        return dataTypeProvider.get(klass) ?: error(
+        return getDataTypeOrNull(klass) ?: error(
             "The dataType is not found for the type \"${klass.qualifiedName}\".",
         )
+    }
+
+    override fun <T : Any> getDataTypeOrNull(klass: KClass<out T>): R2dbcDataType<T>? {
+        return dataTypeProvider.get(klass)
     }
 
     override fun getDataTypeName(klass: KClass<*>): String {

--- a/komapper-template/src/main/kotlin/org/komapper/template/expression/ExprEvaluator.kt
+++ b/komapper-template/src/main/kotlin/org/komapper/template/expression/ExprEvaluator.kt
@@ -181,7 +181,7 @@ internal class DefaultExprEvaluator(
 
     private fun visitValue(node: ExprNode.Value, ctx: ExprContext): Value<*> {
         return ctx.valueMap[node.name] ?: exprEnvironment.ctx[node.name]
-            ?: throw ExprException("The variable \"${node.name}\" is not found. Make sure the variable name is correct. ${node.location}")
+            ?: throw ExprException("The template variable \"${node.name}\" is not bound to a value. Make sure the variable name is correct. ${node.location}")
     }
 
     private fun visitProperty(node: ExprNode.Property, ctx: ExprContext): Value<*> {

--- a/komapper-template/src/main/kotlin/org/komapper/template/expression/ExprEvaluator.kt
+++ b/komapper-template/src/main/kotlin/org/komapper/template/expression/ExprEvaluator.kt
@@ -180,7 +180,8 @@ internal class DefaultExprEvaluator(
     }
 
     private fun visitValue(node: ExprNode.Value, ctx: ExprContext): Value<*> {
-        return ctx.valueMap[node.name] ?: exprEnvironment.ctx[node.name] ?: Value(null, Any::class)
+        return ctx.valueMap[node.name] ?: exprEnvironment.ctx[node.name]
+            ?: throw ExprException("The variable \"${node.name}\" is not found. Make sure the variable name is correct. ${node.location}")
     }
 
     private fun visitProperty(node: ExprNode.Property, ctx: ExprContext): Value<*> {

--- a/komapper-template/src/test/kotlin/org/komapper/template/TwoWayTemplateStatementBuilderTest.kt
+++ b/komapper-template/src/test/kotlin/org/komapper/template/TwoWayTemplateStatementBuilderTest.kt
@@ -40,7 +40,8 @@ class TwoWayTemplateStatementBuilderTest {
     fun complex() {
         val template =
             "select name, age from person where name = /*name*/'test' and age > 1 order by name, age for update"
-        val statement = statementBuilder.build(template, emptyMap(), extensions)
+        val valueMap = mapOf("name" to Value(""))
+        val statement = statementBuilder.build(template, valueMap, extensions)
         assertEquals(
             "select name, age from person where name = ? and age > 1 order by name, age for update",
             statement.toSql(),
@@ -71,9 +72,9 @@ class TwoWayTemplateStatementBuilderTest {
         @Test
         fun singleValue_null() {
             val template = "select name, age from person where name = /*name*/'test' and age > 1"
-            val statement = statementBuilder.build(template, emptyMap(), extensions)
+            val statement = statementBuilder.build(template, mapOf("name" to Value(null, String::class)), extensions)
             assertEquals("select name, age from person where name = ? and age > 1", statement.toSql())
-            assertEquals(listOf(Value(null, Any::class)), statement.args)
+            assertEquals(listOf(Value(null, String::class)), statement.args)
         }
 
         @Test
@@ -95,7 +96,8 @@ class TwoWayTemplateStatementBuilderTest {
         @Test
         fun multipleValues_null() {
             val template = "select name, age from person where name in /*name*/('a', 'b') and age > 1"
-            val statement = statementBuilder.build(template, emptyMap(), extensions)
+            val valueMap = mapOf("name" to Value(null, Any::class))
+            val statement = statementBuilder.build(template, valueMap, extensions)
             assertEquals("select name, age from person where name in ? and age > 1", statement.toSql())
             assertEquals(listOf(Value(null, Any::class)), statement.args)
         }
@@ -216,7 +218,7 @@ class TwoWayTemplateStatementBuilderTest {
         fun if_false() {
             val template =
                 "select name, age from person where /*%if name != null*/name = /*name*/'test'/*%end*/ and 1 = 1"
-            val statement = statementBuilder.build(template, emptyMap(), extensions)
+            val statement = statementBuilder.build(template, mapOf("name" to Value(null, String::class)), extensions)
             assertEquals("select name, age from person where   1 = 1", statement.toSql())
         }
 
@@ -224,7 +226,7 @@ class TwoWayTemplateStatementBuilderTest {
         fun `Remove the 'where' clause automatically`() {
             val template =
                 "select name, age from person where /*%if name != null*/name = /*name*/'test'/*%end*/ order by name"
-            val statement = statementBuilder.build(template, emptyMap(), extensions)
+            val statement = statementBuilder.build(template, mapOf("name" to Value(null, String::class)), extensions)
             assertEquals("select name, age from person   order by name", statement.toSql())
         }
 
@@ -232,7 +234,7 @@ class TwoWayTemplateStatementBuilderTest {
         fun `Remove the 'where' and 'order by' clauses automatically`() {
             val template =
                 "select name, age from person where /*%if name != null*/name = /*name*/'test'/*%end*/ order by /*%if false*/name/*%end*/"
-            val statement = statementBuilder.build(template, emptyMap(), extensions)
+            val statement = statementBuilder.build(template, mapOf("name" to Value(null, String::class)), extensions)
             assertEquals("select name, age from person ", statement.toSql())
         }
     }

--- a/komapper-template/src/test/kotlin/org/komapper/template/expression/ExprEvaluatorTest.kt
+++ b/komapper-template/src/test/kotlin/org/komapper/template/expression/ExprEvaluatorTest.kt
@@ -414,12 +414,12 @@ class ExprEvaluatorTest {
         }
 
         @Test
-        fun `The value cannot be resolved`() {
+        fun `The template variable is not bound to a value`() {
             val ctx = ExprContext(emptyMap(), extensions)
             val ex = assertFailsWith<ExprException> {
                 evaluator.eval("a", ctx)
             }
-            assertEquals("The variable \"a\" is not found. Make sure the variable name is correct. <a>:1", ex.message)
+            assertEquals("The template variable \"a\" is not bound to a value. Make sure the variable name is correct. <a>:1", ex.message)
         }
     }
 

--- a/komapper-template/src/test/kotlin/org/komapper/template/expression/ExprEvaluatorTest.kt
+++ b/komapper-template/src/test/kotlin/org/komapper/template/expression/ExprEvaluatorTest.kt
@@ -416,8 +416,10 @@ class ExprEvaluatorTest {
         @Test
         fun `The value cannot be resolved`() {
             val ctx = ExprContext(emptyMap(), extensions)
-            val result = evaluator.eval("a", ctx)
-            assertEquals(Value(null, Any::class), result)
+            val ex = assertFailsWith<ExprException> {
+                evaluator.eval("a", ctx)
+            }
+            assertEquals("The variable \"a\" is not found. Make sure the variable name is correct. <a>:1", ex.message)
         }
     }
 


### PR DESCRIPTION
```kotlin
db.runQuery {
    val sql = "select * from address where street = /*street*/'test'"
    QueryDsl.fromTemplate(sql)
        .bind("unknown", "STREET 10")
        .select(asAddress)
}
```

The above code throws an exception with a stack trace like this:

```
org.komapper.template.sql.SqlException: The expression evaluation was failed at <select * from address where street = /*street*/'test'>:1:47.
...
Caused by: org.komapper.template.expression.ExprException: The variable "street" is not found. Make sure the variable name is correct. <street>:6
```
