### PR TITLE
Apply line break when writing ")" in properties and newEntity method

### DIFF
--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -412,7 +412,7 @@ internal class EntityMetamodelGenerator(
             }
         }
         val nameList = properties.joinToString(",\n        ", prefix = "\n        ")
-        w.println("    override fun properties(): List<$PropertyMetamodel<$entityTypeName, *, *>> = listOf($nameList)")
+        w.println("    override fun properties(): List<$PropertyMetamodel<$entityTypeName, *, *>> = listOf($nameList\n    )")
     }
 
     private fun extractId() {
@@ -600,7 +600,7 @@ internal class EntityMetamodelGenerator(
                 }
             }
         }
-        w.println("    override fun newEntity(m: Map<$PropertyMetamodel<*, *, *>, Any?>) = $entityTypeName($argList)")
+        w.println("    override fun newEntity(m: Map<$PropertyMetamodel<*, *, *>, Any?>) = $entityTypeName($argList\n    )")
     }
 
     private fun newMetamodel() {


### PR DESCRIPTION
## Describing changes

I just applied line break when writing `)` in properties and newEntity method in `EntityMetamodelGenerator`.

I know this change is not important, but I thought the generated file would be okay if it fits the lint as much as possible.

If this change is not necessary, please process it boldly closed. thank you

The example below is the result of executing the following command(`gradle :example-spring-boot-jdbc:clean :example-spring-boot-jdbc:build`) on the `example-spring-boot-jdbc` folder.

### AS-IS

```kotlin
// ...
    override fun properties(): List<org.komapper.core.dsl.metamodel.PropertyMetamodel<example.spring.boot.jdbc.Message, *, *>> = listOf(
        `id`,
        `text`)
// ...
    override fun newEntity(m: Map<org.komapper.core.dsl.metamodel.PropertyMetamodel<*, *, *>, Any?>) = example.spring.boot.jdbc.Message(
        `id` = m[this.`id`] as kotlin.Int?,
        `text` = m[this.`text`] as kotlin.String)
// ...
```

### TO-BE

```kotlin
// ...
    override fun properties(): List<org.komapper.core.dsl.metamodel.PropertyMetamodel<example.spring.boot.jdbc.Message, *, *>> = listOf(
        `id`,
        `text`
    )
// ...
    override fun newEntity(m: Map<org.komapper.core.dsl.metamodel.PropertyMetamodel<*, *, *>, Any?>) = example.spring.boot.jdbc.Message(
        `id` = m[this.`id`] as kotlin.Int?,
        `text` = m[this.`text`] as kotlin.String
    )
// ...
```


### Commits

lint: Apply line break when writing ")"
- Edit EntityMetamodelGenerator
  - Apply line break when writing closed parentheses in properties and newEntity method