### PR TITLE
Support specifying serach conditions and a conflict target in upsert statements

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
@@ -52,6 +52,9 @@ interface PostgreSqlSetting<DATABASE : Database> : Setting<DATABASE> {
         create table if not exists interval_data(id integer not null primary key, value interval);
         create table if not exists json_data(id integer not null primary key, value jsonb);
 
+        create table if not exists friend(uuid1 uuid, uuid2 uuid, pending boolean, constraint pk_friend primary key(uuid1, uuid2));
+        create unique index friend_unique_idx on friend (greatest(uuid1, uuid2), least(uuid1, uuid2));
+    
         insert into department values(1,10,'ACCOUNTING','NEW YORK',1);
         insert into department values(2,20,'RESEARCH','DALLAS',1);
         insert into department values(3,30,'SALES','CHICAGO',1);

--- a/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/PostgreSqlEntities.kt
+++ b/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/PostgreSqlEntities.kt
@@ -4,9 +4,19 @@ import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperId
 import org.komapper.annotation.KomapperTable
+import java.util.UUID
 
 data class Json(val data: String)
 
 @KomapperEntity
 @KomapperTable("json_data")
 data class JsonData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Json)
+
+@KomapperEntity
+data class Friend(
+    @KomapperId
+    val uuid1: UUID,
+    @KomapperId
+    val uuid2: UUID,
+    val pending: Boolean,
+)

--- a/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/PostgreSqlInsertSingleTest.kt
+++ b/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/PostgreSqlInsertSingleTest.kt
@@ -1,0 +1,55 @@
+package integration.jdbc.postgresql
+
+import integration.jdbc.JdbcEnv
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.query.single
+import org.komapper.jdbc.JdbcDatabase
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExtendWith(JdbcEnv::class)
+class PostgreSqlInsertSingleTest(private val db: JdbcDatabase) {
+
+    @Test
+    fun dangerouslyOnDuplicateKeyUpdate() {
+        val f = Meta.friend
+        val friend = Friend(UUID.randomUUID(), UUID.randomUUID(), false)
+        db.runQuery(QueryDsl.insert(f).single(friend))
+        db.runQuery(
+            QueryDsl.insert(f)
+                .dangerouslyOnDuplicateKeyUpdate("(greatest(uuid1, uuid2), least(uuid1, uuid2))")
+                .set {
+                    f.pending eq true
+                }.where {
+                    f.pending eq false
+                }
+                .single(friend),
+        )
+        val result = db.runQuery(
+            QueryDsl.from(f).where {
+                f.uuid1 eq friend.uuid1
+                f.uuid2 eq friend.uuid2
+            }.single(),
+        )
+        assertTrue(result.pending)
+    }
+
+    @Test
+    fun dangerouslyOnDuplicateKeyIgnore() {
+        val f = Meta.friend
+        val friend = Friend(UUID.randomUUID(), UUID.randomUUID(), false)
+        db.runQuery(QueryDsl.insert(f).single(friend))
+        val friend2 = friend.copy(uuid1 = friend.uuid2, uuid2 = friend.uuid1)
+        db.runQuery(
+            QueryDsl.insert(f)
+                .dangerouslyOnDuplicateKeyIgnore("(greatest(uuid1, uuid2), least(uuid1, uuid2))")
+                .single(friend2),
+        )
+        val result = db.runQuery(QueryDsl.from(f))
+        assertEquals(1, result.size)
+    }
+}

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
@@ -447,6 +447,21 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
     }
 
     @Test
+    @Run(unless = [Dbms.POSTGRESQL])
+    fun dangerouslyOnDuplicateKeyUpdate() {
+        val d = Meta.department
+        val department = Department(5, 10, "PLANNING", "TOKYO", 10)
+        val query = QueryDsl.insert(d)
+            .dangerouslyOnDuplicateKeyUpdate("test")
+            .single(department)
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery(query)
+            Unit
+        }
+        println(ex)
+    }
+
+    @Test
     fun onDuplicateKeyIgnore_inserted() {
         val a = Meta.address
         val address = Address(16, "STREET 16", 0)

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
@@ -47,6 +47,7 @@ import java.time.ZoneId
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 
 @ExtendWith(JdbcEnv::class)
@@ -384,6 +385,65 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
         assertEquals("PLANNING2", found.departmentName)
         assertEquals("NEW YORK_TOKYO", found.location)
         assertEquals(1, found.version)
+    }
+
+    @Test
+    @Run(onlyIf = [Dbms.H2, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    fun onDuplicateKeyUpdateWithKey_update_set_where_success() {
+        val d = Meta.department
+        val department = Department(5, 10, "PLANNING", "TOKYO", 10)
+        val query = QueryDsl.insert(d)
+            .onDuplicateKeyUpdate(d.departmentNo)
+            .set { excluded ->
+                d.departmentName eq "PLANNING2"
+                d.location eq concat(d.location, concat("_", excluded.location))
+            }.where {
+                d.location eq "NEW YORK"
+            }.single(department)
+        db.runQuery { query }
+        val found = db.runQuery { QueryDsl.from(d).where { d.departmentNo eq 10 }.first() }
+        assertEquals(1, found.departmentId)
+        assertEquals("PLANNING2", found.departmentName)
+        assertEquals("NEW YORK_TOKYO", found.location)
+        assertEquals(1, found.version)
+    }
+
+    @Test
+    @Run(onlyIf = [Dbms.H2, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    fun onDuplicateKeyUpdateWithKey_update_set_where_fail() {
+        val d = Meta.department
+        val department = Department(5, 10, "PLANNING", "TOKYO", 10)
+        val query = QueryDsl.insert(d)
+            .onDuplicateKeyUpdate(d.departmentNo)
+            .set { excluded ->
+                d.departmentName eq "PLANNING2"
+                d.location eq concat(d.location, concat("_", excluded.location))
+            }.where {
+                d.location eq "KYOTO"
+            }.single(department)
+        db.runQuery { query }
+        val found = db.runQuery { QueryDsl.from(d).where { d.departmentNo eq 10 }.first() }
+        assertEquals(1, found.departmentId)
+        assertNotEquals("PLANNING2", found.departmentName)
+        assertNotEquals("NEW YORK_TOKYO", found.location)
+        assertEquals(1, found.version)
+    }
+
+    @Test
+    @Run(onlyIf = [Dbms.MARIADB, Dbms.MYSQL])
+    fun onDuplicateKeyUpdateWithKey_update_set_where_unsupported() {
+        val d = Meta.department
+        val department = Department(5, 10, "PLANNING", "TOKYO", 10)
+        val query = QueryDsl.insert(d)
+            .onDuplicateKeyUpdate(d.departmentNo)
+            .where {
+                d.location eq "NEW YORK"
+            }.single(department)
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery(query)
+            Unit
+        }
+        println(ex)
     }
 
     @Test

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -204,6 +204,11 @@ interface Dialect {
     fun supportsAsKeywordForTableAlias(): Boolean = true
 
     /**
+     * Returns whether the conflict_target is supported in the UPSERT statement.
+     */
+    fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
+    /**
      * Returns whether the "CREATE TABLE/SEQUENCE IF NOT EXISTS" syntax is supported.
      */
     fun supportsCreateIfNotExists(): Boolean = true

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -284,6 +284,11 @@ interface Dialect {
     fun supportsOptimisticLockOfBatchExecution(): Boolean = true
 
     /**
+     * Returns whether the search condition is supported in the UPSERT statement.
+     */
+    fun supportsSearchConditionInUpsertStatement(): Boolean = false
+
+    /**
      * Returns whether the table hint is supported.
      */
     fun supportsTableHint(): Boolean = false

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderUtility.kt
@@ -16,7 +16,7 @@ import org.komapper.core.dsl.scope.HavingScope
 import org.komapper.core.dsl.scope.OnScope
 import org.komapper.core.dsl.scope.WhereScope
 
-internal fun WhereProvider.getWhereCriteria(): List<Criterion> {
+fun WhereProvider.getWhereCriteria(): List<Criterion> {
     val where = getCompositeWhere()
     val support = FilterScopeSupport()
     WhereScope(support).apply(where)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
@@ -30,6 +30,18 @@ data class EntityInsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
         )
     }
 
+    fun asEntityUpsertContext(
+        conflictTarget: String,
+        duplicateKeyType: DuplicateKeyType,
+    ): EntityUpsertContext<ENTITY, ID, META> {
+        return EntityUpsertContext(
+            insertContext = this,
+            target = target,
+            conflictTarget = conflictTarget,
+            duplicateKeyType = duplicateKeyType,
+        )
+    }
+
     fun asRelationInsertValuesContext(declaration: AssignmentDeclaration<ENTITY, META>): RelationInsertValuesContext<ENTITY, ID, META> {
         return RelationInsertValuesContext(
             target = target,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
@@ -21,6 +21,7 @@ data class EntityUpsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
         declaration = {},
     ),
     val keys: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
+    val conflictTarget: String? = null,
     val duplicateKeyType: DuplicateKeyType,
     val set: AssignmentDeclaration<ENTITY, META> = {},
     val where: WhereDeclaration = {},

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
@@ -3,8 +3,10 @@ package org.komapper.core.dsl.context
 import org.komapper.core.ThreadSafe
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.TableExpression
+import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
+import org.komapper.core.dsl.options.WhereOptions
 
 @ThreadSafe
 data class EntityUpsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
@@ -21,10 +23,18 @@ data class EntityUpsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     val keys: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
     val duplicateKeyType: DuplicateKeyType,
     val set: AssignmentDeclaration<ENTITY, META> = {},
-) : TablesProvider {
+    val where: WhereDeclaration = {},
+) : WhereProvider, TablesProvider {
+
+    override val options: WhereOptions
+        get() = insertContext.options
 
     override fun getTables(): Set<TableExpression<*>> {
         return setOf(target)
+    }
+
+    override fun getCompositeWhere(): WhereDeclaration {
+        return where
     }
 }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/InsertOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/InsertOptions.kt
@@ -9,7 +9,9 @@ data class InsertOptions(
     val returnGeneratedKeys: Boolean,
     override val queryTimeoutSeconds: Int?,
     override val suppressLogging: Boolean,
-) : BatchOptions, QueryOptions {
+    override val allowMissingWhereClause: Boolean,
+    override val escapeSequence: String?,
+) : WhereOptions, BatchOptions, QueryOptions {
 
     companion object {
         val DEFAULT = InsertOptions(
@@ -18,6 +20,8 @@ data class InsertOptions(
             returnGeneratedKeys = true,
             queryTimeoutSeconds = null,
             suppressLogging = false,
+            allowMissingWhereClause = true,
+            escapeSequence = null,
         )
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyUpdateQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyUpdateQueryBuilder.kt
@@ -5,6 +5,7 @@ import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.operator.plus
 import org.komapper.core.dsl.scope.AssignmentScope
@@ -25,6 +26,14 @@ interface InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY : Any, ID : Any, META : 
      * @return the builder
      */
     fun set(declaration: AssignmentScope<ENTITY>.(META) -> Unit): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META>
+
+    /**
+     * Sets search conditions.
+     *
+     * @param declaration the where declaration
+     * @return the builder
+     * */
+    fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META>
 
     /**
      * Builds a query to insert or update a single entity.
@@ -83,6 +92,11 @@ internal data class InsertOnDuplicateKeyUpdateQueryBuilderImpl<ENTITY : Any, ID 
 
     override fun set(declaration: AssignmentDeclaration<ENTITY, META>): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META> {
         val newContext = context.copy(set = context.set + declaration)
+        return copy(context = newContext)
+    }
+
+    override fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META> {
+        val newContext = context.copy(where = context.where + declaration)
         return copy(context = newContext)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertQueryBuilder.kt
@@ -26,12 +26,30 @@ interface InsertQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
     fun onDuplicateKeyUpdate(vararg keys: PropertyMetamodel<ENTITY, *, *> = emptyArray()): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META>
 
     /**
+     * Creates a builder of the query that inserts or updates entities.
+     * Do not pass a SQL injection potential string in the [conflictTarget] parameter.
+     *
+     * @param conflictTarget the hint to perform unique index inference
+     * @return the query
+     */
+    fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META>
+
+    /**
      * Creates a builder of the query that inserts entities and ignores duplicate keys.
      *
      * @param keys the keys used for duplicate checking
      * @return the query
      */
     fun onDuplicateKeyIgnore(vararg keys: PropertyMetamodel<ENTITY, *, *> = emptyArray()): InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META>
+
+    /**
+     * Creates a builder of the query that inserts entities and ignores duplicate keys.
+     * Do not pass a SQL injection potential string in the [conflictTarget] parameter.
+     *
+     * @param conflictTarget the hint to perform unique index inference
+     * @return the query
+     */
+    fun dangerouslyOnDuplicateKeyIgnore(conflictTarget: String): InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META>
 
     /**
      * Builds a query to insert a single entity.
@@ -108,8 +126,18 @@ internal data class InsertQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
         return InsertOnDuplicateKeyUpdateQueryBuilderImpl(newContext)
     }
 
+    override fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META> {
+        val newContext = context.asEntityUpsertContext(conflictTarget, DuplicateKeyType.UPDATE)
+        return InsertOnDuplicateKeyUpdateQueryBuilderImpl(newContext)
+    }
+
     override fun onDuplicateKeyIgnore(vararg keys: PropertyMetamodel<ENTITY, *, *>): InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META> {
         val newContext = context.asEntityUpsertContext(keys.toList(), DuplicateKeyType.IGNORE)
+        return InsertOnDuplicateKeyIgnoreQueryBuilderImpl(newContext)
+    }
+
+    override fun dangerouslyOnDuplicateKeyIgnore(conflictTarget: String): InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META> {
+        val newContext = context.asEntityUpsertContext(conflictTarget, DuplicateKeyType.IGNORE)
         return InsertOnDuplicateKeyIgnoreQueryBuilderImpl(newContext)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertBatchRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertBatchRunner.kt
@@ -17,6 +17,7 @@ class EntityUpsertBatchRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENT
     override fun check(config: DatabaseConfig) {
         checkBatchExecutionOfParameterizedStatement(config)
         checkSearchConditionInUpsertStatement(config, context)
+        checkConflictTargetInUpsertStatement(config, context.conflictTarget)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertBatchRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertBatchRunner.kt
@@ -7,7 +7,7 @@ import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 class EntityUpsertBatchRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    context: EntityUpsertContext<ENTITY, ID, META>,
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
     private val entities: List<ENTITY>,
 ) : Runner {
 
@@ -16,6 +16,7 @@ class EntityUpsertBatchRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENT
 
     override fun check(config: DatabaseConfig) {
         checkBatchExecutionOfParameterizedStatement(config)
+        checkSearchConditionInUpsertStatement(config, context)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertMultipleRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertMultipleRunner.kt
@@ -16,6 +16,7 @@ class EntityUpsertMultipleRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<
 
     override fun check(config: DatabaseConfig) {
         checkSearchConditionInUpsertStatement(config, context)
+        checkConflictTargetInUpsertStatement(config, context.conflictTarget)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertMultipleRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertMultipleRunner.kt
@@ -14,7 +14,9 @@ class EntityUpsertMultipleRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<
     private val support: EntityUpsertRunnerSupport<ENTITY, ID, META> =
         EntityUpsertRunnerSupport(context)
 
-    override fun check(config: DatabaseConfig) = Unit
+    override fun check(config: DatabaseConfig) {
+        checkSearchConditionInUpsertStatement(config, context)
+    }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {
         if (entities.isEmpty()) return DryRunStatement.EMPTY

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertSingleRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertSingleRunner.kt
@@ -7,14 +7,16 @@ import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 class EntityUpsertSingleRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    context: EntityUpsertContext<ENTITY, ID, META>,
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
     private val entity: ENTITY,
 ) : Runner {
 
     private val support: EntityUpsertRunnerSupport<ENTITY, ID, META> =
         EntityUpsertRunnerSupport(context)
 
-    override fun check(config: DatabaseConfig) = Unit
+    override fun check(config: DatabaseConfig) {
+        checkSearchConditionInUpsertStatement(config, context)
+    }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {
         val statement = buildStatement(config, entity)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertSingleRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertSingleRunner.kt
@@ -16,6 +16,7 @@ class EntityUpsertSingleRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
 
     override fun check(config: DatabaseConfig) {
         checkSearchConditionInUpsertStatement(config, context)
+        checkConflictTargetInUpsertStatement(config, context.conflictTarget)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
@@ -89,3 +89,15 @@ internal fun checkOptimisticLockOfBatchExecution(config: DatabaseConfig, options
         )
     }
 }
+
+internal fun checkSearchConditionInUpsertStatement(config: DatabaseConfig, whereProvider: WhereProvider) {
+    val dialect = config.dialect
+    if (!config.dialect.supportsSearchConditionInUpsertStatement()) {
+        val criteria = whereProvider.getWhereCriteria()
+        if (criteria.isNotEmpty()) {
+            throw UnsupportedOperationException(
+                "The dialect(driver=${dialect.driver}) does not support specifying search conditions in upsert statements.",
+            )
+        }
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
@@ -44,6 +44,15 @@ internal fun checkAutoIncrementWhenInsertingMultipleRows(config: DatabaseConfig,
     }
 }
 
+internal fun checkConflictTargetInUpsertStatement(config: DatabaseConfig, conflictTarget: String?) {
+    val dialect = config.dialect
+    if (!config.dialect.supportsConflictTargetInUpsertStatement() && conflictTarget != null) {
+        throw UnsupportedOperationException(
+            "The dialect(driver=${dialect.driver}) does not support specifying a conflict target in upsert statements.",
+        )
+    }
+}
+
 internal fun checkBatchExecutionOfParameterizedStatement(config: DatabaseConfig) {
     val dialect = config.dialect
     if (!config.dialect.supportsBatchExecutionOfParameterizedStatement()) {

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
@@ -35,5 +35,7 @@ interface H2Dialect : Dialect {
         return H2EntityUpsertStatementBuilder(dialect, context, entities)
     }
 
+    override fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
     override fun supportsSearchConditionInUpsertStatement(): Boolean = true
 }

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
@@ -34,4 +34,6 @@ interface H2Dialect : Dialect {
     ): EntityUpsertStatementBuilder<ENTITY> {
         return H2EntityUpsertStatementBuilder(dialect, context, entities)
     }
+
+    override fun supportsSearchConditionInUpsertStatement(): Boolean = true
 }

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityUpsertStatementBuilder.kt
@@ -7,9 +7,11 @@ import org.komapper.core.dsl.builder.AliasManager
 import org.komapper.core.dsl.builder.BuilderSupport
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.TableNameType
+import org.komapper.core.dsl.builder.getWhereCriteria
 import org.komapper.core.dsl.context.DuplicateKeyType
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -26,7 +28,7 @@ internal class H2EntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Ent
     private val excluded = context.excluded
     private val aliasManager = UpsertAliasManager(target, excluded)
     private val buf = StatementBuffer()
-    private val support = BuilderSupport(dialect, aliasManager, buf)
+    private val support = BuilderSupport(dialect, aliasManager, buf, context.insertContext.options.escapeSequence)
     private val sourceStatementBuilder = SourceStatementBuilder(dialect, context, entities)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
@@ -59,7 +61,15 @@ internal class H2EntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Ent
         buf.cutBack(2)
         buf.append(")")
         if (context.duplicateKeyType == DuplicateKeyType.UPDATE) {
-            buf.append(" when matched then update set ")
+            buf.append(" when matched")
+            val criteria = context.getWhereCriteria()
+            if (criteria.isNotEmpty()) {
+                buf.append(" and ")
+                for ((index, criterion) in criteria.withIndex()) {
+                    criterion(index, criterion)
+                }
+            }
+            buf.append(" then update set ")
             for ((left, right) in assignments) {
                 column(left)
                 buf.append(" = ")
@@ -86,6 +96,10 @@ internal class H2EntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Ent
 
     private fun operand(operand: Operand) {
         support.visitOperand(operand)
+    }
+
+    private fun criterion(index: Int, c: Criterion) {
+        support.visitCriterion(index, c)
     }
 
     private class UpsertAliasManager(

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
@@ -55,4 +55,6 @@ interface MariaDbDialect : Dialect {
     override fun supportsNullOrdering(): Boolean = false
 
     override fun supportsOptimisticLockOfBatchExecution(): Boolean = false
+
+    override fun supportsSearchConditionInUpsertStatement(): Boolean = false
 }

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
@@ -44,6 +44,8 @@ interface MariaDbDialect : Dialect {
 
     override fun supportsAliasForDeleteStatement() = false
 
+    override fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
     override fun supportsGeneratedKeysReturningWhenInsertingMultipleRows(): Boolean = false
 
     override fun supportsLockOptionNowait(): Boolean = true

--- a/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
+++ b/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
@@ -50,6 +50,8 @@ interface MySqlDialect : Dialect {
 
     override fun supportsNullOrdering(): Boolean = false
 
+    override fun supportsSearchConditionInUpsertStatement(): Boolean = false
+
     override fun supportsSetOperationIntersect(): Boolean = false
 
     override fun supportsSetOperationExcept(): Boolean = false

--- a/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
+++ b/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
@@ -42,6 +42,8 @@ interface MySqlDialect : Dialect {
         return MySqlEntityUpsertStatementBuilder(dialect, context, entities)
     }
 
+    override fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
     override fun supportsLockOfTables(): Boolean = true
 
     override fun supportsLockOptionNowait(): Boolean = true

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
@@ -59,6 +59,8 @@ interface OracleDialect : Dialect {
 
     override fun supportsAutoIncrementWhenInsertingMultipleRows(): Boolean = false
 
+    override fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
     override fun supportsCreateIfNotExists(): Boolean = false
 
     override fun supportsDropIfExists(): Boolean = false

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
@@ -78,4 +78,6 @@ interface OracleDialect : Dialect {
     override fun supportsSetOperationExcept(): Boolean = false
 
     override fun supportsSetOperationMinus(): Boolean = true
+
+    override fun supportsSearchConditionInUpsertStatement(): Boolean = true
 }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityUpsertStatementBuilder.kt
@@ -7,9 +7,11 @@ import org.komapper.core.dsl.builder.AliasManager
 import org.komapper.core.dsl.builder.BuilderSupport
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.TableNameType
+import org.komapper.core.dsl.builder.getWhereCriteria
 import org.komapper.core.dsl.context.DuplicateKeyType
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -26,7 +28,7 @@ internal class OracleEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META :
     private val excluded = context.excluded
     private val aliasManager = UpsertAliasManager(target, excluded)
     private val buf = StatementBuffer()
-    private val support = BuilderSupport(dialect, aliasManager, buf)
+    private val support = BuilderSupport(dialect, aliasManager, buf, context.insertContext.options.escapeSequence)
     private val sourceStatementBuilder = SourceStatementBuilder(dialect, context, entities)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
@@ -57,6 +59,15 @@ internal class OracleEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META :
                 buf.append(", ")
             }
             buf.cutBack(2)
+            val criteria = context.getWhereCriteria()
+            if (criteria.isNotEmpty()) {
+                buf.append(" where ")
+                for ((index, criterion) in criteria.withIndex()) {
+                    criterion(index, criterion)
+                    buf.append(" and ")
+                }
+                buf.cutBack(5)
+            }
         }
         buf.append(" when not matched then insert (")
         for (p in target.getNonAutoIncrementProperties()) {
@@ -89,6 +100,10 @@ internal class OracleEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META :
 
     private fun operand(operand: Operand) {
         support.visitOperand(operand)
+    }
+
+    private fun criterion(index: Int, c: Criterion) {
+        support.visitCriterion(index, c)
     }
 
     private class UpsertAliasManager(

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
@@ -40,4 +40,6 @@ interface PostgreSqlDialect : Dialect {
     override fun supportsLockOptionNowait(): Boolean = true
 
     override fun supportsLockOptionSkipLocked(): Boolean = true
+
+    override fun supportsSearchConditionInUpsertStatement(): Boolean = true
 }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
@@ -35,6 +35,8 @@ interface PostgreSqlDialect : Dialect {
         return PostgreSqlEntityUpsertStatementBuilder(dialect, context, entities)
     }
 
+    override fun supportsConflictTargetInUpsertStatement(): Boolean = true
+
     override fun supportsLockOfTables(): Boolean = true
 
     override fun supportsLockOptionNowait(): Boolean = true

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
@@ -7,9 +7,11 @@ import org.komapper.core.dsl.builder.AliasManager
 import org.komapper.core.dsl.builder.BuilderSupport
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.TableNameType
+import org.komapper.core.dsl.builder.getWhereCriteria
 import org.komapper.core.dsl.context.DuplicateKeyType
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -26,7 +28,7 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
     private val excluded = context.excluded
     private val aliasManager = UpsertAliasManager(target, excluded)
     private val buf = StatementBuffer()
-    private val support = BuilderSupport(dialect, aliasManager, buf)
+    private val support = BuilderSupport(dialect, aliasManager, buf, context.insertContext.options.escapeSequence)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         val properties = target.getNonAutoIncrementProperties()
@@ -69,6 +71,15 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
                     buf.append(", ")
                 }
                 buf.cutBack(2)
+                val criteria = context.getWhereCriteria()
+                if (criteria.isNotEmpty()) {
+                    buf.append(" where ")
+                    for ((index, criterion) in criteria.withIndex()) {
+                        criterion(index, criterion)
+                        buf.append(" and ")
+                    }
+                    buf.cutBack(5)
+                }
             }
         }
         return buf.toStatement()
@@ -85,6 +96,10 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
 
     private fun operand(operand: Operand) {
         support.visitOperand(operand)
+    }
+
+    private fun criterion(index: Int, c: Criterion) {
+        support.visitCriterion(index, c)
     }
 
     private class UpsertAliasManager(

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
@@ -51,13 +51,19 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
             buf.append("), ")
         }
         buf.cutBack(2)
-        buf.append(" on conflict (")
-        for (p in context.keys) {
-            column(p)
-            buf.append(", ")
+        buf.append(" on conflict ")
+        val conflictTarget = context.conflictTarget
+        if (conflictTarget != null) {
+            buf.append(conflictTarget)
+        } else if (context.keys.isNotEmpty()) {
+            buf.append("(")
+            for (p in context.keys) {
+                column(p)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+            buf.append(")")
         }
-        buf.cutBack(2)
-        buf.append(")")
         when (context.duplicateKeyType) {
             DuplicateKeyType.IGNORE -> {
                 buf.append(" do nothing")

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
@@ -70,4 +70,6 @@ interface SqlServerDialect : Dialect {
     override fun supportsTableHint(): Boolean = true
 
     override fun supportsLockOptionNowait(): Boolean = true
+
+    override fun supportsSearchConditionInUpsertStatement(): Boolean = true
 }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
@@ -51,6 +51,8 @@ interface SqlServerDialect : Dialect {
 
     override fun getDefaultLengthForSubstringFunction(): Int? = Int.MAX_VALUE
 
+    override fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
     override fun supportsLimitOffsetWithoutOrderByClause(): Boolean = false
 
     override fun supportsAliasForDeleteStatement(): Boolean = false


### PR DESCRIPTION
This pull request will enhance the functionality of `onDuplicateKeyUpdate` and `onDuplicateKeyIgnore`.

For example, the following code works for PostgreSQL:
```sql
create table if not exists friend(uuid1 uuid, uuid2 uuid, pending boolean, constraint pk_friend primary key(uuid1, uuid2));
create unique index friend_unique_idx on friend (greatest(uuid1, uuid2), least(uuid1, uuid2));
```
```kotlin
@KomapperEntity
data class Friend(
    @KomapperId
    val uuid1: UUID,
    @KomapperId
    val uuid2: UUID,
    val pending: Boolean,
)
```
```kotlin
@Test
fun dangerouslyOnDuplicateKeyUpdate() {
    val f = Meta.friend
    val friend = Friend(UUID.randomUUID(), UUID.randomUUID(), false)
    db.runQuery(QueryDsl.insert(f).single(friend))
    db.runQuery(
        QueryDsl.insert(f)
            .dangerouslyOnDuplicateKeyUpdate("(greatest(uuid1, uuid2), least(uuid1, uuid2))")
            .set {
                f.pending eq true
            }.where {
                f.pending eq false
            }
            .single(friend),
    )
    val result = db.runQuery(
        QueryDsl.from(f).where {
            f.uuid1 eq friend.uuid1
            f.uuid2 eq friend.uuid2
        }.single(),
    )
    assertTrue(result.pending)
}
```

The following is the log output when the above code is executed:
```
10:24:51.681 [Test worker] TRACE org.komapper.SqlWithArgs - insert into friend (uuid1, uuid2, pending) values (7be3c733-c1bb-44e5-93ad-a09774dc3d0e, ef3dc464-f3eb-435b-998d-6dc3238fd34e, FALSE)
10:24:51.705 [Test worker] TRACE org.komapper.SqlWithArgs - insert into friend as t0_ (uuid1, uuid2, pending) values (7be3c733-c1bb-44e5-93ad-a09774dc3d0e, ef3dc464-f3eb-435b-998d-6dc3238fd34e, FALSE) on conflict (greatest(uuid1, uuid2), least(uuid1, uuid2)) do update set pending = TRUE where t0_.pending = FALSE
10:24:51.720 [Test worker] TRACE org.komapper.SqlWithArgs - select t0_.uuid1, t0_.uuid2, t0_.pending from friend as t0_ where t0_.uuid1 = 7be3c733-c1bb-44e5-93ad-a09774dc3d0e and t0_.uuid2 = ef3dc464-f3eb-435b-998d-6dc3238fd34e
```