### PR TITLE
Add the experimental association API

### DIFF
--- a/integration-test-core/build.gradle.kts
+++ b/integration-test-core/build.gradle.kts
@@ -26,3 +26,9 @@ ksp {
     arg("komapper.namingStrategy", "lower_snake_case")
     arg("komapper.enableEntityMetamodelListing", "true")
 }
+
+tasks {
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        kotlinOptions.freeCompilerArgs += listOf("-opt-in=org.komapper.annotation.KomapperExperimentalAssociation")
+    }
+}

--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -1,7 +1,5 @@
 package integration.core
 
-import org.komapper.annotation.AssociationType
-import org.komapper.annotation.KomapperAssociation
 import org.komapper.annotation.KomapperAutoIncrement
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperColumnOverride
@@ -11,6 +9,10 @@ import org.komapper.annotation.KomapperEmbeddedId
 import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperEntityDef
 import org.komapper.annotation.KomapperId
+import org.komapper.annotation.KomapperLink
+import org.komapper.annotation.KomapperManyToOne
+import org.komapper.annotation.KomapperOneToMany
+import org.komapper.annotation.KomapperOneToOne
 import org.komapper.annotation.KomapperSequence
 import org.komapper.annotation.KomapperTable
 import org.komapper.annotation.KomapperUpdatedAt
@@ -121,8 +123,10 @@ data class Human(
     @KomapperUpdatedAt val updatedAt: OffsetDateTime? = null,
 )
 
-@KomapperAssociation(AssociationType.MANY_TO_ONE, Department::class)
-@KomapperAssociation(AssociationType.ONE_TO_ONE, Address::class)
+@KomapperManyToOne(Department::class)
+@KomapperOneToOne(Address::class)
+@KomapperManyToOne(Employee::class, link = KomapperLink(target = "manager"))
+@KomapperOneToMany(Employee::class, navigator = "employees", link = KomapperLink(source = "manager", target = "employee"))
 @KomapperEntity(["employee", "manager"])
 data class Employee(
     @KomapperId
@@ -219,7 +223,7 @@ data class CyborgDef(
     @KomapperVersion val version: Nothing,
 )
 
-@KomapperAssociation(AssociationType.ONE_TO_MANY, Employee::class, "employees")
+@KomapperOneToMany(Employee::class, navigator = "employees")
 @KomapperEntity
 data class Department(
     @KomapperId

--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -1,5 +1,6 @@
 package integration.core
 
+import org.komapper.annotation.KomapperAggregateRoot
 import org.komapper.annotation.KomapperAutoIncrement
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperColumnOverride
@@ -223,6 +224,7 @@ data class CyborgDef(
     @KomapperVersion val version: Nothing,
 )
 
+@KomapperAggregateRoot("departments")
 @KomapperOneToMany(Employee::class, navigator = "employees")
 @KomapperEntity
 data class Department(

--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -1,5 +1,7 @@
 package integration.core
 
+import org.komapper.annotation.AssociationType
+import org.komapper.annotation.KomapperAssociation
 import org.komapper.annotation.KomapperAutoIncrement
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperColumnOverride
@@ -119,6 +121,8 @@ data class Human(
     @KomapperUpdatedAt val updatedAt: OffsetDateTime? = null,
 )
 
+@KomapperAssociation(AssociationType.MANY_TO_ONE, Department::class)
+@KomapperAssociation(AssociationType.ONE_TO_ONE, Address::class)
 @KomapperEntity(["employee", "manager"])
 data class Employee(
     @KomapperId
@@ -215,6 +219,7 @@ data class CyborgDef(
     @KomapperVersion val version: Nothing,
 )
 
+@KomapperAssociation(AssociationType.ONE_TO_MANY, Employee::class, "employees")
 @KomapperEntity
 data class Department(
     @KomapperId

--- a/integration-test-jdbc/build.gradle.kts
+++ b/integration-test-jdbc/build.gradle.kts
@@ -46,6 +46,9 @@ tasks {
             testing.suites.named("sqlserver"),
         )
     }
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        kotlinOptions.freeCompilerArgs += listOf("-opt-in=org.komapper.annotation.KomapperExperimentalAssociation")
+    }
 }
 
 testing {

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectJoinTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectJoinTest.kt
@@ -3,6 +3,7 @@ package integration.jdbc
 import integration.core.address
 import integration.core.department
 import integration.core.employee
+import integration.core.employees
 import integration.core.manager
 import integration.core.person
 import org.junit.jupiter.api.extension.ExtendWith
@@ -282,5 +283,27 @@ class JdbcSelectJoinTest(private val db: JdbcDatabase) {
         assertEquals(14, store[a].size)
         assertEquals(14, store[e].size)
         assertEquals(3, store[d].size)
+    }
+
+    @Test
+    fun associationHelper() {
+        val d = Meta.department
+        val e = Meta.employee
+        val a = Meta.address
+        val store = db.runQuery {
+            QueryDsl.from(d)
+                .innerJoin(e) {
+                    d.departmentId eq e.departmentId
+                }.innerJoin(a) {
+                    e.addressId eq a.addressId
+                }.includeAll()
+        }
+        for (department in store[d]) {
+            val employees = department.employees(store, d, e)
+            for (employee in employees) {
+                val address = employee.address(store, e, a)
+                println("department=${department.departmentName}, employee=${employee.employeeName}, address=${address?.street}")
+            }
+        }
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectJoinTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectJoinTest.kt
@@ -306,4 +306,24 @@ class JdbcSelectJoinTest(private val db: JdbcDatabase) {
             }
         }
     }
+
+    @Test
+    fun associationHelper_manyToOne() {
+        val d = Meta.department
+        val e = Meta.employee
+        val a = Meta.address
+        val store = db.runQuery {
+            QueryDsl.from(d)
+                .innerJoin(e) {
+                    d.departmentId eq e.departmentId
+                }.innerJoin(a) {
+                    e.addressId eq a.addressId
+                }.includeAll()
+        }
+        for (employee in store[e]) {
+            val department = employee.department(store, e, d)
+            val address = employee.address(store, e, a)
+            println("department=${department?.departmentName}, employee=${employee.employeeName}, address=${address?.street}")
+        }
+    }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectJoinTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectJoinTest.kt
@@ -2,6 +2,7 @@ package integration.jdbc
 
 import integration.core.address
 import integration.core.department
+import integration.core.departments
 import integration.core.employee
 import integration.core.employees
 import integration.core.manager
@@ -298,7 +299,7 @@ class JdbcSelectJoinTest(private val db: JdbcDatabase) {
                     e.addressId eq a.addressId
                 }.includeAll()
         }
-        for (department in store[d]) {
+        for (department in store.departments()) {
             val employees = department.employees(store)
             for (employee in employees) {
                 val address = employee.address(store)

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
@@ -320,3 +320,15 @@ annotation class KomapperManyToOne(
         const val NAVIGATOR: String = ""
     }
 }
+
+// TODO
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+@Repeatable
+annotation class KomapperAggregateRoot(
+    val navigator: String = NAVIGATOR,
+) {
+    companion object {
+        const val NAVIGATOR: String = ""
+    }
+}

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
@@ -243,3 +243,17 @@ annotation class KomapperEntityDef(
     val aliases: Array<String> = [],
     val unit: KClass<*> = DefaultUnit::class,
 )
+
+// TODO: KDoc comment
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+@Repeatable
+annotation class KomapperAssociation(
+    val type: AssociationType,
+    val targetEntity: KClass<*>,
+    val name: String = NAME,
+) {
+    companion object {
+        const val NAME: String = ""
+    }
+}

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
@@ -244,16 +244,79 @@ annotation class KomapperEntityDef(
     val unit: KClass<*> = DefaultUnit::class,
 )
 
-// TODO: KDoc comment
+/**
+ * Indicates an association link.
+ *
+ * @property source the source name of an entity metamodel instance. The source is inferred from the annotated class.
+ * @property target the target name of an entity metamodel instance. The target is inferred from the targetEntity property of association annotation.
+ */
+@Retention(AnnotationRetention.SOURCE)
+annotation class KomapperLink(
+    val source: String = SOURCE,
+    val target: String = TARGET,
+) {
+    companion object {
+        const val SOURCE: String = ""
+        const val TARGET: String = ""
+    }
+}
+
+/**
+ * Indicates a one-to-one association.
+ *
+ * @property targetEntity the target entity class. The class must be annotated with [KomapperEntity] or [KomapperEntityDef].
+ * @property navigator the function name for navigation. The navigator is inferred from the [KomapperLink.target] value.
+ * @property link the association link
+ */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 @Repeatable
-annotation class KomapperAssociation(
-    val type: AssociationType,
+annotation class KomapperOneToOne(
     val targetEntity: KClass<*>,
-    val name: String = NAME,
+    val navigator: String = NAVIGATOR,
+    val link: KomapperLink = KomapperLink(),
 ) {
     companion object {
-        const val NAME: String = ""
+        const val NAVIGATOR: String = ""
+    }
+}
+
+/**
+ * Indicates a one-to-many association.
+ *
+ * @property targetEntity the target entity class. The class must be annotated with [KomapperEntity] or [KomapperEntityDef].
+ * @property navigator the function name for navigation. The navigator is inferred from the [KomapperLink.target] value.
+ * @property link the association link
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+@Repeatable
+annotation class KomapperOneToMany(
+    val targetEntity: KClass<*>,
+    val navigator: String = NAVIGATOR,
+    val link: KomapperLink = KomapperLink(),
+) {
+    companion object {
+        const val NAVIGATOR: String = ""
+    }
+}
+
+/**
+ * Indicates a many-to-one association.
+ *
+ * @property targetEntity the target entity class. The class must be annotated with [KomapperEntity] or [KomapperEntityDef].
+ * @property navigator the function name for navigation. The navigator is inferred from the [KomapperLink.target] value.
+ * @property link the association link
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+@Repeatable
+annotation class KomapperManyToOne(
+    val targetEntity: KClass<*>,
+    val navigator: String = NAVIGATOR,
+    val link: KomapperLink = KomapperLink(),
+) {
+    companion object {
+        const val NAVIGATOR: String = ""
     }
 }

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
@@ -252,6 +252,7 @@ annotation class KomapperEntityDef(
  * @property source the source name of an entity metamodel instance. The source is inferred from the annotated class.
  * @property target the target name of an entity metamodel instance. The target is inferred from the targetEntity property of association annotation.
  */
+@KomapperExperimentalAssociation
 @Retention(AnnotationRetention.SOURCE)
 annotation class KomapperLink(
     val source: String = SOURCE,
@@ -270,6 +271,7 @@ annotation class KomapperLink(
  * @property navigator the function name for navigation. The navigator is inferred from the [KomapperLink.target] value.
  * @property link the association link
  */
+@KomapperExperimentalAssociation
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 @Repeatable
@@ -290,6 +292,7 @@ annotation class KomapperOneToOne(
  * @property navigator the function name for navigation. The navigator is inferred from the [KomapperLink.target] value.
  * @property link the association link
  */
+@KomapperExperimentalAssociation
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 @Repeatable
@@ -310,6 +313,7 @@ annotation class KomapperOneToMany(
  * @property navigator the function name for navigation. The navigator is inferred from the [KomapperLink.target] value.
  * @property link the association link
  */
+@KomapperExperimentalAssociation
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 @Repeatable
@@ -323,10 +327,14 @@ annotation class KomapperManyToOne(
     }
 }
 
-// TODO
+/**
+ * Indicates an aggregate root.
+ *
+ * @property navigator the function name for navigation. The navigator is inferred from the annotated class.
+ */
+@KomapperExperimentalAssociation
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
-@Repeatable
 annotation class KomapperAggregateRoot(
     val navigator: String = NAVIGATOR,
 ) {
@@ -334,3 +342,9 @@ annotation class KomapperAggregateRoot(
         const val NAVIGATOR: String = ""
     }
 }
+
+/**
+ * Indicates that the annotated element uses the experimental association API.
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+annotation class KomapperExperimentalAssociation

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/AssociationType.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/AssociationType.kt
@@ -1,7 +1,0 @@
-package org.komapper.annotation
-
-enum class AssociationType {
-    ONE_TO_ONE,
-    ONE_TO_MANY,
-    MANY_TO_ONE,
-}

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/AssociationType.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/AssociationType.kt
@@ -1,0 +1,7 @@
+package org.komapper.annotation
+
+enum class AssociationType {
+    ONE_TO_ONE,
+    ONE_TO_MANY,
+    MANY_TO_ONE,
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityStoreContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityStoreContext.kt
@@ -1,0 +1,22 @@
+package org.komapper.core.dsl.query
+
+import org.komapper.core.ThreadSafe
+
+/**
+ * Represents a container for an [EntityStore] instance.
+ */
+@ThreadSafe
+interface EntityStoreContext {
+    val store: EntityStore
+}
+
+internal class EntityStoreContextImpl(
+    override val store: EntityStore,
+) : EntityStoreContext
+
+/**
+ * Converts [EntityStore] to [EntityStoreContext].
+ */
+fun EntityStore.asContext(): EntityStoreContext {
+    return EntityStoreContextImpl(this)
+}

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/AnnotationSupport.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/AnnotationSupport.kt
@@ -6,6 +6,7 @@ import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueParameter
+import org.komapper.annotation.KomapperAggregateRoot
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperColumnOverride
 import org.komapper.annotation.KomapperEntity
@@ -36,6 +37,19 @@ internal class AnnotationSupport(
         val alwaysQuote =
             annotation?.findValue("alwaysQuote")?.toString()?.toBooleanStrict() ?: config.alwaysQuote
         return Table(name, catalog, schema, alwaysQuote)
+    }
+
+    fun getAggregateRoot(definitionSource: EntityDefinitionSource): AggregateRoot? {
+        val annotation = definitionSource.defDeclaration.findAnnotation(KomapperAggregateRoot::class)
+        return if (annotation == null) {
+            null
+        } else {
+            val target = definitionSource.names.first()
+            val navigator = annotation.findValue("navigator")?.toString()?.trim().let { navigator ->
+                if (navigator.isNullOrBlank()) target else navigator
+            }
+            AggregateRoot(navigator, definitionSource, target)
+        }
     }
 
     fun getAssociations(definitionSource: EntityDefinitionSource): List<Association> {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/AnnotationSupport.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/AnnotationSupport.kt
@@ -1,19 +1,27 @@
 package org.komapper.processor
 
+import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueParameter
-import org.komapper.annotation.KomapperAssociation
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperColumnOverride
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperEntityDef
 import org.komapper.annotation.KomapperEnum
 import org.komapper.annotation.KomapperEnumOverride
+import org.komapper.annotation.KomapperLink
+import org.komapper.annotation.KomapperManyToOne
+import org.komapper.annotation.KomapperOneToMany
+import org.komapper.annotation.KomapperOneToOne
 import org.komapper.annotation.KomapperTable
 import org.komapper.core.NamingStrategy
 
 internal class AnnotationSupport(
-    @Suppress("unused") private val config: Config,
+    @Suppress("unused") private val logger: KSPLogger,
+    private val config: Config,
 ) {
 
     private val namingStrategy: NamingStrategy = config.namingStrategy
@@ -31,30 +39,94 @@ internal class AnnotationSupport(
     }
 
     fun getAssociations(definitionSource: EntityDefinitionSource): List<Association> {
-        return definitionSource.defDeclaration
-            .findAnnotations(KomapperAssociation::class)
-            .map { annotation ->
-                val targetEntity = annotation.findValue("targetEntity").let {
-                    if (it !is KSType) report("targetEntity is not KSType: $it", annotation)
-                    it.declaration.accept(ClassDeclarationVisitor(), Unit) ?: report("targetEntity is not KSClassDeclaration: ${it.declaration}", annotation)
-                }
-                val name = annotation.findValue("name")?.toString()?.trim().let { name ->
-                    if (name.isNullOrBlank()) {
-                        targetEntity.simpleName.asString().replaceFirstChar { it.lowercaseChar() }
-                    } else {
-                        name
+        val pairs = listOf(
+            KomapperOneToOne::class to AssociationKind.ONE_TO_ONE,
+            KomapperOneToMany::class to AssociationKind.ONE_TO_MANY,
+            KomapperManyToOne::class to AssociationKind.MANY_TO_ONE,
+        )
+        return pairs.flatMap { (klass, kind) ->
+            definitionSource.defDeclaration
+                .findAnnotations(klass)
+                .map { createAssociation(definitionSource, it, kind) }
+        }
+    }
+
+    private fun createAssociation(
+        sourceEntity: EntityDefinitionSource,
+        annotation: KSAnnotation,
+        kind: AssociationKind,
+    ): Association {
+        val targetEntity = annotation.findValue("targetEntity").let { type ->
+            if (type !is KSType) report("targetEntity is not KSType: $type", annotation)
+            resolveEntityDefinitionSource(type.declaration) ?: report(
+                "The targetEntity must be annotated with either @KomapperEntity or @KomapperEntityDef.",
+                annotation,
+            )
+        }
+        val defaultSource = sourceEntity.names.first()
+        val defaultTarget = targetEntity.names.first()
+        val link = annotation.findValue("link")?.let { node ->
+            when (node) {
+                is KSNode -> {
+                    val linkAnnotation = node.accept(AnnotationVisitor(), Unit)
+                    linkAnnotation?.let { annotation ->
+                        val source = annotation.findValue("source")?.toString().let {
+                            when (it) {
+                                KomapperLink.SOURCE -> defaultSource
+                                null, !in sourceEntity.names ->
+                                    report(
+                                        "@KomapperLink.source \"$it\" is invalid. It must be one of ${sourceEntity.names}.",
+                                        node,
+                                    )
+                                else -> it
+                            }
+                        }
+                        val target = annotation.findValue("target")?.toString().let {
+                            when (it) {
+                                KomapperLink.TARGET -> defaultTarget
+                                null, !in targetEntity.names ->
+                                    report(
+                                        "@KomapperLink.target \"$it\" is invalid. It must be one of ${targetEntity.names}.",
+                                        node,
+                                    )
+                                else -> it
+                            }
+                        }
+                        Link(source, target)
                     }
                 }
-                val kind = annotation.findValue("type").let {
-                    when (val type = it?.toString()) {
-                        Symbols.AssociationType_ONE_TO_ONE -> AssociationKind.ONE_TO_ONE
-                        Symbols.AssociationType_ONE_TO_MANY -> AssociationKind.ONE_TO_MANY
-                        Symbols.AssociationType_MANY_TO_ONE -> AssociationKind.MANY_TO_ONE
-                        else -> report("Unknown association type is found: $type", annotation)
-                    }
-                }
-                Association(targetEntity, kind, name)
+                else -> null
             }
+        } ?: report("Cannot get a value from the link property", annotation)
+        val navigator = annotation.findValue("navigator")?.toString()?.trim().let { navigator ->
+            if (navigator.isNullOrBlank()) link.target else navigator
+        }
+        return Association(annotation, navigator, sourceEntity, targetEntity, link, kind)
+    }
+
+    private fun resolveEntityDefinitionSource(declaration: KSDeclaration): EntityDefinitionSource? {
+        val selfDefinitionSourceResolver = SelfDefinitionSourceResolver(config)
+        val separateDefinitionSourceResolver = SeparateDefinitionSourceResolver(config)
+        val definitionSource = declaration.annotations.firstNotNullOfOrNull { annotation ->
+            when (annotation.shortName.asString()) {
+                KomapperEntity::class.simpleName -> {
+                    try {
+                        selfDefinitionSourceResolver.resolve(declaration)
+                    } catch (e: Exit) {
+                        null
+                    }
+                }
+                KomapperEntityDef::class.simpleName -> {
+                    try {
+                        separateDefinitionSourceResolver.resolve(declaration)
+                    } catch (e: Exit) {
+                        null
+                    }
+                }
+                else -> null
+            }
+        }
+        return definitionSource
     }
 
     fun getColumn(parameter: KSValueParameter): Column {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Config.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Config.kt
@@ -12,6 +12,7 @@ internal data class Config(
     val namingStrategy: NamingStrategy,
     val metaObject: String,
     val alwaysQuote: Boolean,
+    val enableEntityStoreContext: Boolean,
 ) {
     companion object {
         private const val PREFIX = "komapper.prefix"
@@ -20,6 +21,7 @@ internal data class Config(
         private const val NAMING_STRATEGY = "komapper.namingStrategy"
         private const val META_OBJECT = "komapper.metaObject"
         private const val ALWAYS_QUOTE = "komapper.alwaysQuote"
+        private const val ENABLE_ENTITY_STORE_CONTEXT = "komapper.enableEntityStoreContext"
 
         fun create(options: Map<String, String>): Config {
             val prefix = options.getOrDefault(PREFIX, "_")
@@ -41,7 +43,8 @@ internal data class Config(
             }
             val metaObject = options.getOrDefault(META_OBJECT, Symbols.Meta)
             val alwaysQuote = options[ALWAYS_QUOTE]?.toBooleanStrict() ?: false
-            return Config(prefix, suffix, enumStrategy, namingStrategy, metaObject, alwaysQuote)
+            val enableEntityStoreContext = options[ENABLE_ENTITY_STORE_CONTEXT]?.toBooleanStrict() ?: false
+            return Config(prefix, suffix, enumStrategy, namingStrategy, metaObject, alwaysQuote, enableEntityStoreContext)
         }
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
@@ -14,8 +14,11 @@ import com.google.devtools.ksp.symbol.Nullability
 internal data class EntityDefinitionSource(
     val defDeclaration: KSClassDeclaration,
     val entityDeclaration: KSClassDeclaration,
+    val packageName: String,
+    val metamodelSimpleName: String,
     val aliases: List<String>,
     val unitDeclaration: KSClassDeclaration?,
+    val unitTypeName: String,
     val stubAnnotation: KSAnnotation?,
 )
 
@@ -239,10 +242,18 @@ internal data class Column(
     val masking: Boolean,
 )
 
+internal data class Link(
+    val source: String,
+    val target: String,
+)
+
 internal data class Association(
-    val targetEntity: KSClassDeclaration,
+    val annotation: KSAnnotation,
+    val navigator: String,
+    val sourceEntity: EntityDefinitionSource,
+    val targetEntity: EntityDefinitionSource,
+    val link: Link,
     val kind: AssociationKind,
-    val name: String,
 )
 
 enum class AssociationKind {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
@@ -150,7 +150,7 @@ internal data class ValueClass(
 
 internal data class PlainClass(
     override val type: KSType,
-    val alternate: ValueClass?,
+    val alternateType: ValueClass?,
 ) : KotlinClass {
     val isArray: Boolean = declaration.qualifiedName?.asString() == "kotlin.Array"
 
@@ -171,7 +171,7 @@ internal data class PlainClass(
 
     override val interiorTypeName: String
         get() {
-            return alternate?.exteriorTypeName ?: exteriorTypeName
+            return alternateType?.exteriorTypeName ?: exteriorTypeName
         }
 
     override fun toString(): String = exteriorTypeName

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
@@ -22,6 +22,7 @@ internal data class EntityDefinitionSource(
 internal data class EntityDef(
     val definitionSource: EntityDefinitionSource,
     val table: Table,
+    val associations: List<Association>,
     val properties: List<PropertyDef>,
 )
 
@@ -48,6 +49,7 @@ internal data class CompositePropertyDef(
 internal data class Entity(
     val declaration: KSClassDeclaration,
     val table: Table,
+    val associations: List<Association>,
     val properties: List<Property>,
     val embeddedIdProperty: CompositeProperty?,
     val virtualEmbeddedIdProperty: CompositeProperty?,
@@ -236,3 +238,15 @@ internal data class Column(
     val alwaysQuote: Boolean,
     val masking: Boolean,
 )
+
+internal data class Association(
+    val targetEntity: KSClassDeclaration,
+    val kind: AssociationKind,
+    val name: String,
+)
+
+enum class AssociationKind {
+    ONE_TO_ONE,
+    ONE_TO_MANY,
+    MANY_TO_ONE,
+}

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
@@ -25,6 +25,7 @@ internal data class EntityDefinitionSource(
 internal data class EntityDef(
     val definitionSource: EntityDefinitionSource,
     val table: Table,
+    val aggregateRoot: AggregateRoot?,
     val associations: List<Association>,
     val properties: List<PropertyDef>,
 )
@@ -52,6 +53,7 @@ internal data class CompositePropertyDef(
 internal data class Entity(
     val declaration: KSClassDeclaration,
     val table: Table,
+    val aggregateRoot: AggregateRoot?,
     val associations: List<Association>,
     val properties: List<Property>,
     val embeddedIdProperty: CompositeProperty?,
@@ -261,3 +263,9 @@ enum class AssociationKind {
     ONE_TO_MANY,
     MANY_TO_ONE,
 }
+
+internal data class AggregateRoot(
+    val navigator: String,
+    val targetEntity: EntityDefinitionSource,
+    val target: String,
+)

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityAnalyzer.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityAnalyzer.kt
@@ -18,10 +18,10 @@ internal class EntityAnalyzer(
         return try {
             val entityDef = EntityDefFactory(logger, config, definitionSource).create()
             val entity = EntityFactory(logger, config, entityDef).create()
-            val model = EntityModel(definitionSource, config.metaObject, entity)
+            val model = EntityModel(definitionSource, entity)
             EntityAnalysisResult.Success(model)
         } catch (e: Exit) {
-            val model = EntityModel(definitionSource, config.metaObject)
+            val model = EntityModel(definitionSource)
             EntityAnalysisResult.Failure(model, e)
         }
     }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
@@ -24,6 +24,7 @@ internal class EntityDefFactory(
 
     fun create(): EntityDef {
         val table = annotationSupport.getTable(definitionSource)
+        val aggregateRoot = annotationSupport.getAggregateRoot(definitionSource)
         val associations = annotationSupport.getAssociations(definitionSource)
         validateAssociations(associations)
         val allProperties = createAllProperties()
@@ -31,7 +32,7 @@ internal class EntityDefFactory(
         val leafProperties = allProperties.filterIsInstance<LeafPropertyDef>()
         validateCompositeProperties(compositeProperties)
         validateLeafProperties(leafProperties)
-        return EntityDef(definitionSource, table, associations, allProperties)
+        return EntityDef(definitionSource, table, aggregateRoot, associations, allProperties)
     }
 
     private fun createAllProperties(): List<PropertyDef> {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
@@ -24,12 +24,14 @@ internal class EntityDefFactory(
 
     fun create(): EntityDef {
         val table = annotationSupport.getTable(definitionSource)
+        // TODO: Check for name duplication
+        val associations = annotationSupport.getAssociations(definitionSource)
         val allProperties = createAllProperties()
         val compositeProperties = allProperties.filterIsInstance<CompositePropertyDef>()
         val leafProperties = allProperties.filterIsInstance<LeafPropertyDef>()
         validateCompositeProperties(compositeProperties)
         validateLeafProperties(leafProperties)
-        return EntityDef(definitionSource, table, allProperties)
+        return EntityDef(definitionSource, table, associations, allProperties)
     }
 
     private fun createAllProperties(): List<PropertyDef> {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefinitionSourceResolver.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefinitionSourceResolver.kt
@@ -13,7 +13,7 @@ internal interface EntityDefinitionSourceResolver {
     fun resolve(symbol: KSNode): EntityDefinitionSource
 }
 
-internal class SeparateDefinitionSourceResolver : EntityDefinitionSourceResolver {
+internal class SeparateDefinitionSourceResolver(val config: Config) : EntityDefinitionSourceResolver {
     override fun resolve(symbol: KSNode): EntityDefinitionSource {
         val defDeclaration = symbol.accept(ClassDeclarationVisitor(), Unit)
             ?: report("@${KomapperEntityDef::class.simpleName} cannot be applied to this element.", symbol)
@@ -33,21 +33,26 @@ internal class SeparateDefinitionSourceResolver : EntityDefinitionSourceResolver
                 defDeclaration,
             )
         }
+        val unitTypeName = createUnitTypeName(config, unitDeclaration)
         val entityDeclaration = entity.declaration.accept(ClassDeclarationVisitor(), Unit)
             ?: report("The entity value of @${KomapperEntityDef::class.simpleName} is not found.", defDeclaration)
         validateContainerClass(entityDeclaration, defAnnotation)
         val stubAnnotation = defDeclaration.findAnnotation(KomapperStub)
+        val (packageName, simpleName) = createMetamodelClassName(config, defDeclaration)
         return EntityDefinitionSource(
             defDeclaration = defDeclaration,
             entityDeclaration = entityDeclaration,
+            packageName = packageName,
+            metamodelSimpleName = simpleName,
             aliases = aliases.map { it.toString() },
             unitDeclaration = unitDeclaration,
+            unitTypeName = unitTypeName,
             stubAnnotation = stubAnnotation,
         )
     }
 }
 
-internal class SelfDefinitionSourceResolver : EntityDefinitionSourceResolver {
+internal class SelfDefinitionSourceResolver(val config: Config) : EntityDefinitionSourceResolver {
     override fun resolve(symbol: KSNode): EntityDefinitionSource {
         val entityDeclaration = symbol.accept(ClassDeclarationVisitor(), Unit)
             ?: report("@${KomapperEntity::class.simpleName} cannot be applied to this element.", symbol)
@@ -63,13 +68,18 @@ internal class SelfDefinitionSourceResolver : EntityDefinitionSourceResolver {
                 entityDeclaration,
             )
         }
+        val unitTypeName = createUnitTypeName(config, unitDeclaration)
         validateContainerClass(entityDeclaration, entityDeclaration)
         val stubAnnotation = entityDeclaration.findAnnotation(KomapperStub)
+        val (packageName, simpleName) = createMetamodelClassName(config, entityDeclaration)
         return EntityDefinitionSource(
             defDeclaration = entityDeclaration,
             entityDeclaration = entityDeclaration,
+            packageName = packageName,
+            metamodelSimpleName = simpleName,
             aliases = aliases.map { it.toString() },
             unitDeclaration = unitDeclaration,
+            unitTypeName = unitTypeName,
             stubAnnotation = stubAnnotation,
         )
     }
@@ -86,4 +96,16 @@ private fun toUnitDeclaration(symbol: Any?, errorHandler: () -> Nothing): KSClas
         }
         else -> null
     }
+}
+
+private fun createMetamodelClassName(config: Config, defDeclaration: KSClassDeclaration): Pair<String, String> {
+    val packageName = defDeclaration.packageName.asString()
+    val qualifiedName = defDeclaration.qualifiedName?.asString() ?: ""
+    val packageRemovedQualifiedName = qualifiedName.removePrefix("$packageName.")
+    val simpleName = config.prefix + packageRemovedQualifiedName.replace(".", "_") + config.suffix
+    return packageName to simpleName
+}
+
+private fun createUnitTypeName(config: Config, unitDeclaration: KSClassDeclaration?): String {
+    return unitDeclaration?.qualifiedName?.asString() ?: config.metaObject
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
@@ -343,10 +343,10 @@ internal class EntityFactory(
                 property.node,
             )
         }
-        if (plainClass.alternate != null) {
-            if (plainClass.declaration != plainClass.alternate.property.type.declaration) {
+        if (plainClass.alternateType != null) {
+            if (plainClass.declaration != plainClass.alternateType.property.type.declaration) {
                 report(
-                    "The property \"${property.path}\" is invalid. The property type does not match the parameter property type in \"${plainClass.alternate.type.name}\".",
+                    "The property \"${property.path}\" is invalid. The property type does not match the parameter property type in \"${plainClass.alternateType.type.name}\".",
                     property.node,
                 )
             }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
@@ -55,6 +55,7 @@ internal class EntityFactory(
         return Entity(
             entityDef.definitionSource.entityDeclaration,
             entityDef.table,
+            entityDef.associations,
             properties,
             embeddedIdProperty,
             virtualEmbeddedIdProperty,

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
@@ -32,7 +32,7 @@ internal class EntityFactory(
     private val entityDef: EntityDef,
 ) {
 
-    private val annotationSupport = AnnotationSupport(config)
+    private val annotationSupport = AnnotationSupport(logger, config)
 
     fun create(): Entity {
         val allProperties = createAllProperties()

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
@@ -55,6 +55,7 @@ internal class EntityFactory(
         return Entity(
             entityDef.definitionSource.entityDeclaration,
             entityDef.table,
+            entityDef.aggregateRoot,
             entityDef.associations,
             properties,
             embeddedIdProperty,

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -20,6 +20,7 @@ import org.komapper.processor.Symbols.EnumMappingException
 import org.komapper.processor.Symbols.IdContext
 import org.komapper.processor.Symbols.IdGenerator
 import org.komapper.processor.Symbols.Instant
+import org.komapper.processor.Symbols.KomapperExperimentalAssociation
 import org.komapper.processor.Symbols.KotlinInstant
 import org.komapper.processor.Symbols.KotlinLocalDateTime
 import org.komapper.processor.Symbols.LocalDateTime
@@ -647,6 +648,7 @@ internal class EntityMetamodelGenerator(
             }
             w.println(
                 """
+                @$KomapperExperimentalAssociation
                 fun $entityTypeName.`${association.navigator}`(
                     store: $EntityStore,
                     source: ${sourceEntity.packageName}.${sourceEntity.metamodelSimpleName} = ${sourceEntity.unitTypeName}.`${association.link.source}`,
@@ -660,6 +662,7 @@ internal class EntityMetamodelGenerator(
             if (config.enableEntityStoreContext) {
                 w.println(
                     """
+                @$KomapperExperimentalAssociation
                 context($EntityStoreContext)
                 fun $entityTypeName.`${association.navigator}`(
                     source: ${sourceEntity.packageName}.${sourceEntity.metamodelSimpleName} = ${sourceEntity.unitTypeName}.`${association.link.source}`,
@@ -679,6 +682,7 @@ internal class EntityMetamodelGenerator(
         val targetEntity = aggregateRoot.targetEntity
         w.println(
             """
+                @$KomapperExperimentalAssociation
                 fun $EntityStore.`${aggregateRoot.navigator}`(
                     target: ${targetEntity.packageName}.${targetEntity.metamodelSimpleName} = ${targetEntity.unitTypeName}.`${aggregateRoot.target}`,
                     ): Set<${targetEntity.typeName}> {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -586,7 +586,7 @@ internal class EntityMetamodelGenerator(
             }
             val expression = when (association.kind) {
                 AssociationKind.ONE_TO_ONE -> "store.oneToOne(thisSide, thatSide)[this]"
-                AssociationKind.MANY_TO_ONE -> "store.oneToMany(thatSide, thisSide).asSequence().firstOrNull { it.value.contains(this) }?.key"
+                AssociationKind.MANY_TO_ONE -> "store.manyToOne(thisSide, thatSide)[this]"
                 AssociationKind.ONE_TO_MANY -> "store.oneToMany(thisSide, thatSide)[this] ?: emptySet()"
             }
             w.println(

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -13,6 +13,7 @@ import org.komapper.processor.Symbols.EntityMetamodel
 import org.komapper.processor.Symbols.EntityMetamodelDeclaration
 import org.komapper.processor.Symbols.EntityMetamodelImplementor
 import org.komapper.processor.Symbols.EntityStore
+import org.komapper.processor.Symbols.EntityStoreContext
 import org.komapper.processor.Symbols.EnumMappingException
 import org.komapper.processor.Symbols.IdContext
 import org.komapper.processor.Symbols.IdGenerator
@@ -34,6 +35,7 @@ import java.time.ZonedDateTime
 
 internal class EntityMetamodelGenerator(
     @Suppress("unused") private val logger: KSPLogger,
+    private val config: Config,
     private val entity: Entity,
     private val metaObject: String,
     private val aliases: List<String>,
@@ -603,6 +605,20 @@ internal class EntityMetamodelGenerator(
             w.println("    return $expression")
             w.println("}")
             w.println()
+            if (config.enableEntityStoreContext) {
+                w.println(
+                    """
+                context($EntityStoreContext)
+                fun $entityTypeName.`${association.navigator}`(
+                    source: ${sourceEntity.packageName}.${sourceEntity.metamodelSimpleName} = ${sourceEntity.unitTypeName}.`${association.link.source}`,
+                    target: ${targetEntity.packageName}.${targetEntity.metamodelSimpleName} = ${targetEntity.unitTypeName}.`${association.link.target}`,
+                    ): $returnType {
+                    """.trimIndent(),
+                )
+                w.println("    return $expression")
+                w.println("}")
+                w.println()
+            }
         }
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityModel.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityModel.kt
@@ -4,21 +4,13 @@ import com.google.devtools.ksp.symbol.KSFile
 
 internal class EntityModel(
     private val definitionSource: EntityDefinitionSource,
-    defaultUnitName: String,
     val entity: Entity? = null,
 ) {
     val hasStubAnnotation: Boolean = definitionSource.stubAnnotation != null
-
     val entityDeclaration = definitionSource.entityDeclaration
-
-    val aliases = definitionSource.aliases.ifEmpty {
-        val alias = toCamelCase(definitionSource.entityDeclaration.simpleName.asString())
-        listOf(alias)
-    }
-
-    val typeName = definitionSource.entityDeclaration.qualifiedName?.asString() ?: ""
-
-    val unitTypeName = definitionSource.unitDeclaration?.qualifiedName?.asString() ?: defaultUnitName
+    val aliases = definitionSource.names
+    val typeName = definitionSource.typeName
+    val unitTypeName = definitionSource.unitTypeName
 
     val containingFiles: List<KSFile>
         get() {
@@ -31,12 +23,7 @@ internal class EntityModel(
             }
         }
 
-    fun createMetamodelClassName(prefix: String, suffix: String): Pair<String, String> {
-        val defDeclaration = definitionSource.defDeclaration
-        val packageName = defDeclaration.packageName.asString()
-        val qualifiedName = defDeclaration.qualifiedName?.asString() ?: ""
-        val packageRemovedQualifiedName = qualifiedName.removePrefix("$packageName.")
-        val simpleName = prefix + packageRemovedQualifiedName.replace(".", "_") + suffix
-        return packageName to simpleName
+    fun createMetamodelClassName(): Pair<String, String> {
+        return definitionSource.packageName to definitionSource.metamodelSimpleName
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityProcessor.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityProcessor.kt
@@ -64,6 +64,7 @@ internal class EntityProcessor(private val environment: SymbolProcessorEnvironme
                 } else {
                     EntityMetamodelGenerator(
                         logger,
+                        config,
                         model.entity,
                         model.unitTypeName,
                         model.aliases,

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityProcessor.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityProcessor.kt
@@ -17,8 +17,8 @@ internal class EntityProcessor(private val environment: SymbolProcessorEnvironme
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val pairs = listOf(
-            KomapperEntityDef::class.qualifiedName!! to SeparateDefinitionSourceResolver(),
-            KomapperEntity::class.qualifiedName!! to SelfDefinitionSourceResolver(),
+            KomapperEntityDef::class.qualifiedName!! to SeparateDefinitionSourceResolver(config),
+            KomapperEntity::class.qualifiedName!! to SelfDefinitionSourceResolver(config),
         )
         for ((annotation, definitionSourceResolver) in pairs) {
             val symbols = resolver.getSymbolsWithAnnotation(annotation)
@@ -47,7 +47,7 @@ internal class EntityProcessor(private val environment: SymbolProcessorEnvironme
 
     private fun generateMetamodel(model: EntityModel) {
         val dependencies = Dependencies(false, *model.containingFiles.toTypedArray())
-        val (packageName, simpleName) = model.createMetamodelClassName(config.prefix, config.suffix)
+        val (packageName, simpleName) = model.createMetamodelClassName()
         environment.codeGenerator.createNewFile(dependencies, packageName, simpleName).use { out ->
             PrintWriter(out).use { writer ->
                 val runnable = if (model.hasStubAnnotation || model.entity == null) {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/ProcessorUtility.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/ProcessorUtility.kt
@@ -30,6 +30,10 @@ internal fun KSAnnotation.findValue(name: String): Any? {
         .firstOrNull()
 }
 
+internal fun KSAnnotated.findAnnotations(klass: KClass<*>): List<KSAnnotation> {
+    return this.annotations.filter { it.shortName.asString() == klass.simpleName }.toList()
+}
+
 internal fun KSAnnotated.findAnnotation(klass: KClass<*>): KSAnnotation? {
     return this.annotations.firstOrNull { it.shortName.asString() == klass.simpleName }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/ProcessorUtility.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/ProcessorUtility.kt
@@ -122,6 +122,17 @@ internal val KSType.name: String
         return buf.toString()
     }
 
+internal val EntityDefinitionSource.names: List<String>
+    get() = this.aliases.ifEmpty {
+        val alias = toCamelCase(this.entityDeclaration.simpleName.asString())
+        listOf(alias)
+    }
+
+internal val EntityDefinitionSource.typeName get() = this.entityDeclaration.qualifiedName?.asString() ?: ""
+
+internal fun EntityDefinitionSource.createUnitTypeName(config: Config) =
+    this.unitDeclaration?.qualifiedName?.asString() ?: config.metaObject
+
 internal fun toCamelCase(text: String): String {
     val builder = StringBuilder()
     val buf = CharBuffer.wrap(text)

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -36,7 +36,5 @@ internal object Symbols {
     const val EnumType_PROPERTY = "org.komapper.annotation.EnumType.PROPERTY"
     const val DefaultUnit = "org.komapper.annotation.DefaultUnit"
     const val EnumMappingException = "org.komapper.core.dsl.runner.EnumMappingException"
-    const val AssociationType_ONE_TO_ONE = "org.komapper.annotation.AssociationType.ONE_TO_ONE"
-    const val AssociationType_ONE_TO_MANY = "org.komapper.annotation.AssociationType.ONE_TO_MANY"
-    const val AssociationType_MANY_TO_ONE = "org.komapper.annotation.AssociationType.MANY_TO_ONE"
+    const val EntityStore = "org.komapper.core.dsl.query.EntityStore"
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -37,4 +37,5 @@ internal object Symbols {
     const val DefaultUnit = "org.komapper.annotation.DefaultUnit"
     const val EnumMappingException = "org.komapper.core.dsl.runner.EnumMappingException"
     const val EntityStore = "org.komapper.core.dsl.query.EntityStore"
+    const val EntityStoreContext = "org.komapper.core.dsl.query.EntityStoreContext"
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -36,4 +36,7 @@ internal object Symbols {
     const val EnumType_PROPERTY = "org.komapper.annotation.EnumType.PROPERTY"
     const val DefaultUnit = "org.komapper.annotation.DefaultUnit"
     const val EnumMappingException = "org.komapper.core.dsl.runner.EnumMappingException"
+    const val AssociationType_ONE_TO_ONE = "org.komapper.annotation.AssociationType.ONE_TO_ONE"
+    const val AssociationType_ONE_TO_MANY = "org.komapper.annotation.AssociationType.ONE_TO_MANY"
+    const val AssociationType_MANY_TO_ONE = "org.komapper.annotation.AssociationType.MANY_TO_ONE"
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -41,4 +41,5 @@ internal object Symbols {
     const val Void = "java.lang.Void"
     const val EntityStore = "org.komapper.core.dsl.query.EntityStore"
     const val EntityStoreContext = "org.komapper.core.dsl.query.EntityStoreContext"
+    const val KomapperExperimentalAssociation = "org.komapper.annotation.KomapperExperimentalAssociation"
 }

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorErrorTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorErrorTest.kt
@@ -1046,4 +1046,110 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
         assertTrue(result.messages.contains("The property \"unknown\" is not found in the test.Color. KomapperEnum's hint property is incorrect."))
     }
+
+    @Test
+    fun `The targetEntity must be annotated with either @KomapperEntity or @KomapperEntityDef`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            data class Dept(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            @KomapperEntity
+            @KomapperManyToOne(Dept::class)
+            data class Emp(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The targetEntity must be annotated with either @KomapperEntity or @KomapperEntityDef."))
+    }
+
+    @Test
+    fun `@KomapperLink source is invalid`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            @KomapperEntity
+            data class Dept(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            @KomapperEntity
+            @KomapperManyToOne(Dept::class, link = KomapperLink("unknown"))
+            data class Emp(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("@KomapperLink.source \"unknown\" is invalid. It must be one of [emp]."))
+    }
+
+    @Test
+    fun `@KomapperLink target is invalid`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            @KomapperEntity
+            data class Dept(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            @KomapperEntity
+            @KomapperManyToOne(Dept::class, link = KomapperLink(target = "unknown"))
+            data class Emp(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("@KomapperLink.target \"unknown\" is invalid. It must be one of [dept]."))
+    }
+
+    @Test
+    fun `The navigator is found multiple times in the association annotations`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            @KomapperEntity
+            data class Dept(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            @KomapperEntity
+            data class Address(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            @KomapperEntity
+            @KomapperManyToOne(Dept::class, navigator="hello")
+            @KomapperOneToOne(Address::class, navigator = "hello")
+            data class Emp(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The navigator \"hello\" is found multiple times in the association annotations."))
+    }
 }

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorOkTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorOkTest.kt
@@ -162,4 +162,55 @@ class EntityProcessorOkTest : AbstractKspTest(EntityProcessorProvider()) {
         )
         assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK, result.messages)
     }
+
+    @Test
+    fun `The targetEntity is annotated with @KomapperEntity`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            @KomapperEntity
+            data class Dept(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            @KomapperEntity
+            @KomapperManyToOne(Dept::class)
+            data class Emp(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `The targetEntity is annotated with @KomapperEntityDef`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            data class Dept(
+                val id: Int,
+                val name: String,
+            )
+            @KomapperEntityDef(Dept::class)
+            data class DeptDef(
+                @KomapperId
+                val id: Nothing,
+            )
+            @KomapperEntity
+            @KomapperManyToOne(DeptDef::class)
+            data class Emp(
+                @KomapperId
+                val id: Int,
+                val name: String,
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
 }


### PR DESCRIPTION
The KomapperAssociation annotation simplifies EntityStore operations.

Entity definitions:

```kotlin
@KomapperEntity
@KomapperAssociation(AssociationType.ONE_TO_MANY, Employee::class, "employees")
data class Department(
    @KomapperId
    @KomapperColumn("department_id")
    val departmentId: Int,
    @KomapperColumn("department_name")
    val departmentName: String,
)

@KomapperEntity(["employee", "manager"])
@KomapperAssociation(AssociationType.MANY_TO_ONE, Department::class)
@KomapperAssociation(AssociationType.ONE_TO_ONE, Address::class)
data class Employee(
    @KomapperId
    @KomapperColumn("employee_id")
    val employeeId: Int,
    @KomapperColumn("employee_name")
    val employeeName: String,
    @KomapperColumn("department_id")
    val departmentId: Int,
    @KomapperColumn("address_id")
    val addressId: Int,
)

@KomapperEntity
data class Address(
    @KomapperId
    @KomapperColumn(name = "address_id")
    val addressId: Int,
    val street: String,
)
```

The Komapper KSP processor generates the following code from the above entity definitions:

```kotlin
fun integration.core.Department.`employees`(store: org.komapper.core.dsl.query.EntityStore,thisSide: _Department,thatSide: org.komapper.core.dsl.metamodel.EntityMetamodel<integration.core.Employee, *, *>,): Set<integration.core.Employee> {
    return store.oneToMany(thisSide, thatSide)[this] ?: emptySet()
}
fun integration.core.Employee.`department`(store: org.komapper.core.dsl.query.EntityStore,thisSide: _Employee,thatSide: org.komapper.core.dsl.metamodel.EntityMetamodel<integration.core.Department, *, *>,): integration.core.Department? {
    return store.oneToMany(thatSide, thisSide).asSequence().firstOrNull { it.value.contains(this) }?.key
}
fun integration.core.Employee.`address`(store: org.komapper.core.dsl.query.EntityStore,thisSide: _Employee,thatSide: org.komapper.core.dsl.metamodel.EntityMetamodel<integration.core.Address, *, *>,): integration.core.Address? {
    return store.oneToOne(thisSide, thatSide)[this]
}
```

With these generated codes you can write as followings:

```kotlin
val d = Meta.department
val e = Meta.employee
val a = Meta.address

// get an EntityStore
val store = db.runQuery {
    QueryDsl.from(d)
        .innerJoin(e) {
            d.departmentId eq e.departmentId
        }.innerJoin(a) {
            e.addressId eq a.addressId
        }.includeAll()
}

// operate the EntityStore
for (department in store[d]) {
    // use the generated extension function
    val employees = department.employees(store, d, e)
    for (employee in employees) {
        // use the generated extension function
        val address = employee.address(store, e, a)
        println("department=${department.departmentName}, employee=${employee.employeeName}, address=${address?.street}")
    }
}
```

In the future, the generated code will use the context receiver:

```kotlin
context(EntityStoreContext)
fun integration.core.Department.`employees`(thisSide: _Department,thatSide: org.komapper.core.dsl.metamodel.EntityMetamodel<integration.core.Employee, *, *>,): Set<integration.core.Employee> {
    return store.oneToMany(thisSide, thatSide)[this] ?: emptySet()
}
context(EntityStoreContext)
fun integration.core.Employee.`department`(thisSide: _Employee,thatSide: org.komapper.core.dsl.metamodel.EntityMetamodel<integration.core.Department, *, *>,): integration.core.Department? {
    return store.oneToMany(thatSide, thisSide).asSequence().firstOrNull { it.value.contains(this) }?.key
}
context(EntityStoreContext)
fun integration.core.Employee.`address`(thisSide: _Employee,thatSide: org.komapper.core.dsl.metamodel.EntityMetamodel<integration.core.Address, *, *>,): integration.core.Address? {
    return store.oneToOne(thisSide, thatSide)[this]
}
```