### PR TITLE
Support for the random function

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcOperatorTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcOperatorTest.kt
@@ -11,6 +11,7 @@ import org.komapper.core.dsl.operator.lower
 import org.komapper.core.dsl.operator.ltrim
 import org.komapper.core.dsl.operator.minus
 import org.komapper.core.dsl.operator.plus
+import org.komapper.core.dsl.operator.random
 import org.komapper.core.dsl.operator.rem
 import org.komapper.core.dsl.operator.rtrim
 import org.komapper.core.dsl.operator.substring
@@ -19,8 +20,10 @@ import org.komapper.core.dsl.operator.upper
 import org.komapper.core.dsl.query.dryRun
 import org.komapper.core.dsl.query.first
 import org.komapper.jdbc.JdbcDatabase
+import java.math.BigDecimal
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @ExtendWith(JdbcEnv::class)
 class JdbcOperatorTest(private val db: JdbcDatabase) {
@@ -246,5 +249,23 @@ class JdbcOperatorTest(private val db: JdbcDatabase) {
             QueryDsl.from(a).select(rtrim(literal(" test "))).first()
         }
         assertEquals(" test", result)
+    }
+
+    @Test
+    fun randomFunction() {
+        val a = Meta.address
+        val result = db.runQuery {
+            QueryDsl.from(a).selectNotNull(random()).first()
+        }
+        assertTrue(result < BigDecimal.ONE)
+    }
+
+    @Test
+    fun orderByRandomFunction() {
+        val a = Meta.address
+        val result = db.runQuery {
+            QueryDsl.from(a).orderBy(random())
+        }
+        println(result)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -114,6 +114,13 @@ interface Dialect {
     }
 
     /**
+     * Returns the RANDOM function.
+     *
+     * @return the RANDOM function
+     */
+    fun getRandomFunction(): String = "random"
+
+    /**
      * Returns the SQL string for retrieving a new sequence number.
      *
      * @param sequenceName the sequence name

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
@@ -14,6 +14,7 @@ import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.EscapeExpression
 import org.komapper.core.dsl.expression.LiteralExpression
+import org.komapper.core.dsl.expression.MathematicalFunction
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.PropertyExpression
 import org.komapper.core.dsl.expression.ScalarExpression
@@ -66,6 +67,9 @@ class BuilderSupport(
             }
             is LiteralExpression<*> -> {
                 visitLiteralExpression(expression)
+            }
+            is MathematicalFunction<*, *> -> {
+                visitMathematicalFunction(expression)
             }
             is ScalarExpression<*, *> -> {
                 visitScalarExpression(expression)
@@ -156,6 +160,16 @@ class BuilderSupport(
     private fun visitLiteralExpression(expression: LiteralExpression<*>) {
         val string = dialect.formatValue(expression.value, expression.interiorClass, false)
         buf.append(string)
+    }
+
+    private fun visitMathematicalFunction(function: MathematicalFunction<*, *>) {
+        @Suppress("USELESS_IS_CHECK")
+        when (function) {
+            is MathematicalFunction<*, *> -> {
+                val random = dialect.getRandomFunction()
+                buf.append("$random()")
+            }
+        }
     }
 
     private fun visitScalarExpression(expression: ScalarExpression<*, *>) {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/MathematicalFunction.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/MathematicalFunction.kt
@@ -1,0 +1,17 @@
+package org.komapper.core.dsl.expression
+
+import java.math.BigDecimal
+import kotlin.reflect.KClass
+
+internal sealed class MathematicalFunction<T : Any, S : Any> : ColumnExpression<T, S> {
+    internal class Random : MathematicalFunction<BigDecimal, BigDecimal>() {
+        override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
+        override val exteriorClass: KClass<BigDecimal> get() = BigDecimal::class
+        override val interiorClass: KClass<BigDecimal> get() = BigDecimal::class
+        override val columnName: String get() = throw UnsupportedOperationException()
+        override val alwaysQuote: Boolean get() = throw UnsupportedOperationException()
+        override val masking: Boolean get() = throw UnsupportedOperationException()
+        override val wrap: (BigDecimal) -> BigDecimal = { it }
+        override val unwrap: (BigDecimal) -> BigDecimal = { it }
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/MathematicalFunctions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/MathematicalFunctions.kt
@@ -1,0 +1,12 @@
+package org.komapper.core.dsl.operator
+
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.MathematicalFunction
+import java.math.BigDecimal
+
+/**
+ * Builds a RANDOM function.
+ */
+fun random(): ColumnExpression<BigDecimal, BigDecimal> {
+    return MathematicalFunction.Random()
+}

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
@@ -26,6 +26,8 @@ interface MariaDbDialect : Dialect {
         return MariaDbOffsetLimitStatementBuilder(dialect, offset, limit)
     }
 
+    override fun getRandomFunction(): String = "rand"
+
     override fun getSequenceSql(sequenceName: String): String {
         return "select next value for $sequenceName"
     }

--- a/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
+++ b/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
@@ -26,6 +26,8 @@ interface MySqlDialect : Dialect {
         return MySqlOffsetLimitStatementBuilder(dialect, offset, limit)
     }
 
+    override fun getRandomFunction(): String = "rand"
+
     override fun getSequenceSql(sequenceName: String): String {
         throw UnsupportedOperationException()
     }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
@@ -24,6 +24,8 @@ interface OracleDialect : Dialect {
 
     override val driver: String get() = DRIVER
 
+    override fun getRandomFunction(): String = "dbms_random.value"
+
     override fun getSequenceSql(sequenceName: String): String {
         return "select $sequenceName.nextval from dual"
     }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
@@ -51,6 +51,8 @@ interface SqlServerDialect : Dialect {
 
     override fun getDefaultLengthForSubstringFunction(): Int? = Int.MAX_VALUE
 
+    override fun getRandomFunction(): String = "rand"
+
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false
 
     override fun supportsLimitOffsetWithoutOrderByClause(): Boolean = false


### PR DESCRIPTION
The `random()` function is defined in the `org.komapper.core.dsl.operator` package.
We can use it as follows:

```kotlin
val a = Meta.address
val result = db.runQuery {
    QueryDsl.from(a).orderBy(random())
}
```

Running the above query will issue the following SQL:
```sql
select t0_.address_id, t0_.street, t0_.version from address as t0_ order by random() asc
```