### PR TITLE
Expose DataSource and ConnectionFactory

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSessionTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSessionTest.kt
@@ -1,0 +1,15 @@
+package integration.jdbc
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.jdbc.JdbcDatabase
+import kotlin.test.assertNotNull
+
+@ExtendWith(JdbcEnv::class)
+class JdbcSessionTest(private val db: JdbcDatabase) {
+
+    @Test
+    fun dataSource() {
+        assertNotNull(db.config.session.dataSource)
+    }
+}

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcSessionTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcSessionTest.kt
@@ -1,0 +1,15 @@
+package integration.r2dbc
+
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.r2dbc.R2dbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+@ExtendWith(R2dbcEnv::class)
+class R2dbcSessionTest(private val db: R2dbcDatabase) {
+
+    @Test
+    fun connectionFactory() {
+        assertNotNull(db.config.session.connectionFactory)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcSession.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcSession.kt
@@ -11,6 +11,8 @@ import javax.sql.DataSource
 @ThreadSafe
 interface JdbcSession {
 
+    val dataSource: DataSource
+
     val transactionOperator: TransactionOperator
 
     /**
@@ -42,7 +44,7 @@ interface JdbcSession {
     }
 }
 
-class DefaultJdbcSession(private val dataSource: DataSource) : JdbcSession {
+class DefaultJdbcSession(override val dataSource: DataSource) : JdbcSession {
     override val transactionOperator: TransactionOperator
         get() = throw UnsupportedOperationException("Use a module that provides transaction management.")
 

--- a/komapper-quarkus-jdbc/src/main/kotlin/org/komapper/quarkus/jdbc/QuarkusJdbcTransactionSession.kt
+++ b/komapper-quarkus-jdbc/src/main/kotlin/org/komapper/quarkus/jdbc/QuarkusJdbcTransactionSession.kt
@@ -8,7 +8,7 @@ import javax.transaction.TransactionManager
 
 class QuarkusJdbcTransactionSession(
     transactionManager: TransactionManager,
-    private val dataSource: DataSource
+    override val dataSource: DataSource
 ) : JdbcSession {
     override val transactionOperator: TransactionOperator = QuarkusJdbcTransactionOperator(transactionManager)
 

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcSession.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcSession.kt
@@ -15,6 +15,8 @@ import org.komapper.tx.core.FlowTransactionOperator
 @ThreadSafe
 interface R2dbcSession {
 
+    val connectionFactory: ConnectionFactory
+
     val coroutineTransactionOperator: CoroutineTransactionOperator
 
     val flowTransactionOperator: FlowTransactionOperator
@@ -48,7 +50,7 @@ interface R2dbcSession {
     }
 }
 
-class DefaultR2dbcSession(private val connectionFactory: ConnectionFactory) : R2dbcSession {
+class DefaultR2dbcSession(override val connectionFactory: ConnectionFactory) : R2dbcSession {
 
     override val coroutineTransactionOperator: CoroutineTransactionOperator
         get() = throw UnsupportedOperationException("Use a module that provides transaction management.")

--- a/komapper-spring-jdbc/src/main/kotlin/org/komapper/spring/jdbc/SpringJdbcTransactionSession.kt
+++ b/komapper-spring-jdbc/src/main/kotlin/org/komapper/spring/jdbc/SpringJdbcTransactionSession.kt
@@ -9,7 +9,7 @@ import javax.sql.DataSource
 
 class SpringJdbcTransactionSession(
     transactionManager: PlatformTransactionManager,
-    private val dataSource: DataSource,
+    override val dataSource: DataSource,
 ) :
     JdbcSession {
 

--- a/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/SpringR2dbcTransactionSession.kt
+++ b/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/SpringR2dbcTransactionSession.kt
@@ -13,7 +13,7 @@ import org.springframework.transaction.ReactiveTransactionManager
 
 class SpringR2dbcTransactionSession(
     transactionManager: ReactiveTransactionManager,
-    private val connectionFactory: ConnectionFactory,
+    override val connectionFactory: ConnectionFactory,
 ) :
     R2dbcSession {
 

--- a/komapper-tx-context-jdbc/src/main/kotlin/org/komapper/tx/context/jdbc/ContextualJdbcDatabase.kt
+++ b/komapper-tx-context-jdbc/src/main/kotlin/org/komapper/tx/context/jdbc/ContextualJdbcDatabase.kt
@@ -14,6 +14,7 @@ import org.komapper.tx.core.TransactionAttribute
 import org.komapper.tx.core.TransactionOperator
 import org.komapper.tx.core.TransactionProperty
 import java.sql.Connection
+import javax.sql.DataSource
 
 interface ContextualJdbcDatabase : Database {
 
@@ -69,6 +70,9 @@ internal class ContextualJdbcDatabaseImpl(
     override fun <T> runQuery(query: Query<T>): T {
         val runtimeConfig = object : JdbcDatabaseConfig by config {
             override val session: JdbcSession = object : JdbcSession {
+                override val dataSource: DataSource
+                    get() = config.session.dataSource
+
                 override val transactionOperator: TransactionOperator
                     get() = throw UnsupportedOperationException()
 

--- a/komapper-tx-context-r2dbc/src/main/kotlin/org/komapper/tx/context/r2dbc/ContextualR2dbcDatabase.kt
+++ b/komapper-tx-context-r2dbc/src/main/kotlin/org/komapper/tx/context/r2dbc/ContextualR2dbcDatabase.kt
@@ -1,5 +1,6 @@
 package org.komapper.tx.context.r2dbc
 
+import io.r2dbc.spi.ConnectionFactory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.reactive.collect
@@ -106,6 +107,9 @@ internal class ContextualR2dbcDatabaseImpl(
     override suspend fun <T> runQuery(query: Query<T>): T {
         val runtimeConfig = object : R2dbcDatabaseConfig by config {
             override val session: R2dbcSession = object : R2dbcSession {
+                override val connectionFactory: ConnectionFactory
+                    get() = config.session.connectionFactory
+
                 override val coroutineTransactionOperator: CoroutineTransactionOperator
                     get() = throw UnsupportedOperationException()
 

--- a/komapper-tx-jdbc/src/main/kotlin/org/komapper/tx/jdbc/JdbcTransactionSession.kt
+++ b/komapper-tx-jdbc/src/main/kotlin/org/komapper/tx/jdbc/JdbcTransactionSession.kt
@@ -12,7 +12,7 @@ import javax.sql.DataSource
  * Represents a transactional session for JDBC.
  */
 class JdbcTransactionSession(
-    dataSource: DataSource,
+    override val dataSource: DataSource,
     loggerFacade: LoggerFacade,
     transactionProperty: TransactionProperty = EmptyTransactionProperty,
 ) : JdbcSession {

--- a/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcTransactionSession.kt
+++ b/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcTransactionSession.kt
@@ -14,7 +14,7 @@ import org.komapper.tx.core.TransactionProperty
  * Represents a transactional session for R2DBC.
  */
 class R2dbcTransactionSession(
-    connectionFactory: ConnectionFactory,
+    override val connectionFactory: ConnectionFactory,
     loggerFacade: LoggerFacade,
     transactionProperty: TransactionProperty = EmptyTransactionProperty,
 ) : R2dbcSession {


### PR DESCRIPTION
This pull request makes available the DataSource and ConnectionFactory managed by Komapper.

JDBC:
```kotlin
val db: JdbcDatabase = ...
val dataSource: DataSource = db.config.session.dataSource
```

R2DBC:
```kotlin
val db: R2dbcDatabase = ...
val connectionFactory: ConnectionFactory = db.config.session.connectionFactory
```