### PR TITLE
Support for `INSERT ... RETURNING` and `UPDATE ... RETURNING`

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertMultipleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertMultipleReturningTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertTrue
 @ExtendWith(JdbcEnv::class)
 class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test() {
         val a = Meta.address
@@ -37,7 +37,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         assertEquals(addressList, addressList2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn() {
         val a = Meta.address
@@ -50,7 +50,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         assertEquals(addressList.map { it.street }, streets)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns() {
         val a = Meta.address
@@ -63,7 +63,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         assertEquals(addressList.map { it.street to it.version }, pairs)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns() {
         val a = Meta.address
@@ -76,7 +76,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         assertEquals(addressList.map { Triple(it.street, it.version, it.addressId) }, triples)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun identity() {
         val i = Meta.identityStrategy
@@ -91,7 +91,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         assertTrue(results1.all { it.id != null })
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun sequenceGenerator() {
         val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
@@ -106,7 +106,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         assertEquals(strategies3, strategies2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdate() {
         val d = Meta.department
@@ -116,7 +116,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
         val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning()
         val departments2 = db.runQuery { query }
-        assertEquals(departments, departments2)
+        assertEquals(departments.toSet(), departments2.toSet())
         val list = db.runQuery {
             QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
         }
@@ -127,7 +127,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateReturningSingleColumn() {
         val d = Meta.department
@@ -137,7 +137,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
         val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning(d.departmentName)
         val departmentNameList = db.runQuery { query }
-        assertEquals(departments.map { it.departmentName }, departmentNameList)
+        assertEquals(departments.map { it.departmentName }.toSet(), departmentNameList.toSet())
         val list = db.runQuery {
             QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
         }
@@ -148,7 +148,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateReturningPairColumns() {
         val d = Meta.department
@@ -158,7 +158,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
         val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning(d.departmentName, d.location)
         val pairList = db.runQuery { query }
-        assertEquals(departments.map { it.departmentName to it.location }, pairList)
+        assertEquals(departments.map { it.departmentName to it.location }.toSet(), pairList.toSet())
         val list = db.runQuery {
             QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
         }
@@ -169,7 +169,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateReturningTripleColumns() {
         val d = Meta.department
@@ -179,7 +179,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
         val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning(d.departmentName, d.location, d.departmentNo)
         val tripleList = db.runQuery { query }
-        assertEquals(departments.map { Triple(it.departmentName, it.location, it.departmentNo) }, tripleList)
+        assertEquals(departments.map { Triple(it.departmentName, it.location, it.departmentNo) }.toSet(), tripleList.toSet())
         val list = db.runQuery {
             QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
         }
@@ -190,7 +190,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnore() {
         val d = Meta.department
@@ -209,7 +209,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnoreReturningSingleColumn() {
         val d = Meta.department
@@ -228,7 +228,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnoreReturningPairColumns() {
         val d = Meta.department
@@ -247,7 +247,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnoreReturningTripleColumns() {
         val d = Meta.department
@@ -266,7 +266,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_insertReturning() {
         val a = Meta.address
@@ -282,7 +282,7 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         println(ex)
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_onDuplicateKeyUpdate_insertReturning() {
         val a = Meta.address

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertMultipleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertMultipleReturningTest.kt
@@ -11,6 +11,7 @@ import integration.core.department
 import integration.core.identityStrategy
 import integration.core.sequenceStrategy
 import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dryRunQuery
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.metamodel.IdGenerator
@@ -136,5 +137,17 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
             Unit
         }
         println(ex)
+    }
+
+    @Test
+    fun dryRun() {
+        val a = Meta.address
+        val addressList = listOf(
+            Address(16, "STREET 16", 0),
+            Address(17, "STREET 17", 0),
+            Address(18, "STREET 18", 0),
+        )
+        val query = QueryDsl.insert(a).multiple(addressList).returning()
+        println(db.dryRunQuery(query))
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertMultipleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertMultipleReturningTest.kt
@@ -39,6 +39,45 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
 
     @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
     @Test
+    fun testReturningSingleColumn() {
+        val a = Meta.address
+        val addressList = listOf(
+            Address(16, "STREET 16", 0),
+            Address(17, "STREET 17", 0),
+            Address(18, "STREET 18", 0),
+        )
+        val streets = db.runQuery { QueryDsl.insert(a).multiple(addressList).returning(a.street) }
+        assertEquals(addressList.map { it.street }, streets)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun testReturningPairColumns() {
+        val a = Meta.address
+        val addressList = listOf(
+            Address(16, "STREET 16", 0),
+            Address(17, "STREET 17", 0),
+            Address(18, "STREET 18", 0),
+        )
+        val pairs = db.runQuery { QueryDsl.insert(a).multiple(addressList).returning(a.street, a.version) }
+        assertEquals(addressList.map { it.street to it.version }, pairs)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun testReturningTripleColumns() {
+        val a = Meta.address
+        val addressList = listOf(
+            Address(16, "STREET 16", 0),
+            Address(17, "STREET 17", 0),
+            Address(18, "STREET 18", 0),
+        )
+        val triples = db.runQuery { QueryDsl.insert(a).multiple(addressList).returning(a.street, a.version, a.addressId) }
+        assertEquals(addressList.map { Triple(it.street, it.version, it.addressId) }, triples)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
     fun identity() {
         val i = Meta.identityStrategy
         val strategies = listOf(
@@ -90,6 +129,69 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
 
     @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
     @Test
+    fun onDuplicateKeyUpdateReturningSingleColumn() {
+        val d = Meta.department
+        val departments = listOf(
+            Department(5, 50, "PLANNING", "TOKYO", 1),
+            Department(1, 60, "DEVELOPMENT", "KYOTO", 1),
+        )
+        val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning(d.departmentName)
+        val departmentNameList = db.runQuery { query }
+        assertEquals(departments.map { it.departmentName }, departmentNameList)
+        val list = db.runQuery {
+            QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
+        }
+        assertEquals(2, list.size)
+        assertEquals(
+            listOf("DEVELOPMENT" to "KYOTO", "PLANNING" to "TOKYO"),
+            list.map { it.departmentName to it.location },
+        )
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdateReturningPairColumns() {
+        val d = Meta.department
+        val departments = listOf(
+            Department(5, 50, "PLANNING", "TOKYO", 1),
+            Department(1, 60, "DEVELOPMENT", "KYOTO", 1),
+        )
+        val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning(d.departmentName, d.location)
+        val pairList = db.runQuery { query }
+        assertEquals(departments.map { it.departmentName to it.location }, pairList)
+        val list = db.runQuery {
+            QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
+        }
+        assertEquals(2, list.size)
+        assertEquals(
+            listOf("DEVELOPMENT" to "KYOTO", "PLANNING" to "TOKYO"),
+            list.map { it.departmentName to it.location },
+        )
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdateReturningTripleColumns() {
+        val d = Meta.department
+        val departments = listOf(
+            Department(5, 50, "PLANNING", "TOKYO", 1),
+            Department(1, 60, "DEVELOPMENT", "KYOTO", 1),
+        )
+        val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning(d.departmentName, d.location, d.departmentNo)
+        val tripleList = db.runQuery { query }
+        assertEquals(departments.map { Triple(it.departmentName, it.location, it.departmentNo) }, tripleList)
+        val list = db.runQuery {
+            QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
+        }
+        assertEquals(2, list.size)
+        assertEquals(
+            listOf("DEVELOPMENT" to "KYOTO", "PLANNING" to "TOKYO"),
+            list.map { it.departmentName to it.location },
+        )
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
     fun onDuplicateKeyIgnore() {
         val d = Meta.department
         val department1 = Department(5, 50, "PLANNING", "TOKYO", 1)
@@ -97,6 +199,63 @@ class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
         val query = QueryDsl.insert(d).onDuplicateKeyIgnore().multiple(listOf(department1, department2)).returning()
         val departments = db.runQuery { query }
         assertEquals(listOf(department1), departments)
+        val list = db.runQuery {
+            QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
+        }
+        assertEquals(2, list.size)
+        assertEquals(
+            listOf("ACCOUNTING" to "NEW YORK", "PLANNING" to "TOKYO"),
+            list.map { it.departmentName to it.location },
+        )
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyIgnoreReturningSingleColumn() {
+        val d = Meta.department
+        val department1 = Department(5, 50, "PLANNING", "TOKYO", 1)
+        val department2 = Department(1, 60, "DEVELOPMENT", "KYOTO", 1)
+        val query = QueryDsl.insert(d).onDuplicateKeyIgnore().multiple(listOf(department1, department2)).returning(d.departmentName)
+        val departmentNameList = db.runQuery { query }
+        assertEquals(listOf(department1.departmentName), departmentNameList)
+        val list = db.runQuery {
+            QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
+        }
+        assertEquals(2, list.size)
+        assertEquals(
+            listOf("ACCOUNTING" to "NEW YORK", "PLANNING" to "TOKYO"),
+            list.map { it.departmentName to it.location },
+        )
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyIgnoreReturningPairColumns() {
+        val d = Meta.department
+        val department1 = Department(5, 50, "PLANNING", "TOKYO", 1)
+        val department2 = Department(1, 60, "DEVELOPMENT", "KYOTO", 1)
+        val query = QueryDsl.insert(d).onDuplicateKeyIgnore().multiple(listOf(department1, department2)).returning(d.departmentName, d.location)
+        val pairList = db.runQuery { query }
+        assertEquals(listOf(department1.departmentName to department1.location), pairList)
+        val list = db.runQuery {
+            QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
+        }
+        assertEquals(2, list.size)
+        assertEquals(
+            listOf("ACCOUNTING" to "NEW YORK", "PLANNING" to "TOKYO"),
+            list.map { it.departmentName to it.location },
+        )
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyIgnoreReturningTripleColumns() {
+        val d = Meta.department
+        val department1 = Department(5, 50, "PLANNING", "TOKYO", 1)
+        val department2 = Department(1, 60, "DEVELOPMENT", "KYOTO", 1)
+        val query = QueryDsl.insert(d).onDuplicateKeyIgnore().multiple(listOf(department1, department2)).returning(d.departmentName, d.location, d.departmentNo)
+        val tripleList = db.runQuery { query }
+        assertEquals(listOf(Triple(department1.departmentName, department1.location, department1.departmentNo)), tripleList)
         val list = db.runQuery {
             QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
         }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertMultipleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertMultipleReturningTest.kt
@@ -1,0 +1,140 @@
+package integration.jdbc
+
+import integration.core.Address
+import integration.core.Dbms
+import integration.core.Department
+import integration.core.IdentityStrategy
+import integration.core.Run
+import integration.core.SequenceStrategy
+import integration.core.address
+import integration.core.department
+import integration.core.identityStrategy
+import integration.core.sequenceStrategy
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.jdbc.JdbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+@ExtendWith(JdbcEnv::class)
+class JdbcInsertMultipleReturningTest(private val db: JdbcDatabase) {
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun test() {
+        val a = Meta.address
+        val addressList = listOf(
+            Address(16, "STREET 16", 0),
+            Address(17, "STREET 17", 0),
+            Address(18, "STREET 18", 0),
+        )
+        val addressList2 = db.runQuery { QueryDsl.insert(a).multiple(addressList).returning() }
+        assertEquals(addressList, addressList2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun identity() {
+        val i = Meta.identityStrategy
+        val strategies = listOf(
+            IdentityStrategy(null, "AAA"),
+            IdentityStrategy(null, "BBB"),
+            IdentityStrategy(null, "CCC"),
+        )
+        val results1 = db.runQuery { QueryDsl.insert(i).multiple(strategies).returning() }
+        val results2 = db.runQuery { QueryDsl.from(i).orderBy(i.id) }
+        assertEquals(results1, results2)
+        assertTrue(results1.all { it.id != null })
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun sequenceGenerator() {
+        val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
+        generator.clear()
+
+        val range = (1..201)
+        val m = Meta.sequenceStrategy
+        val strategies = range.map { SequenceStrategy(0, "test") }
+        val strategies2 = db.runQuery { QueryDsl.insert(m).multiple(strategies).returning() }
+        val strategies3 = range.map { SequenceStrategy(it, "test") }
+
+        assertEquals(strategies3, strategies2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdate() {
+        val d = Meta.department
+        val departments = listOf(
+            Department(5, 50, "PLANNING", "TOKYO", 1),
+            Department(1, 60, "DEVELOPMENT", "KYOTO", 1),
+        )
+        val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning()
+        val departments2 = db.runQuery { query }
+        assertEquals(departments, departments2)
+        val list = db.runQuery {
+            QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
+        }
+        assertEquals(2, list.size)
+        assertEquals(
+            listOf("DEVELOPMENT" to "KYOTO", "PLANNING" to "TOKYO"),
+            list.map { it.departmentName to it.location },
+        )
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyIgnore() {
+        val d = Meta.department
+        val department1 = Department(5, 50, "PLANNING", "TOKYO", 1)
+        val department2 = Department(1, 60, "DEVELOPMENT", "KYOTO", 1)
+        val query = QueryDsl.insert(d).onDuplicateKeyIgnore().multiple(listOf(department1, department2)).returning()
+        val departments = db.runQuery { query }
+        assertEquals(listOf(department1), departments)
+        val list = db.runQuery {
+            QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
+        }
+        assertEquals(2, list.size)
+        assertEquals(
+            listOf("ACCOUNTING" to "NEW YORK", "PLANNING" to "TOKYO"),
+            list.map { it.departmentName to it.location },
+        )
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_insertReturning() {
+        val a = Meta.address
+        val addressList = listOf(
+            Address(16, "STREET 16", 0),
+            Address(17, "STREET 17", 0),
+            Address(18, "STREET 18", 0),
+        )
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.insert(a).multiple(addressList).returning() }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_onDuplicateKeyUpdate_insertReturning() {
+        val a = Meta.address
+        val addressList = listOf(
+            Address(16, "STREET 16", 0),
+            Address(17, "STREET 17", 0),
+            Address(18, "STREET 18", 0),
+        )
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.insert(a).onDuplicateKeyUpdate().multiple(addressList).returning() }
+            Unit
+        }
+        println(ex)
+    }
+}

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleReturningTest.kt
@@ -12,6 +12,7 @@ import integration.core.identityStrategy
 import integration.core.sequenceStrategy
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.UniqueConstraintException
+import org.komapper.core.dryRunQuery
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.metamodel.IdGenerator
@@ -180,5 +181,13 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
             Unit
         }
         println(ex)
+    }
+
+    @Test
+    fun dryRun() {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val query = QueryDsl.insert(a).single(address).returning()
+        println(db.dryRunQuery(query))
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleReturningTest.kt
@@ -1,0 +1,184 @@
+package integration.jdbc
+
+import integration.core.Address
+import integration.core.Dbms
+import integration.core.Department
+import integration.core.IdentityStrategy
+import integration.core.Run
+import integration.core.SequenceStrategy
+import integration.core.address
+import integration.core.department
+import integration.core.identityStrategy
+import integration.core.sequenceStrategy
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.UniqueConstraintException
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.core.dsl.operator.concat
+import org.komapper.core.dsl.query.first
+import org.komapper.jdbc.JdbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@ExtendWith(JdbcEnv::class)
+class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun test() {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val address2 = db.runQuery { QueryDsl.insert(a).single(address).returning() }
+        assertEquals(address, address2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun uniqueConstraintException() {
+        val a = Meta.address
+        val address = Address(1, "STREET 1", 0)
+        assertFailsWith<UniqueConstraintException> {
+            db.runQuery { QueryDsl.insert(a).single(address).returning() }.let { }
+        }
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun sequenceGenerator() {
+        val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
+        generator.clear()
+
+        for (i in 1..201) {
+            val m = Meta.sequenceStrategy
+            val strategy = SequenceStrategy(0, "test")
+            val result = db.runQuery { QueryDsl.insert(m).single(strategy) }
+            assertEquals(i, result.id)
+        }
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun identityGenerator() {
+        for (i in 1..201) {
+            val m = Meta.identityStrategy
+            val strategy = IdentityStrategy(0, "test")
+            val result = db.runQuery { QueryDsl.insert(m).single(strategy).returning() }
+            assertEquals(i, result.id, "i = $i")
+        }
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdate_insert() {
+        val d = Meta.department
+        val department = Department(5, 50, "PLANNING", "TOKYO", 0)
+        val query = QueryDsl.insert(d).onDuplicateKeyUpdate().single(department).returning()
+        val department2 = db.runQuery { query }
+        assertEquals(department, department2)
+        val found = db.runQuery { QueryDsl.from(d).where { d.departmentId eq 5 }.first() }
+        assertNotNull(found)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdate_update() {
+        val d = Meta.department
+        val department = Department(1, 50, "PLANNING", "TOKYO", 10)
+        val query = QueryDsl.insert(d).onDuplicateKeyUpdate().single(department).returning()
+        val department2 = db.runQuery { query }
+        assertEquals(department, department2)
+        val found = db.runQuery { QueryDsl.from(d).where { d.departmentId eq 1 }.first() }
+        assertEquals(50, found.departmentNo)
+        assertEquals("PLANNING", found.departmentName)
+        assertEquals("TOKYO", found.location)
+        assertEquals(10, found.version)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdateWithKey_update_set_where_success() {
+        val d = Meta.department
+        val department = Department(5, 10, "PLANNING", "TOKYO", 10)
+        val query = QueryDsl.insert(d)
+            .onDuplicateKeyUpdate(d.departmentNo)
+            .set { excluded ->
+                d.departmentName eq "PLANNING2"
+                d.location eq concat(d.location, concat("_", excluded.location))
+            }.where {
+                d.location eq "NEW YORK"
+            }.single(department).returning()
+        val department2 = db.runQuery { query }
+        assertNotNull(department2)
+        val found = db.runQuery { QueryDsl.from(d).where { d.departmentNo eq 10 }.first() }
+        assertEquals(department2, found)
+        assertEquals(1, found.departmentId)
+        assertEquals("PLANNING2", found.departmentName)
+        assertEquals("NEW YORK_TOKYO", found.location)
+        assertEquals(1, found.version)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdateWithKey_update_set_where_fail() {
+        val d = Meta.department
+        val department = Department(5, 10, "PLANNING", "TOKYO", 10)
+        val query = QueryDsl.insert(d)
+            .onDuplicateKeyUpdate(d.departmentNo)
+            .set { excluded ->
+                d.departmentName eq "PLANNING2"
+                d.location eq concat(d.location, concat("_", excluded.location))
+            }.where {
+                d.location eq "KYOTO"
+            }.single(department).returning()
+        val department2 = db.runQuery { query }
+        assertNull(department2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyIgnore_inserted() {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val query = QueryDsl.insert(a).onDuplicateKeyIgnore().single(address).returning()
+        val address2 = db.runQuery { query }
+        assertEquals(address, address2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyIgnore_ignored() {
+        val a = Meta.address
+        val address = Address(1, "STREET 100", 0)
+        val query = QueryDsl.insert(a).onDuplicateKeyIgnore().single(address).returning()
+        val address2 = db.runQuery { query }
+        assertNull(address2)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_insertReturning() {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.insert(a).single(address).returning() }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_onDuplicateKeyUpdate_insertReturning() {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.insert(a).onDuplicateKeyUpdate().single(address).returning() }
+            Unit
+        }
+        println(ex)
+    }
+}

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleReturningTest.kt
@@ -28,7 +28,7 @@ import kotlin.test.assertNull
 @ExtendWith(JdbcEnv::class)
 class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test() {
         val a = Meta.address
@@ -37,7 +37,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address, address2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn() {
         val a = Meta.address
@@ -46,7 +46,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address.street, street)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns() {
         val a = Meta.address
@@ -56,7 +56,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address.version, version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns() {
         val a = Meta.address
@@ -67,7 +67,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address.addressId, addressId)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun uniqueConstraintException() {
         val a = Meta.address
@@ -77,7 +77,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun sequenceGenerator() {
         val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
@@ -91,7 +91,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun identityGenerator() {
         for (i in 1..201) {
@@ -102,7 +102,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdate_insert() {
         val d = Meta.department
@@ -114,7 +114,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertNotNull(found)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdate_insert_returningSingleColumn() {
         val d = Meta.department
@@ -126,7 +126,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertNotNull(found)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdate_insert_returningPairColumns() {
         val d = Meta.department
@@ -139,7 +139,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertNotNull(found)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdate_insert_returningThirdColumns() {
         val d = Meta.department
@@ -153,7 +153,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertNotNull(found)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdate_update() {
         val d = Meta.department
@@ -168,7 +168,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(10, found.version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateWithKey_update_set_where_success() {
         val d = Meta.department
@@ -191,7 +191,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(1, found.version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateWithKey_update_set_where_success_returningPairColumns() {
         val d = Meta.department
@@ -215,7 +215,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(1, found.version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateWithKey_update_set_where_fail() {
         val d = Meta.department
@@ -232,7 +232,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertNull(department2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnore_inserted() {
         val a = Meta.address
@@ -242,7 +242,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address, address2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnore_ignored() {
         val a = Meta.address
@@ -252,7 +252,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertNull(address2)
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_insertReturning() {
         val a = Meta.address
@@ -264,7 +264,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         println(ex)
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_onDuplicateKeyUpdate_insertReturning() {
         val a = Meta.address

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
@@ -36,6 +36,7 @@ import org.komapper.core.ClockProvider
 import org.komapper.core.UniqueConstraintException
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.metamodel.IdGenerator
 import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.query.first
 import org.komapper.jdbc.JdbcDatabase
@@ -283,6 +284,9 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
     @Run(unless = [Dbms.MYSQL])
     @Test
     fun sequenceGenerator() {
+        val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
+        generator.clear()
+
         for (i in 1..201) {
             val m = Meta.sequenceStrategy
             val strategy = SequenceStrategy(0, "test")

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertValuesReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertValuesReturningTest.kt
@@ -1,0 +1,138 @@
+package integration.jdbc
+
+import integration.core.Address
+import integration.core.Dbms
+import integration.core.IdentityStrategy
+import integration.core.Run
+import integration.core.SequenceStrategy
+import integration.core.address
+import integration.core.identityStrategy
+import integration.core.sequenceStrategy
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dryRunQuery
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.jdbc.JdbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@ExtendWith(JdbcEnv::class)
+class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun test() {
+        val a = Meta.address
+        val address = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.addressId eq 19
+                a.street eq "STREET 16"
+                a.version eq 0
+            }.returning()
+        }
+        assertEquals(Address(19, "STREET 16", 0), address)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun testReturningSingleColumn() {
+        val a = Meta.address
+        val street = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.addressId eq 19
+                a.street eq "STREET 16"
+                a.version eq 0
+            }.returning(a.street)
+        }
+        assertEquals("STREET 16", street)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun testReturningPairColumns() {
+        val a = Meta.address
+        val (street, version) = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.addressId eq 19
+                a.street eq "STREET 16"
+                a.version eq 0
+            }.returning(a.street, a.version)
+        }
+        assertEquals("STREET 16", street)
+        assertEquals(0, version)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun testReturningTripleColumns() {
+        val a = Meta.address
+        val (street, version, addressId) = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.addressId eq 19
+                a.street eq "STREET 16"
+                a.version eq 0
+            }.returning(a.street, a.version, a.addressId)
+        }
+        assertEquals("STREET 16", street)
+        assertEquals(0, version)
+        assertEquals(19, addressId)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun generatedKeys_autoIncrement() {
+        val a = Meta.identityStrategy
+        val strategy = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.id eq 10
+                a.value eq "test"
+            }.returning()
+        }
+        assertEquals(IdentityStrategy(1, "test"), strategy)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun generatedKeys_sequence() {
+        val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
+        generator.clear()
+
+        val a = Meta.sequenceStrategy
+        val strategy = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.value eq "test"
+            }.returning()
+        }
+        assertEquals(SequenceStrategy(1, "test"), strategy)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException() {
+        val a = Meta.address
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery {
+                QueryDsl.insert(a).values {
+                    a.addressId eq 19
+                    a.street eq "STREET 16"
+                    a.version eq 0
+                }.returning()
+            }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Test
+    fun dryRun() {
+        val a = Meta.address
+        val query = QueryDsl.insert(a).values {
+            a.addressId eq 19
+            a.street eq "STREET 16"
+            a.version eq 0
+        }.returning()
+        println(db.dryRunQuery(query))
+    }
+}

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertValuesReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertValuesReturningTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertFailsWith
 @ExtendWith(JdbcEnv::class)
 class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test() {
         val a = Meta.address
@@ -35,7 +35,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals(Address(19, "STREET 16", 0), address)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn() {
         val a = Meta.address
@@ -49,7 +49,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals("STREET 16", street)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns() {
         val a = Meta.address
@@ -64,7 +64,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals(0, version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns() {
         val a = Meta.address
@@ -80,7 +80,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals(19, addressId)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun generatedKeys_autoIncrement() {
         val a = Meta.identityStrategy
@@ -93,7 +93,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals(IdentityStrategy(1, "test"), strategy)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun generatedKeys_sequence() {
         val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
@@ -108,7 +108,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals(SequenceStrategy(1, "test"), strategy)
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException() {
         val a = Meta.address

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSetReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSetReturningTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 @ExtendWith(JdbcEnv::class)
 class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test() {
         val a = Meta.address
@@ -37,7 +37,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(list.single(), address)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn() {
         val a = Meta.address
@@ -57,7 +57,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(list.single(), address.street)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns() {
         val a = Meta.address
@@ -77,7 +77,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(list.single(), address.street to address.version)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns() {
         val a = Meta.address
@@ -97,7 +97,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(list.single(), Triple(address.street, address.version, address.addressId))
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testMultipleUpdate() {
         val a = Meta.address
@@ -118,7 +118,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(list.toSet(), list2.toSet())
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun incrementVersion_auto() {
         val a = Meta.address
@@ -143,7 +143,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(2, address2.version)
     }
 
-    @Run(unless = [Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_updateReturning() {
         val a = Meta.address

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSetReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSetReturningTest.kt
@@ -1,0 +1,173 @@
+package integration.jdbc
+
+import integration.core.Dbms
+import integration.core.Run
+import integration.core.address
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dryRunQuery
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.query.first
+import org.komapper.jdbc.JdbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+@ExtendWith(JdbcEnv::class)
+class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun test() {
+        val a = Meta.address
+        val list = db.runQuery {
+            QueryDsl.update(a).set {
+                a.street eq "STREET 16"
+            }.where {
+                a.addressId eq 1
+            }.returning()
+        }
+        assertEquals(1, list.size)
+        val address = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 1
+            }.first()
+        }
+        assertEquals(list.single(), address)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testReturningSingleColumn() {
+        val a = Meta.address
+        val list = db.runQuery {
+            QueryDsl.update(a).set {
+                a.street eq "STREET 16"
+            }.where {
+                a.addressId eq 1
+            }.returning(a.street)
+        }
+        assertEquals(1, list.size)
+        val address = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 1
+            }.first()
+        }
+        assertEquals(list.single(), address.street)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testReturningPairColumns() {
+        val a = Meta.address
+        val list = db.runQuery {
+            QueryDsl.update(a).set {
+                a.street eq "STREET 16"
+            }.where {
+                a.addressId eq 1
+            }.returning(a.street, a.version)
+        }
+        assertEquals(1, list.size)
+        val address = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 1
+            }.first()
+        }
+        assertEquals(list.single(), address.street to address.version)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testReturningTripleColumns() {
+        val a = Meta.address
+        val list = db.runQuery {
+            QueryDsl.update(a).set {
+                a.street eq "STREET 16"
+            }.where {
+                a.addressId eq 1
+            }.returning(a.street, a.version, a.addressId)
+        }
+        assertEquals(1, list.size)
+        val address = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 1
+            }.first()
+        }
+        assertEquals(list.single(), Triple(address.street, address.version, address.addressId))
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testMultipleUpdate() {
+        val a = Meta.address
+        val list = db.runQuery {
+            QueryDsl.update(a).set {
+                a.version eq 100
+            }.where {
+                a.addressId inList listOf(1, 2)
+            }.returning()
+        }
+        assertEquals(2, list.size)
+        val list2 = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId inList listOf(1, 2)
+            }
+        }
+        assertTrue(list.all { it.version == 100 })
+        assertEquals(list.toSet(), list2.toSet())
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun incrementVersion_auto() {
+        val a = Meta.address
+        val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.first() }
+        assertEquals(1, address1.version)
+
+        val versions = db.runQuery {
+            QueryDsl.update(a).set {
+                a.street eq "STREET 16"
+            }.where {
+                a.addressId eq 1
+            }.returning(a.version)
+        }
+        assertEquals(1, versions.size)
+        assertEquals(2, versions.single())
+
+        val address2 = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 1
+            }.first()
+        }
+        assertEquals(2, address2.version)
+    }
+
+    @Run(unless = [Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_updateReturning() {
+        val a = Meta.address
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery {
+                QueryDsl.update(a).set {
+                    a.street eq "STREET 16"
+                }.where {
+                    a.addressId eq 1
+                }.returning()
+            }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Test
+    fun dryRun() {
+        val a = Meta.address
+        val query = QueryDsl.update(a).set {
+            a.street eq "STREET 16"
+        }.where {
+            a.addressId eq 1
+        }.returning()
+        println(db.dryRunQuery(query))
+    }
+}

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleReturningTest.kt
@@ -1,0 +1,75 @@
+package integration.jdbc
+
+import integration.core.Address
+import integration.core.Dbms
+import integration.core.Run
+import integration.core.address
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.OptimisticLockException
+import org.komapper.core.UniqueConstraintException
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.query.first
+import org.komapper.core.dsl.query.firstOrNull
+import org.komapper.core.dsl.query.single
+import org.komapper.jdbc.JdbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@ExtendWith(JdbcEnv::class)
+class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun test() {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val newAddress = address.copy(street = "NY street")
+        val returningAddress = db.runQuery { QueryDsl.update(a).single(newAddress).returning() }
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertEquals(
+            Address(
+                15,
+                "NY street",
+                2,
+            ),
+            address2,
+        )
+        assertEquals(address2, returningAddress)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun uniqueConstraintException() {
+        val a = Meta.address
+        val address = Address(1, "STREET 2", 1)
+        assertFailsWith<UniqueConstraintException> {
+            db.runQuery { QueryDsl.update(a).single(address).returning() }.let { }
+        }
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun optimisticLockException() {
+        val a = Meta.address
+        val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 15 }.first() }
+        db.runQuery { QueryDsl.update(a).single(address) }
+        assertFailsWith<OptimisticLockException> {
+            db.runQuery { QueryDsl.update(a).single(address).returning() }.let {}
+        }
+    }
+
+    @Run(unless = [Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_updateReturning() {
+        val a = Meta.address
+        val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 15 }.single() }
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.update(a).single(address.copy(street = "STREET 123")).returning() }
+            Unit
+        }
+        println(ex)
+    }
+}

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleReturningTest.kt
@@ -7,6 +7,7 @@ import integration.core.address
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.UniqueConstraintException
+import org.komapper.core.dryRunQuery
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.query.first
@@ -71,5 +72,13 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
             Unit
         }
         println(ex)
+    }
+
+    @Test
+    fun dryRun() {
+        val a = Meta.address
+        val address = Address(addressId = 1, street = "STREET 123", version = 0)
+        val query = QueryDsl.update(a).single(address).returning()
+        println(db.dryRunQuery(query))
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleReturningTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertNull
 @ExtendWith(JdbcEnv::class)
 class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test() {
         val a = Meta.address
@@ -42,7 +42,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address2, returningAddress)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn() {
         val a = Meta.address
@@ -62,7 +62,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns() {
         val a = Meta.address
@@ -82,7 +82,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns() {
         val a = Meta.address
@@ -102,7 +102,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun suppressOptimisticLockException() {
         val a = Meta.address
@@ -113,7 +113,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         assertNull(returningAddress)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun uniqueConstraintException() {
         val a = Meta.address
@@ -123,7 +123,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun optimisticLockException() {
         val a = Meta.address
@@ -134,7 +134,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(unless = [Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_updateReturning() {
         val a = Meta.address

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertMultipleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertMultipleReturningTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertTrue
 @ExtendWith(R2dbcEnv::class)
 class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -37,7 +37,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(addressList, addressList2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -50,7 +50,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(addressList.map { it.street }, streets)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -63,7 +63,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(addressList.map { it.street to it.version }, pairs)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -76,7 +76,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(addressList.map { Triple(it.street, it.version, it.addressId) }, triples)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun identity(info: TestInfo) = inTransaction(db, info) {
         val i = Meta.identityStrategy
@@ -91,7 +91,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         assertTrue(results1.all { it.id != null })
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun sequenceGenerator(info: TestInfo) = inTransaction(db, info) {
         val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
@@ -106,7 +106,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(strategies3, strategies2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdate(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -116,7 +116,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
         val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning()
         val departments2 = db.runQuery { query }
-        assertEquals(departments, departments2)
+        assertEquals(departments.toSet(), departments2.toSet())
         val list = db.runQuery {
             QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
         }
@@ -127,7 +127,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -137,7 +137,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
         val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning(d.departmentName)
         val departmentNameList = db.runQuery { query }
-        assertEquals(departments.map { it.departmentName }, departmentNameList)
+        assertEquals(departments.map { it.departmentName }.toSet(), departmentNameList.toSet())
         val list = db.runQuery {
             QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
         }
@@ -148,7 +148,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -158,7 +158,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
         val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning(d.departmentName, d.location)
         val pairList = db.runQuery { query }
-        assertEquals(departments.map { it.departmentName to it.location }, pairList)
+        assertEquals(departments.map { it.departmentName to it.location }.toSet(), pairList.toSet())
         val list = db.runQuery {
             QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
         }
@@ -169,7 +169,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -179,7 +179,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
         val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning(d.departmentName, d.location, d.departmentNo)
         val tripleList = db.runQuery { query }
-        assertEquals(departments.map { Triple(it.departmentName, it.location, it.departmentNo) }, tripleList)
+        assertEquals(departments.map { Triple(it.departmentName, it.location, it.departmentNo) }.toSet(), tripleList.toSet())
         val list = db.runQuery {
             QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
         }
@@ -190,7 +190,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnore(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -209,7 +209,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnoreReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -228,7 +228,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnoreReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -247,7 +247,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnoreReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -266,7 +266,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_insertReturning(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -282,7 +282,7 @@ class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
         println(ex)
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_onDuplicateKeyUpdate_insertReturning(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertMultipleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertMultipleReturningTest.kt
@@ -1,0 +1,141 @@
+package integration.r2dbc
+
+import integration.core.Address
+import integration.core.Dbms
+import integration.core.Department
+import integration.core.IdentityStrategy
+import integration.core.Run
+import integration.core.SequenceStrategy
+import integration.core.address
+import integration.core.department
+import integration.core.identityStrategy
+import integration.core.sequenceStrategy
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.r2dbc.R2dbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+@ExtendWith(R2dbcEnv::class)
+class R2dbcInsertMultipleReturningTest(private val db: R2dbcDatabase) {
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun test(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val addressList = listOf(
+            Address(16, "STREET 16", 0),
+            Address(17, "STREET 17", 0),
+            Address(18, "STREET 18", 0),
+        )
+        val addressList2 = db.runQuery { QueryDsl.insert(a).multiple(addressList).returning() }
+        assertEquals(addressList, addressList2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun identity(info: TestInfo) = inTransaction(db, info) {
+        val i = Meta.identityStrategy
+        val strategies = listOf(
+            IdentityStrategy(null, "AAA"),
+            IdentityStrategy(null, "BBB"),
+            IdentityStrategy(null, "CCC"),
+        )
+        val results1 = db.runQuery { QueryDsl.insert(i).multiple(strategies).returning() }
+        val results2 = db.runQuery { QueryDsl.from(i).orderBy(i.id) }
+        assertEquals(results1, results2)
+        assertTrue(results1.all { it.id != null })
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun sequenceGenerator(info: TestInfo) = inTransaction(db, info) {
+        val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
+        generator.clear()
+
+        val range = (1..201)
+        val m = Meta.sequenceStrategy
+        val strategies = range.map { SequenceStrategy(0, "test") }
+        val strategies2 = db.runQuery { QueryDsl.insert(m).multiple(strategies).returning() }
+        val strategies3 = range.map { SequenceStrategy(it, "test") }
+
+        assertEquals(strategies3, strategies2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdate(info: TestInfo) = inTransaction(db, info) {
+        val d = Meta.department
+        val departments = listOf(
+            Department(5, 50, "PLANNING", "TOKYO", 1),
+            Department(1, 60, "DEVELOPMENT", "KYOTO", 1),
+        )
+        val query = QueryDsl.insert(d).onDuplicateKeyUpdate().multiple(departments).returning()
+        val departments2 = db.runQuery { query }
+        assertEquals(departments, departments2)
+        val list = db.runQuery {
+            QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
+        }
+        assertEquals(2, list.size)
+        assertEquals(
+            listOf("DEVELOPMENT" to "KYOTO", "PLANNING" to "TOKYO"),
+            list.map { it.departmentName to it.location },
+        )
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyIgnore(info: TestInfo) = inTransaction(db, info) {
+        val d = Meta.department
+        val department1 = Department(5, 50, "PLANNING", "TOKYO", 1)
+        val department2 = Department(1, 60, "DEVELOPMENT", "KYOTO", 1)
+        val query = QueryDsl.insert(d).onDuplicateKeyIgnore().multiple(listOf(department1, department2)).returning()
+        val departments = db.runQuery { query }
+        assertEquals(listOf(department1), departments)
+        val list = db.runQuery {
+            QueryDsl.from(d).where { d.departmentId inList listOf(1, 5) }.orderBy(d.departmentId)
+        }
+        assertEquals(2, list.size)
+        assertEquals(
+            listOf("ACCOUNTING" to "NEW YORK", "PLANNING" to "TOKYO"),
+            list.map { it.departmentName to it.location },
+        )
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_insertReturning(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val addressList = listOf(
+            Address(16, "STREET 16", 0),
+            Address(17, "STREET 17", 0),
+            Address(18, "STREET 18", 0),
+        )
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.insert(a).multiple(addressList).returning() }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_onDuplicateKeyUpdate_insertReturning(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val addressList = listOf(
+            Address(16, "STREET 16", 0),
+            Address(17, "STREET 17", 0),
+            Address(18, "STREET 18", 0),
+        )
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.insert(a).onDuplicateKeyUpdate().multiple(addressList).returning() }
+            Unit
+        }
+        println(ex)
+    }
+}

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleReturningTest.kt
@@ -1,0 +1,185 @@
+package integration.r2dbc
+
+import integration.core.Address
+import integration.core.Dbms
+import integration.core.Department
+import integration.core.IdentityStrategy
+import integration.core.Run
+import integration.core.SequenceStrategy
+import integration.core.address
+import integration.core.department
+import integration.core.identityStrategy
+import integration.core.sequenceStrategy
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.UniqueConstraintException
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.core.dsl.operator.concat
+import org.komapper.core.dsl.query.first
+import org.komapper.r2dbc.R2dbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@ExtendWith(R2dbcEnv::class)
+class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun test(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val address2 = db.runQuery { QueryDsl.insert(a).single(address).returning() }
+        assertEquals(address, address2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun uniqueConstraintException(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = Address(1, "STREET 1", 0)
+        assertFailsWith<UniqueConstraintException> {
+            db.runQuery { QueryDsl.insert(a).single(address).returning() }.let { }
+        }
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun sequenceGenerator(info: TestInfo) = inTransaction(db, info) {
+        val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
+        generator.clear()
+
+        for (i in 1..201) {
+            val m = Meta.sequenceStrategy
+            val strategy = SequenceStrategy(0, "test")
+            val result = db.runQuery { QueryDsl.insert(m).single(strategy) }
+            assertEquals(i, result.id)
+        }
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun identityGenerator(info: TestInfo) = inTransaction(db, info) {
+        for (i in 1..201) {
+            val m = Meta.identityStrategy
+            val strategy = IdentityStrategy(0, "test")
+            val result = db.runQuery { QueryDsl.insert(m).single(strategy).returning() }
+            assertEquals(i, result.id, "i = $i")
+        }
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdate_insert(info: TestInfo) = inTransaction(db, info) {
+        val d = Meta.department
+        val department = Department(5, 50, "PLANNING", "TOKYO", 0)
+        val query = QueryDsl.insert(d).onDuplicateKeyUpdate().single(department).returning()
+        val department2 = db.runQuery { query }
+        assertEquals(department, department2)
+        val found = db.runQuery { QueryDsl.from(d).where { d.departmentId eq 5 }.first() }
+        assertNotNull(found)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdate_update(info: TestInfo) = inTransaction(db, info) {
+        val d = Meta.department
+        val department = Department(1, 50, "PLANNING", "TOKYO", 10)
+        val query = QueryDsl.insert(d).onDuplicateKeyUpdate().single(department).returning()
+        val department2 = db.runQuery { query }
+        assertEquals(department, department2)
+        val found = db.runQuery { QueryDsl.from(d).where { d.departmentId eq 1 }.first() }
+        assertEquals(50, found.departmentNo)
+        assertEquals("PLANNING", found.departmentName)
+        assertEquals("TOKYO", found.location)
+        assertEquals(10, found.version)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdateWithKey_update_set_where_success(info: TestInfo) = inTransaction(db, info) {
+        val d = Meta.department
+        val department = Department(5, 10, "PLANNING", "TOKYO", 10)
+        val query = QueryDsl.insert(d)
+            .onDuplicateKeyUpdate(d.departmentNo)
+            .set { excluded ->
+                d.departmentName eq "PLANNING2"
+                d.location eq concat(d.location, concat("_", excluded.location))
+            }.where {
+                d.location eq "NEW YORK"
+            }.single(department).returning()
+        val department2 = db.runQuery { query }
+        assertNotNull(department2)
+        val found = db.runQuery { QueryDsl.from(d).where { d.departmentNo eq 10 }.first() }
+        assertEquals(department2, found)
+        assertEquals(1, found.departmentId)
+        assertEquals("PLANNING2", found.departmentName)
+        assertEquals("NEW YORK_TOKYO", found.location)
+        assertEquals(1, found.version)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdateWithKey_update_set_where_fail(info: TestInfo) = inTransaction(db, info) {
+        val d = Meta.department
+        val department = Department(5, 10, "PLANNING", "TOKYO", 10)
+        val query = QueryDsl.insert(d)
+            .onDuplicateKeyUpdate(d.departmentNo)
+            .set { excluded ->
+                d.departmentName eq "PLANNING2"
+                d.location eq concat(d.location, concat("_", excluded.location))
+            }.where {
+                d.location eq "KYOTO"
+            }.single(department).returning()
+        val department2 = db.runQuery { query }
+        assertNull(department2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyIgnore_inserted(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val query = QueryDsl.insert(a).onDuplicateKeyIgnore().single(address).returning()
+        val address2 = db.runQuery { query }
+        assertEquals(address, address2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyIgnore_ignored(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = Address(1, "STREET 100", 0)
+        val query = QueryDsl.insert(a).onDuplicateKeyIgnore().single(address).returning()
+        val address2 = db.runQuery { query }
+        assertNull(address2)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_insertReturning(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.insert(a).single(address).returning() }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_onDuplicateKeyUpdate_insertReturning(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.insert(a).onDuplicateKeyUpdate().single(address).returning() }
+            Unit
+        }
+        println(ex)
+    }
+}

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleReturningTest.kt
@@ -28,7 +28,7 @@ import kotlin.test.assertNull
 @ExtendWith(R2dbcEnv::class)
 class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -37,7 +37,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(address, address2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -46,7 +46,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(address.street, street)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -56,7 +56,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(address.version, version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -67,7 +67,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(address.addressId, addressId)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun uniqueConstraintException(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -77,7 +77,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun sequenceGenerator(info: TestInfo) = inTransaction(db, info) {
         val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
@@ -91,7 +91,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun identityGenerator(info: TestInfo) = inTransaction(db, info) {
         for (i in 1..201) {
@@ -102,7 +102,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdate_insert(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -114,7 +114,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         assertNotNull(found)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdate_update(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -129,7 +129,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(10, found.version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateWithKey_update_set_where_success(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -152,7 +152,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(1, found.version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyUpdateWithKey_update_set_where_fail(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
@@ -169,7 +169,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         assertNull(department2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnore_inserted(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -179,7 +179,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(address, address2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun onDuplicateKeyIgnore_ignored(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -189,7 +189,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         assertNull(address2)
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_insertReturning(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -201,7 +201,7 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
         println(ex)
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_onDuplicateKeyUpdate_insertReturning(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleReturningTest.kt
@@ -39,6 +39,36 @@ class R2dbcInsertSingleReturningTest(private val db: R2dbcDatabase) {
 
     @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
     @Test
+    fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val street = db.runQuery { QueryDsl.insert(a).single(address).returning(a.street) }
+        assertEquals(address.street, street)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val (street, version) = db.runQuery { QueryDsl.insert(a).single(address).returning(a.street, a.version) }
+        assertEquals(address.street, street)
+        assertEquals(address.version, version)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = Address(16, "STREET 16", 0)
+        val (street, version, addressId) = db.runQuery { QueryDsl.insert(a).single(address).returning(a.street, a.version, a.addressId) }
+        assertEquals(address.street, street)
+        assertEquals(address.version, version)
+        assertEquals(address.addressId, addressId)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
     fun uniqueConstraintException(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
         val address = Address(1, "STREET 1", 0)

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleTest.kt
@@ -33,6 +33,7 @@ import org.komapper.core.ClockProvider
 import org.komapper.core.UniqueConstraintException
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.metamodel.IdGenerator
 import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.query.first
 import org.komapper.r2dbc.R2dbcDatabase
@@ -244,6 +245,9 @@ class R2dbcInsertSingleTest(private val db: R2dbcDatabase) {
     @Run(unless = [Dbms.MYSQL])
     @Test
     fun sequenceGenerator(info: TestInfo) = inTransaction(db, info) {
+        val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
+        generator.clear()
+
         for (i in 1..201) {
             val m = Meta.sequenceStrategy
             val strategy = SequenceStrategy(0, "test")

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertValuesReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertValuesReturningTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertFailsWith
 @ExtendWith(R2dbcEnv::class)
 class R2dbcInsertValuesReturningTest(private val db: R2dbcDatabase) {
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -36,7 +36,7 @@ class R2dbcInsertValuesReturningTest(private val db: R2dbcDatabase) {
         assertEquals(Address(19, "STREET 16", 0), address)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -50,7 +50,7 @@ class R2dbcInsertValuesReturningTest(private val db: R2dbcDatabase) {
         assertEquals("STREET 16", street)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -65,7 +65,7 @@ class R2dbcInsertValuesReturningTest(private val db: R2dbcDatabase) {
         assertEquals(0, version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -81,7 +81,7 @@ class R2dbcInsertValuesReturningTest(private val db: R2dbcDatabase) {
         assertEquals(19, addressId)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun generatedKeys_autoIncrement(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.identityStrategy
@@ -94,7 +94,7 @@ class R2dbcInsertValuesReturningTest(private val db: R2dbcDatabase) {
         assertEquals(IdentityStrategy(1, "test"), strategy)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun generatedKeys_sequence(info: TestInfo) = inTransaction(db, info) {
         val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
@@ -109,7 +109,7 @@ class R2dbcInsertValuesReturningTest(private val db: R2dbcDatabase) {
         assertEquals(SequenceStrategy(1, "test"), strategy)
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertValuesReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertValuesReturningTest.kt
@@ -1,0 +1,139 @@
+package integration.r2dbc
+
+import integration.core.Address
+import integration.core.Dbms
+import integration.core.IdentityStrategy
+import integration.core.Run
+import integration.core.SequenceStrategy
+import integration.core.address
+import integration.core.identityStrategy
+import integration.core.sequenceStrategy
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dryRunQuery
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.r2dbc.R2dbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@ExtendWith(R2dbcEnv::class)
+class R2dbcInsertValuesReturningTest(private val db: R2dbcDatabase) {
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun test(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.addressId eq 19
+                a.street eq "STREET 16"
+                a.version eq 0
+            }.returning()
+        }
+        assertEquals(Address(19, "STREET 16", 0), address)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val street = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.addressId eq 19
+                a.street eq "STREET 16"
+                a.version eq 0
+            }.returning(a.street)
+        }
+        assertEquals("STREET 16", street)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val (street, version) = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.addressId eq 19
+                a.street eq "STREET 16"
+                a.version eq 0
+            }.returning(a.street, a.version)
+        }
+        assertEquals("STREET 16", street)
+        assertEquals(0, version)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val (street, version, addressId) = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.addressId eq 19
+                a.street eq "STREET 16"
+                a.version eq 0
+            }.returning(a.street, a.version, a.addressId)
+        }
+        assertEquals("STREET 16", street)
+        assertEquals(0, version)
+        assertEquals(19, addressId)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun generatedKeys_autoIncrement(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.identityStrategy
+        val strategy = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.id eq 10
+                a.value eq "test"
+            }.returning()
+        }
+        assertEquals(IdentityStrategy(1, "test"), strategy)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun generatedKeys_sequence(info: TestInfo) = inTransaction(db, info) {
+        val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
+        generator.clear()
+
+        val a = Meta.sequenceStrategy
+        val strategy = db.runQuery {
+            QueryDsl.insert(a).values {
+                a.value eq "test"
+            }.returning()
+        }
+        assertEquals(SequenceStrategy(1, "test"), strategy)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery {
+                QueryDsl.insert(a).values {
+                    a.addressId eq 19
+                    a.street eq "STREET 16"
+                    a.version eq 0
+                }.returning()
+            }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Test
+    fun dryRun() {
+        val a = Meta.address
+        val query = QueryDsl.insert(a).values {
+            a.addressId eq 19
+            a.street eq "STREET 16"
+            a.version eq 0
+        }.returning()
+        println(db.dryRunQuery(query))
+    }
+}

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSetReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSetReturningTest.kt
@@ -1,0 +1,174 @@
+package integration.r2dbc
+
+import integration.core.Dbms
+import integration.core.Run
+import integration.core.address
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dryRunQuery
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.query.first
+import org.komapper.r2dbc.R2dbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+@ExtendWith(R2dbcEnv::class)
+class R2dbcUpdateSetReturningTest(private val db: R2dbcDatabase) {
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun test(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val list = db.runQuery {
+            QueryDsl.update(a).set {
+                a.street eq "STREET 16"
+            }.where {
+                a.addressId eq 1
+            }.returning()
+        }
+        assertEquals(1, list.size)
+        val address = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 1
+            }.first()
+        }
+        assertEquals(list.single(), address)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val list = db.runQuery {
+            QueryDsl.update(a).set {
+                a.street eq "STREET 16"
+            }.where {
+                a.addressId eq 1
+            }.returning(a.street)
+        }
+        assertEquals(1, list.size)
+        val address = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 1
+            }.first()
+        }
+        assertEquals(list.single(), address.street)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val list = db.runQuery {
+            QueryDsl.update(a).set {
+                a.street eq "STREET 16"
+            }.where {
+                a.addressId eq 1
+            }.returning(a.street, a.version)
+        }
+        assertEquals(1, list.size)
+        val address = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 1
+            }.first()
+        }
+        assertEquals(list.single(), address.street to address.version)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val list = db.runQuery {
+            QueryDsl.update(a).set {
+                a.street eq "STREET 16"
+            }.where {
+                a.addressId eq 1
+            }.returning(a.street, a.version, a.addressId)
+        }
+        assertEquals(1, list.size)
+        val address = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 1
+            }.first()
+        }
+        assertEquals(list.single(), Triple(address.street, address.version, address.addressId))
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testMultipleUpdate(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val list = db.runQuery {
+            QueryDsl.update(a).set {
+                a.version eq 100
+            }.where {
+                a.addressId inList listOf(1, 2)
+            }.returning()
+        }
+        assertEquals(2, list.size)
+        val list2 = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId inList listOf(1, 2)
+            }
+        }
+        assertTrue(list.all { it.version == 100 })
+        assertEquals(list.toSet(), list2.toSet())
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun incrementVersion_auto(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address1 = db.runQuery { QueryDsl.from(a).where { a.addressId eq 1 }.first() }
+        assertEquals(1, address1.version)
+
+        val versions = db.runQuery {
+            QueryDsl.update(a).set {
+                a.street eq "STREET 16"
+            }.where {
+                a.addressId eq 1
+            }.returning(a.version)
+        }
+        assertEquals(1, versions.size)
+        assertEquals(2, versions.single())
+
+        val address2 = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 1
+            }.first()
+        }
+        assertEquals(2, address2.version)
+    }
+
+    @Run(unless = [Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_updateReturning(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery {
+                QueryDsl.update(a).set {
+                    a.street eq "STREET 16"
+                }.where {
+                    a.addressId eq 1
+                }.returning()
+            }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Test
+    fun dryRun() {
+        val a = Meta.address
+        val query = QueryDsl.update(a).set {
+            a.street eq "STREET 16"
+        }.where {
+            a.addressId eq 1
+        }.returning()
+        println(db.dryRunQuery(query))
+    }
+}

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSetReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSetReturningTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertTrue
 @ExtendWith(R2dbcEnv::class)
 class R2dbcUpdateSetReturningTest(private val db: R2dbcDatabase) {
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -38,7 +38,7 @@ class R2dbcUpdateSetReturningTest(private val db: R2dbcDatabase) {
         assertEquals(list.single(), address)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -58,7 +58,7 @@ class R2dbcUpdateSetReturningTest(private val db: R2dbcDatabase) {
         assertEquals(list.single(), address.street)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -78,7 +78,7 @@ class R2dbcUpdateSetReturningTest(private val db: R2dbcDatabase) {
         assertEquals(list.single(), address.street to address.version)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -98,7 +98,7 @@ class R2dbcUpdateSetReturningTest(private val db: R2dbcDatabase) {
         assertEquals(list.single(), Triple(address.street, address.version, address.addressId))
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testMultipleUpdate(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -119,7 +119,7 @@ class R2dbcUpdateSetReturningTest(private val db: R2dbcDatabase) {
         assertEquals(list.toSet(), list2.toSet())
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun incrementVersion_auto(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -144,7 +144,7 @@ class R2dbcUpdateSetReturningTest(private val db: R2dbcDatabase) {
         assertEquals(2, address2.version)
     }
 
-    @Run(unless = [Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_updateReturning(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleReturningTest.kt
@@ -1,0 +1,76 @@
+package integration.r2dbc
+
+import integration.core.Address
+import integration.core.Dbms
+import integration.core.Run
+import integration.core.address
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.OptimisticLockException
+import org.komapper.core.UniqueConstraintException
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.query.first
+import org.komapper.core.dsl.query.firstOrNull
+import org.komapper.core.dsl.query.single
+import org.komapper.r2dbc.R2dbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@ExtendWith(R2dbcEnv::class)
+class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun test(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val newAddress = address.copy(street = "NY street")
+        val returningAddress = db.runQuery { QueryDsl.update(a).single(newAddress).returning() }
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertEquals(
+            Address(
+                15,
+                "NY street",
+                2,
+            ),
+            address2,
+        )
+        assertEquals(address2, returningAddress)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun uniqueConstraintException(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = Address(1, "STREET 2", 1)
+        assertFailsWith<UniqueConstraintException> {
+            db.runQuery { QueryDsl.update(a).single(address).returning() }.let { }
+        }
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun optimisticLockException(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 15 }.first() }
+        db.runQuery { QueryDsl.update(a).single(address) }
+        assertFailsWith<OptimisticLockException> {
+            db.runQuery { QueryDsl.update(a).single(address).returning() }.let {}
+        }
+    }
+
+    @Run(unless = [Dbms.POSTGRESQL])
+    @Test
+    fun unsupportedOperationException_updateReturning(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = db.runQuery { QueryDsl.from(a).where { a.addressId eq 15 }.single() }
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.update(a).single(address.copy(street = "STREET 123")).returning() }
+            Unit
+        }
+        println(ex)
+    }
+}

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleReturningTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertNull
 @ExtendWith(R2dbcEnv::class)
 class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -42,7 +42,7 @@ class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(address2, returningAddress)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -62,7 +62,7 @@ class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -82,7 +82,7 @@ class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -102,7 +102,7 @@ class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun suppressOptimisticLockException(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -113,7 +113,7 @@ class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
         assertNull(returningAddress)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun uniqueConstraintException(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -123,7 +123,7 @@ class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun optimisticLockException(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
@@ -134,7 +134,7 @@ class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
         }
     }
 
-    @Run(unless = [Dbms.POSTGRESQL])
+    @Run(unless = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_updateReturning(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleReturningTest.kt
@@ -17,6 +17,7 @@ import org.komapper.r2dbc.R2dbcDatabase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 @ExtendWith(R2dbcEnv::class)
 class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
@@ -39,6 +40,77 @@ class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
             address2,
         )
         assertEquals(address2, returningAddress)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val newAddress = address.copy(street = "NY street")
+        val street = db.runQuery { QueryDsl.update(a).single(newAddress).returning(a.street) }
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertEquals("NY street", street)
+        assertEquals(
+            Address(
+                15,
+                "NY street",
+                2,
+            ),
+            address2,
+        )
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val newAddress = address.copy(street = "NY street")
+        val pair = db.runQuery { QueryDsl.update(a).single(newAddress).returning(a.street, a.version) }
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertEquals("NY street" to 2, pair)
+        assertEquals(
+            Address(
+                15,
+                "NY street",
+                2,
+            ),
+            address2,
+        )
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val newAddress = address.copy(street = "NY street")
+        val triple = db.runQuery { QueryDsl.update(a).single(newAddress).returning(a.street, a.version, a.addressId) }
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertEquals(Triple("NY street", 2, 15), triple)
+        assertEquals(
+            Address(
+                15,
+                "NY street",
+                2,
+            ),
+            address2,
+        )
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun suppressOptimisticLockException(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val newAddress = address.copy(street = "NY street", version = address.version + 1)
+        val returningAddress = db.runQuery { QueryDsl.update(a).single(newAddress).returning().options { it.copy(suppressOptimisticLockException = true) } }
+        assertNull(returningAddress)
     }
 
     @Run(onlyIf = [Dbms.POSTGRESQL])

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -8,10 +8,14 @@ import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilderImpl
+import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
+import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.context.RelationUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import java.util.regex.Pattern
 
@@ -178,6 +182,20 @@ interface Dialect {
         context: EntityUpsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
     ): EntityUpsertStatementBuilder<ENTITY>
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+    ): RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+        return RelationInsertValuesStatementBuilder(dialect, context)
+    }
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationUpdateStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationUpdateContext<ENTITY, ID, META>,
+    ): RelationUpdateStatementBuilder<ENTITY, ID, META> {
+        return RelationUpdateStatementBuilder(dialect, context)
+    }
 
     /**
      * Returns the default length argument for the SUBSTRING function.

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -1,13 +1,16 @@
 package org.komapper.core
 
 import org.komapper.core.dsl.builder.DefaultEntityInsertStatementBuilder
+import org.komapper.core.dsl.builder.DefaultEntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.DryRunSchemaStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
+import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilderImpl
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import java.util.regex.Pattern
@@ -149,6 +152,14 @@ interface Dialect {
         entities: List<ENTITY>,
     ): EntityInsertStatementBuilder<ENTITY, ID, META> {
         return DefaultEntityInsertStatementBuilder(dialect, context, entities)
+    }
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpdateStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): EntityUpdateStatementBuilder<ENTITY, ID, META> {
+        return DefaultEntityUpdateStatementBuilder(dialect, context, entity)
     }
 
     /**
@@ -306,6 +317,8 @@ interface Dialect {
      * Returns whether the table hint is supported.
      */
     fun supportsTableHint(): Boolean = false
+
+    fun supportsUpdateReturning(): Boolean = false
 }
 
 object DryRunDialect : Dialect {

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -230,6 +230,8 @@ interface Dialect {
      */
     fun supportsGeneratedKeysReturningWhenInsertingMultipleRows(): Boolean = true
 
+    fun supportsInsertReturning(): Boolean = false
+
     /**
      * Returns whether the INTERSECT set operation is supported.
      */

--- a/komapper-core/src/main/kotlin/org/komapper/core/Statement.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Statement.kt
@@ -61,7 +61,7 @@ data class Statement(val parts: List<StatementPart>) {
         }
     }
 
-/**
+    /**
      * Adds a part of the SQL statement.
      *
      * @param text a part of the SQL statement

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/EntityUpdateStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/EntityUpdateStatementBuilder.kt
@@ -9,15 +9,19 @@ import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
-class EntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+interface EntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> {
+    fun build(): Statement
+}
+
+class DefaultEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val dialect: BuilderDialect,
     private val context: EntityUpdateContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) {
+) : EntityUpdateStatementBuilder<ENTITY, ID, META> {
     private val buf = StatementBuffer()
     private val support = BuilderSupport(dialect, EmptyAliasManager, buf)
 
-    fun build(): Statement {
+    override fun build(): Statement {
         val target = context.target
         val idProperties = target.idProperties()
         val versionProperty = target.versionProperty()

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/RelationInsertValuesStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/RelationInsertValuesStatementBuilder.kt
@@ -9,15 +9,26 @@ import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 
-class RelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+interface RelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> {
+    fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement
+}
+
+fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> RelationInsertValuesStatementBuilder(
+    dialect: BuilderDialect,
+    context: RelationInsertValuesContext<ENTITY, ID, META>,
+): RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+    return DefaultRelationInsertValuesStatementBuilder(dialect, context)
+}
+
+internal class DefaultRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val dialect: BuilderDialect,
     private val context: RelationInsertValuesContext<ENTITY, ID, META>,
-) {
+) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
     private val aliasManager = DefaultAliasManager(context)
     private val buf = StatementBuffer()
     private val support = BuilderSupport(dialect, aliasManager, buf)
 
-    fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+    override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         val target = context.target
         buf.append("insert into ")
         table(target)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/RelationInsertValuesStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/RelationInsertValuesStatementBuilder.kt
@@ -20,49 +20,66 @@ fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> RelationI
     return DefaultRelationInsertValuesStatementBuilder(dialect, context)
 }
 
-internal class DefaultRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+class DefaultRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val dialect: BuilderDialect,
     private val context: RelationInsertValuesContext<ENTITY, ID, META>,
 ) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+
     private val aliasManager = DefaultAliasManager(context)
-    private val buf = StatementBuffer()
-    private val support = BuilderSupport(dialect, aliasManager, buf)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
-        val target = context.target
-        buf.append("insert into ")
-        table(target)
-        buf.append(" (")
-        if (assignments.isNotEmpty()) {
-            for ((property, _) in assignments) {
-                column(property)
-                buf.append(", ")
-            }
-        }
-        buf.cutBack(2)
-        buf.append(") values (")
-        if (assignments.isNotEmpty()) {
-            for ((_, operand) in assignments) {
-                operand(operand)
-                buf.append(", ")
-            }
-        }
-        buf.cutBack(2)
-        buf.append(")")
+        val buf = StatementBuffer()
+        buf.append(buildInsertInto(assignments))
+        buf.append(" ")
+        buf.append(buildValues(assignments))
         return buf.toStatement()
     }
 
-    private fun table(metamodel: EntityMetamodel<*, *, *>) {
+    fun buildInsertInto(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        val target = context.target
+        return with(StatementBuffer()) {
+            append("insert into ")
+            table(target)
+            append(" (")
+            if (assignments.isNotEmpty()) {
+                for ((property, _) in assignments) {
+                    column(property)
+                    append(", ")
+                }
+            }
+            cutBack(2)
+            append(")")
+            toStatement()
+        }
+    }
+
+    fun buildValues(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        return with(StatementBuffer()) {
+            val support = BuilderSupport(dialect, aliasManager, this)
+            append("values (")
+            if (assignments.isNotEmpty()) {
+                for ((_, operand) in assignments) {
+                    operand(operand, support)
+                    append(", ")
+                }
+            }
+            cutBack(2)
+            append(")")
+            toStatement()
+        }
+    }
+
+    private fun StatementBuffer.table(metamodel: EntityMetamodel<*, *, *>) {
         val name = metamodel.getCanonicalTableName(dialect::enquote)
-        buf.append(name)
+        append(name)
     }
 
-    private fun column(expression: ColumnExpression<*, *>) {
+    private fun StatementBuffer.column(expression: ColumnExpression<*, *>) {
         val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
+        append(name)
     }
 
-    private fun operand(operand: Operand) {
+    private fun operand(operand: Operand, support: BuilderSupport) {
         support.visitOperand(operand)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/RelationUpdateStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/RelationUpdateStatementBuilder.kt
@@ -11,10 +11,21 @@ import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 
-class RelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+interface RelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> {
+    fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement
+}
+
+fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> RelationUpdateStatementBuilder(
+    dialect: BuilderDialect,
+    context: RelationUpdateContext<ENTITY, ID, META>,
+): RelationUpdateStatementBuilder<ENTITY, ID, META> {
+    return DefaultRelationUpdateStatementBuilder(dialect, context)
+}
+
+internal class DefaultRelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val dialect: BuilderDialect,
     private val context: RelationUpdateContext<ENTITY, ID, META>,
-) {
+) : RelationUpdateStatementBuilder<ENTITY, ID, META> {
 
     private val aliasManager = if (dialect.supportsAliasForUpdateStatement()) {
         DefaultAliasManager(context)
@@ -25,7 +36,7 @@ class RelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamo
     private val buf = StatementBuffer()
     private val support = BuilderSupport(dialect, aliasManager, buf, context.options.escapeSequence)
 
-    fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+    override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         buf.append("update ")
         table(context.target)
         buf.append(" set ")

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
@@ -1,7 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
-import org.komapper.core.dsl.element.Output
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.expression.TableExpression
@@ -12,9 +12,9 @@ import org.komapper.core.dsl.options.InsertOptions
 @ThreadSafe
 data class EntityInsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
-    val returning: Output = Output.Expressions(emptyList()),
+    override val returning: Returning = Returning.Expressions(emptyList()),
     val options: InsertOptions = InsertOptions.DEFAULT,
-) : TablesProvider {
+) : TablesProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {
         return setOf(target)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
@@ -48,6 +48,7 @@ data class EntityInsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
         return RelationInsertValuesContext(
             target = target,
             values = declaration,
+            returning = returning,
             options = options,
         )
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
@@ -11,6 +11,7 @@ import org.komapper.core.dsl.options.InsertOptions
 @ThreadSafe
 data class EntityInsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
+    val returning: Boolean = false,
     val options: InsertOptions = InsertOptions.DEFAULT,
 ) : TablesProvider {
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.element.Output
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.expression.TableExpression
@@ -11,7 +12,7 @@ import org.komapper.core.dsl.options.InsertOptions
 @ThreadSafe
 data class EntityInsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
-    val returning: Boolean = false,
+    val returning: Output = Output.Expressions(emptyList()),
     val options: InsertOptions = InsertOptions.DEFAULT,
 ) : TablesProvider {
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpdateContext.kt
@@ -1,7 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
-import org.komapper.core.dsl.element.Output
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.expression.WhereDeclaration
@@ -15,9 +15,9 @@ data class EntityUpdateContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     val target: META,
     val includedProperties: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
     val excludedProperties: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
-    val returning: Output = Output.Expressions(emptyList()),
+    override val returning: Returning = Returning.Expressions(emptyList()),
     override val options: UpdateOptions = UpdateOptions.DEFAULT,
-) : TablesProvider, WhereProvider {
+) : TablesProvider, WhereProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {
         return setOf(target)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpdateContext.kt
@@ -14,6 +14,7 @@ data class EntityUpdateContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     val target: META,
     val includedProperties: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
     val excludedProperties: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
+    val returning: Boolean = false,
     override val options: UpdateOptions = UpdateOptions.DEFAULT,
 ) : TablesProvider, WhereProvider {
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpdateContext.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.element.Output
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.expression.WhereDeclaration
@@ -14,7 +15,7 @@ data class EntityUpdateContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     val target: META,
     val includedProperties: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
     val excludedProperties: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
-    val returning: Boolean = false,
+    val returning: Output = Output.Expressions(emptyList()),
     override val options: UpdateOptions = UpdateOptions.DEFAULT,
 ) : TablesProvider, WhereProvider {
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
@@ -6,6 +6,7 @@ import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
+import org.komapper.core.dsl.options.InsertOptions
 import org.komapper.core.dsl.options.WhereOptions
 
 @ThreadSafe
@@ -25,6 +26,7 @@ data class EntityUpsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     val duplicateKeyType: DuplicateKeyType,
     val set: AssignmentDeclaration<ENTITY, META> = {},
     val where: WhereDeclaration = {},
+    val returning: Boolean = false,
 ) : WhereProvider, TablesProvider {
 
     override val options: WhereOptions
@@ -36,6 +38,12 @@ data class EntityUpsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
 
     override fun getCompositeWhere(): WhereDeclaration {
         return where
+    }
+
+    internal fun copyConfigure(configure: (InsertOptions) -> InsertOptions): EntityUpsertContext<ENTITY, ID, META> {
+        val options = configure(this.insertContext.options)
+        val insertContext = this.insertContext.copy(options = options)
+        return this.copy(insertContext = insertContext)
     }
 }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
@@ -1,7 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
-import org.komapper.core.dsl.element.Output
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.expression.WhereDeclaration
@@ -27,8 +27,8 @@ data class EntityUpsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     val duplicateKeyType: DuplicateKeyType,
     val set: AssignmentDeclaration<ENTITY, META> = {},
     val where: WhereDeclaration = {},
-    val returning: Output = Output.Expressions(emptyList()),
-) : WhereProvider, TablesProvider {
+    override val returning: Returning = Returning.Expressions(emptyList()),
+) : WhereProvider, TablesProvider, ReturningProvider {
 
     override val options: WhereOptions
         get() = insertContext.options

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.element.Output
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.expression.WhereDeclaration
@@ -26,7 +27,7 @@ data class EntityUpsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     val duplicateKeyType: DuplicateKeyType,
     val set: AssignmentDeclaration<ENTITY, META> = {},
     val where: WhereDeclaration = {},
-    val returning: Boolean = false,
+    val returning: Output = Output.Expressions(emptyList()),
 ) : WhereProvider, TablesProvider {
 
     override val options: WhereOptions

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationInsertValuesContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationInsertValuesContext.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.element.Output
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -10,6 +11,7 @@ import org.komapper.core.dsl.options.InsertOptions
 data class RelationInsertValuesContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
     val values: AssignmentDeclaration<ENTITY, META>,
+    val returning: Output = Output.Expressions(emptyList()),
     val options: InsertOptions,
 ) : TablesProvider {
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationInsertValuesContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationInsertValuesContext.kt
@@ -1,7 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
-import org.komapper.core.dsl.element.Output
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -11,9 +11,9 @@ import org.komapper.core.dsl.options.InsertOptions
 data class RelationInsertValuesContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
     val values: AssignmentDeclaration<ENTITY, META>,
-    val returning: Output = Output.Expressions(emptyList()),
+    override val returning: Returning = Returning.Expressions(emptyList()),
     val options: InsertOptions,
-) : TablesProvider {
+) : TablesProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {
         return setOf(target)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationUpdateContext.kt
@@ -1,7 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
-import org.komapper.core.dsl.element.Output
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.expression.WhereDeclaration
@@ -15,9 +15,9 @@ data class RelationUpdateContext<ENTITY : Any, ID : Any, META : EntityMetamodel<
     val target: META,
     val set: AssignmentDeclaration<ENTITY, META> = {},
     val where: WhereDeclaration = { },
-    val returning: Output = Output.Expressions(emptyList()),
+    override val returning: Returning = Returning.Expressions(emptyList()),
     override val options: UpdateOptions = UpdateOptions.DEFAULT,
-) : TablesProvider, WhereProvider {
+) : TablesProvider, WhereProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {
         return setOf(target)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationUpdateContext.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.element.Output
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.expression.WhereDeclaration
@@ -14,6 +15,7 @@ data class RelationUpdateContext<ENTITY : Any, ID : Any, META : EntityMetamodel<
     val target: META,
     val set: AssignmentDeclaration<ENTITY, META> = {},
     val where: WhereDeclaration = { },
+    val returning: Output = Output.Expressions(emptyList()),
     override val options: UpdateOptions = UpdateOptions.DEFAULT,
 ) : TablesProvider, WhereProvider {
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/ReturningProvider.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/ReturningProvider.kt
@@ -1,0 +1,7 @@
+package org.komapper.core.dsl.context
+
+import org.komapper.core.dsl.element.Returning
+
+interface ReturningProvider {
+    val returning: Returning
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Output.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Output.kt
@@ -1,0 +1,18 @@
+package org.komapper.core.dsl.element
+
+import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+@ThreadSafe
+sealed class Output {
+    data class Expressions(val expressions: List<ColumnExpression<*, *>>) : Output()
+    data class Metamodel(val metamodel: EntityMetamodel<*, *, *>) : Output()
+
+    fun expressions(): List<ColumnExpression<*, *>> {
+        return when (this) {
+            is Expressions -> this.expressions
+            is Metamodel -> this.metamodel.properties()
+        }
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Returning.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/element/Returning.kt
@@ -5,9 +5,9 @@ import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 @ThreadSafe
-sealed class Output {
-    data class Expressions(val expressions: List<ColumnExpression<*, *>>) : Output()
-    data class Metamodel(val metamodel: EntityMetamodel<*, *, *>) : Output()
+sealed class Returning {
+    data class Expressions(val expressions: List<ColumnExpression<*, *>>) : Returning()
+    data class Metamodel(val metamodel: EntityMetamodel<*, *, *>) : Returning()
 
     fun expressions(): List<ColumnExpression<*, *>> {
         return when (this) {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/IdGenerator.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/IdGenerator.kt
@@ -50,5 +50,9 @@ sealed class IdGenerator<ENTITY : Any, ID : Any> {
             return listOf(catalogName, schemaName, name)
                 .filter { it.isNotBlank() }.joinToString(".", transform = transform)
         }
+
+        fun clear() {
+            idContextMap.clear()
+        }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertQuery.kt
@@ -1,7 +1,9 @@
 package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.element.Output
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.options.InsertOptions
 import org.komapper.core.dsl.visitor.QueryVisitor
 
@@ -32,6 +34,12 @@ interface EntityInsertSingleQuery<ENTITY : Any> : EntityInsertQuery<ENTITY> {
      */
     fun returning(): EntityInsertReturningQuery<ENTITY>
 
+    fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityInsertReturningQuery<A?>
+
+    fun <A : Any, B : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>): EntityInsertReturningQuery<Pair<A?, B?>>
+
+    fun <A : Any, B : Any, C : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>, expression3: PropertyMetamodel<ENTITY, C, *>): EntityInsertReturningQuery<Triple<A?, B?, C?>>
+
     override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertSingleQuery<ENTITY>
 }
 
@@ -46,6 +54,12 @@ interface EntityInsertMultipleQuery<ENTITY : Any> : EntityInsertQuery<List<ENTIT
      */
     fun returning(): EntityInsertReturningQuery<List<ENTITY>>
 
+    fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityInsertReturningQuery<List<A?>>
+
+    fun <A : Any, B : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>): EntityInsertReturningQuery<List<Pair<A?, B?>>>
+
+    fun <A : Any, B : Any, C : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>, expression3: PropertyMetamodel<ENTITY, C, *>): EntityInsertReturningQuery<List<Triple<A?, B?, C?>>>
+
     override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertMultipleQuery<ENTITY>
 }
 
@@ -54,8 +68,32 @@ internal data class EntityInsertSingleQueryImpl<ENTITY : Any, ID : Any, META : E
     private val entity: ENTITY,
 ) : EntityInsertSingleQuery<ENTITY> {
     override fun returning(): EntityInsertReturningQuery<ENTITY> {
-        val newContext = context.copy(returning = true)
+        val newContext = context.copy(returning = Output.Metamodel(context.target))
         return EntityInsertSingleReturningQuery(newContext, entity)
+    }
+
+    override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityInsertReturningQuery<A?> {
+        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        return EntityInsertSingleReturningSingleColumnQuery(newContext, entity, expression)
+    }
+
+    override fun <A : Any, B : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+    ): EntityInsertReturningQuery<Pair<A?, B?>> {
+        val expressions = expression1 to expression2
+        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        return EntityInsertSingleReturningPairColumnsQuery(newContext, entity, expressions)
+    }
+
+    override fun <A : Any, B : Any, C : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+        expression3: PropertyMetamodel<ENTITY, C, *>,
+    ): EntityInsertReturningQuery<Triple<A?, B?, C?>> {
+        val expressions = Triple(expression1, expression2, expression3)
+        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        return EntityInsertSingleReturningTripleColumnsQuery(newContext, entity, expressions)
     }
 
     override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertSingleQuery<ENTITY> {
@@ -73,8 +111,32 @@ internal data class EntityInsertMultipleQueryImpl<ENTITY : Any, ID : Any, META :
     private val entities: List<ENTITY>,
 ) : EntityInsertMultipleQuery<ENTITY> {
     override fun returning(): EntityInsertReturningQuery<List<ENTITY>> {
-        val newContext = context.copy(returning = true)
+        val newContext = context.copy(returning = Output.Metamodel(context.target))
         return EntityInsertMultipleReturningQuery(newContext, entities)
+    }
+
+    override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityInsertReturningQuery<List<A?>> {
+        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        return EntityInsertMultipleReturningSingleColumnQuery(newContext, entities, expression)
+    }
+
+    override fun <A : Any, B : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+    ): EntityInsertReturningQuery<List<Pair<A?, B?>>> {
+        val expressions = expression1 to expression2
+        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        return EntityInsertMultipleReturningPairColumnsQuery(newContext, entities, expressions)
+    }
+
+    override fun <A : Any, B : Any, C : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+        expression3: PropertyMetamodel<ENTITY, C, *>,
+    ): EntityInsertReturningQuery<List<Triple<A?, B?, C?>>> {
+        val expressions = Triple(expression1, expression2, expression3)
+        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        return EntityInsertMultipleReturningTripleColumnsQuery(newContext, entities, expressions)
     }
 
     override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertMultipleQuery<ENTITY> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertQuery.kt
@@ -31,6 +31,8 @@ interface EntityInsertSingleQuery<ENTITY : Any> : EntityInsertQuery<ENTITY> {
      * Indicates to retrieve an inserted entity.
      */
     fun returning(): EntityInsertReturningQuery<ENTITY>
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertSingleQuery<ENTITY>
 }
 
 /**
@@ -43,6 +45,8 @@ interface EntityInsertMultipleQuery<ENTITY : Any> : EntityInsertQuery<List<ENTIT
      * Indicates to retrieve inserted entities.
      */
     fun returning(): EntityInsertReturningQuery<List<ENTITY>>
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertMultipleQuery<ENTITY>
 }
 
 internal data class EntityInsertSingleQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
@@ -54,7 +58,7 @@ internal data class EntityInsertSingleQueryImpl<ENTITY : Any, ID : Any, META : E
         return EntityInsertSingleReturningQuery(newContext, entity)
     }
 
-    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertQuery<ENTITY> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertSingleQuery<ENTITY> {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertQuery.kt
@@ -9,7 +9,7 @@ import org.komapper.core.dsl.visitor.QueryVisitor
  * Represents a query to insert entities.
  * This query returns new entity or entities.
  *
- * @param T the entity type
+ * @param T the result type
  */
 interface EntityInsertQuery<T> : Query<T> {
     /**
@@ -21,10 +21,39 @@ interface EntityInsertQuery<T> : Query<T> {
     fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertQuery<T>
 }
 
-internal data class EntityInsertSingleQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+/**
+ * Represents a query to insert a single entity.
+ *
+ * @param ENTITY the entity type
+ */
+interface EntityInsertSingleQuery<ENTITY : Any> : EntityInsertQuery<ENTITY> {
+    /**
+     * Indicates to retrieve an inserted entity.
+     */
+    fun returning(): EntityInsertReturningQuery<ENTITY>
+}
+
+/**
+ * Represents a query to insert multiple entities.
+ *
+ * @param ENTITY the entity type
+ */
+interface EntityInsertMultipleQuery<ENTITY : Any> : EntityInsertQuery<List<ENTITY>> {
+    /**
+     * Indicates to retrieve inserted entities.
+     */
+    fun returning(): EntityInsertReturningQuery<List<ENTITY>>
+}
+
+internal data class EntityInsertSingleQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: EntityInsertContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) : EntityInsertQuery<ENTITY> {
+) : EntityInsertSingleQuery<ENTITY> {
+    override fun returning(): EntityInsertReturningQuery<ENTITY> {
+        val newContext = context.copy(returning = true)
+        return EntityInsertSingleReturningQuery(newContext, entity)
+    }
+
     override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertQuery<ENTITY> {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
@@ -35,11 +64,16 @@ internal data class EntityInsertSingleQuery<ENTITY : Any, ID : Any, META : Entit
     }
 }
 
-internal data class EntityInsertMultipleQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+internal data class EntityInsertMultipleQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: EntityInsertContext<ENTITY, ID, META>,
     private val entities: List<ENTITY>,
-) : EntityInsertQuery<List<ENTITY>> {
-    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertQuery<List<ENTITY>> {
+) : EntityInsertMultipleQuery<ENTITY> {
+    override fun returning(): EntityInsertReturningQuery<List<ENTITY>> {
+        val newContext = context.copy(returning = true)
+        return EntityInsertMultipleReturningQuery(newContext, entities)
+    }
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertMultipleQuery<ENTITY> {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertQuery.kt
@@ -30,14 +30,37 @@ interface EntityInsertQuery<T> : Query<T> {
  */
 interface EntityInsertSingleQuery<ENTITY : Any> : EntityInsertQuery<ENTITY> {
     /**
-     * Indicates to retrieve an inserted entity.
+     * Indicates to retrieve an entity.
+     *
+     * @return the query
      */
     fun returning(): EntityInsertReturningQuery<ENTITY>
 
+    /**
+     * Indicates to retrieve a property.
+     *
+     * @param expression the property
+     * @return the query
+     */
     fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityInsertReturningQuery<A?>
 
+    /**
+     * Indicates to retrieve a property pair.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @return the query
+     */
     fun <A : Any, B : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>): EntityInsertReturningQuery<Pair<A?, B?>>
 
+    /**
+     * Indicates to retrieve a property triple.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @param expression3 the third property
+     * @return the query
+     */
     fun <A : Any, B : Any, C : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>, expression3: PropertyMetamodel<ENTITY, C, *>): EntityInsertReturningQuery<Triple<A?, B?, C?>>
 
     override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertSingleQuery<ENTITY>
@@ -50,14 +73,37 @@ interface EntityInsertSingleQuery<ENTITY : Any> : EntityInsertQuery<ENTITY> {
  */
 interface EntityInsertMultipleQuery<ENTITY : Any> : EntityInsertQuery<List<ENTITY>> {
     /**
-     * Indicates to retrieve inserted entities.
+     * Indicates to retrieve a list of entity.
+     *
+     * @return the query
      */
     fun returning(): EntityInsertReturningQuery<List<ENTITY>>
 
+    /**
+     * Indicates to retrieve a list of property.
+     *
+     * @param expression the property
+     * @return the query
+     */
     fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityInsertReturningQuery<List<A?>>
 
+    /**
+     * Indicates to retrieve a list of property pair.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @return the query
+     */
     fun <A : Any, B : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>): EntityInsertReturningQuery<List<Pair<A?, B?>>>
 
+    /**
+     * Indicates to retrieve a list of property triple.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @param expression3 the third property
+     * @return the query
+     */
     fun <A : Any, B : Any, C : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>, expression3: PropertyMetamodel<ENTITY, C, *>): EntityInsertReturningQuery<List<Triple<A?, B?, C?>>>
 
     override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertMultipleQuery<ENTITY>

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertQuery.kt
@@ -1,7 +1,7 @@
 package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.EntityInsertContext
-import org.komapper.core.dsl.element.Output
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.options.InsertOptions
@@ -114,12 +114,12 @@ internal data class EntityInsertSingleQueryImpl<ENTITY : Any, ID : Any, META : E
     private val entity: ENTITY,
 ) : EntityInsertSingleQuery<ENTITY> {
     override fun returning(): EntityInsertReturningQuery<ENTITY> {
-        val newContext = context.copy(returning = Output.Metamodel(context.target))
+        val newContext = context.copy(returning = Returning.Metamodel(context.target))
         return EntityInsertSingleReturningQuery(newContext, entity)
     }
 
     override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityInsertReturningQuery<A?> {
-        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        val newContext = context.copy(returning = Returning.Expressions(listOf(expression)))
         return EntityInsertSingleReturningSingleColumnQuery(newContext, entity, expression)
     }
 
@@ -128,7 +128,7 @@ internal data class EntityInsertSingleQueryImpl<ENTITY : Any, ID : Any, META : E
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): EntityInsertReturningQuery<Pair<A?, B?>> {
         val expressions = expression1 to expression2
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityInsertSingleReturningPairColumnsQuery(newContext, entity, expressions)
     }
 
@@ -138,7 +138,7 @@ internal data class EntityInsertSingleQueryImpl<ENTITY : Any, ID : Any, META : E
         expression3: PropertyMetamodel<ENTITY, C, *>,
     ): EntityInsertReturningQuery<Triple<A?, B?, C?>> {
         val expressions = Triple(expression1, expression2, expression3)
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityInsertSingleReturningTripleColumnsQuery(newContext, entity, expressions)
     }
 
@@ -157,12 +157,12 @@ internal data class EntityInsertMultipleQueryImpl<ENTITY : Any, ID : Any, META :
     private val entities: List<ENTITY>,
 ) : EntityInsertMultipleQuery<ENTITY> {
     override fun returning(): EntityInsertReturningQuery<List<ENTITY>> {
-        val newContext = context.copy(returning = Output.Metamodel(context.target))
+        val newContext = context.copy(returning = Returning.Metamodel(context.target))
         return EntityInsertMultipleReturningQuery(newContext, entities)
     }
 
     override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityInsertReturningQuery<List<A?>> {
-        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        val newContext = context.copy(returning = Returning.Expressions(listOf(expression)))
         return EntityInsertMultipleReturningSingleColumnQuery(newContext, entities, expression)
     }
 
@@ -171,7 +171,7 @@ internal data class EntityInsertMultipleQueryImpl<ENTITY : Any, ID : Any, META :
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): EntityInsertReturningQuery<List<Pair<A?, B?>>> {
         val expressions = expression1 to expression2
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityInsertMultipleReturningPairColumnsQuery(newContext, entities, expressions)
     }
 
@@ -181,7 +181,7 @@ internal data class EntityInsertMultipleQueryImpl<ENTITY : Any, ID : Any, META :
         expression3: PropertyMetamodel<ENTITY, C, *>,
     ): EntityInsertReturningQuery<List<Triple<A?, B?, C?>>> {
         val expressions = Triple(expression1, expression2, expression3)
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityInsertMultipleReturningTripleColumnsQuery(newContext, entities, expressions)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertReturningQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertReturningQuery.kt
@@ -1,0 +1,50 @@
+package org.komapper.core.dsl.query
+
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.options.InsertOptions
+import org.komapper.core.dsl.visitor.QueryVisitor
+
+/**
+ * Represents a query to insert entities and retrieve inserted entities.
+ * This query returns new entity or entities.
+ *
+ * @param T the result type
+ */
+interface EntityInsertReturningQuery<T> : Query<T> {
+    /**
+     * Builds a query with the options applied.
+     *
+     * @param configure the configure function to apply options
+     * @return the query
+     */
+    fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertReturningQuery<T>
+}
+
+internal data class EntityInsertSingleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : EntityInsertReturningQuery<ENTITY> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertReturningQuery<ENTITY> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityInsertSingleReturningQuery(context, entity)
+    }
+}
+
+internal data class EntityInsertMultipleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+) : EntityInsertReturningQuery<List<ENTITY>> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertReturningQuery<List<ENTITY>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityInsertMultipleReturningQuery(context, entities)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertReturningQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityInsertReturningQuery.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.InsertOptions
 import org.komapper.core.dsl.visitor.QueryVisitor
@@ -35,6 +36,51 @@ internal data class EntityInsertSingleReturningQuery<ENTITY : Any, ID : Any, MET
     }
 }
 
+internal data class EntityInsertSingleReturningSingleColumnQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expression: ColumnExpression<A, *>,
+) : EntityInsertReturningQuery<A?> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertReturningQuery<A?> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityInsertSingleReturningSingleColumnQuery(context, entity, expression)
+    }
+}
+
+internal data class EntityInsertSingleReturningPairColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+) : EntityInsertReturningQuery<Pair<A?, B?>> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertReturningQuery<Pair<A?, B?>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityInsertSingleReturningPairColumnsQuery(context, entity, expressions)
+    }
+}
+
+internal data class EntityInsertSingleReturningTripleColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+) : EntityInsertReturningQuery<Triple<A?, B?, C?>> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertReturningQuery<Triple<A?, B?, C?>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityInsertSingleReturningTripleColumnsQuery(context, entity, expressions)
+    }
+}
+
 internal data class EntityInsertMultipleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: EntityInsertContext<ENTITY, ID, META>,
     private val entities: List<ENTITY>,
@@ -46,5 +92,50 @@ internal data class EntityInsertMultipleReturningQuery<ENTITY : Any, ID : Any, M
 
     override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
         return visitor.entityInsertMultipleReturningQuery(context, entities)
+    }
+}
+
+internal data class EntityInsertMultipleReturningSingleColumnQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+    private val expression: ColumnExpression<A, *>,
+) : EntityInsertReturningQuery<List<A?>> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertReturningQuery<List<A?>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityInsertMultipleReturningSingleColumnQuery(context, entities, expression)
+    }
+}
+
+internal data class EntityInsertMultipleReturningPairColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+    private val expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+) : EntityInsertReturningQuery<List<Pair<A?, B?>>> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertReturningQuery<List<Pair<A?, B?>>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityInsertMultipleReturningPairColumnsQuery(context, entities, expressions)
+    }
+}
+
+internal data class EntityInsertMultipleReturningTripleColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+    private val expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+) : EntityInsertReturningQuery<List<Triple<A?, B?, C?>>> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityInsertReturningQuery<List<Triple<A?, B?, C?>>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityInsertMultipleReturningTripleColumnsQuery(context, entities, expressions)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpdateQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpdateQuery.kt
@@ -1,7 +1,7 @@
 package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.EntityUpdateContext
-import org.komapper.core.dsl.element.Output
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.options.UpdateOptions
@@ -77,12 +77,12 @@ internal data class EntityUpdateSingleQueryImpl<ENTITY : Any, ID : Any, META : E
     private val entity: ENTITY,
 ) : EntityUpdateSingleQuery<ENTITY> {
     override fun returning(): EntityUpdateReturningQuery<ENTITY?> {
-        val newContext = context.copy(returning = Output.Metamodel(context.target))
+        val newContext = context.copy(returning = Returning.Metamodel(context.target))
         return EntityUpdateSingleReturningQuery(newContext, entity)
     }
 
     override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityUpdateReturningQuery<A?> {
-        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        val newContext = context.copy(returning = Returning.Expressions(listOf(expression)))
         return EntityUpdateSingleReturningSingleColumnQuery(newContext, entity, expression)
     }
 
@@ -91,7 +91,7 @@ internal data class EntityUpdateSingleQueryImpl<ENTITY : Any, ID : Any, META : E
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): EntityUpdateReturningQuery<Pair<A?, B?>?> {
         val expressions = expression1 to expression2
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityUpdateSingleReturningPairColumnsQuery(newContext, entity, expressions)
     }
 
@@ -101,7 +101,7 @@ internal data class EntityUpdateSingleQueryImpl<ENTITY : Any, ID : Any, META : E
         expression3: PropertyMetamodel<ENTITY, C, *>,
     ): EntityUpdateReturningQuery<Triple<A?, B?, C?>?> {
         val expressions = Triple(expression1, expression2, expression3)
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityUpdateSingleReturningTripleColumnsQuery(newContext, entity, expressions)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpdateQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpdateQuery.kt
@@ -11,7 +11,7 @@ import org.komapper.core.dsl.visitor.QueryVisitor
  * Represents a query to update entities.
  * This query returns new entity or entities.
  *
- * @param T the entity type
+ * @param T the result type
  */
 interface EntityUpdateQuery<T> : Query<T> {
     /**
@@ -23,20 +23,52 @@ interface EntityUpdateQuery<T> : Query<T> {
     fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateQuery<T>
 }
 
+/**
+ * Represents a query to update a single entity.
+ *
+ * @param ENTITY the entity type
+ */
 interface EntityUpdateSingleQuery<ENTITY : Any> : EntityUpdateQuery<ENTITY> {
+    /**
+     * Indicates to retrieve an entity.
+     * @return the query
+     */
     fun returning(): EntityUpdateReturningQuery<ENTITY?>
+
+    /**
+     * Indicates to retrieve a property.
+     *
+     * @param expression the property
+     * @return the query
+     */
     fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityUpdateReturningQuery<A?>
 
+    /**
+     * Indicates to retrieve a property pair.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @return the query
+     */
     fun <A : Any, B : Any> returning(
         expression1: PropertyMetamodel<ENTITY, A, *>,
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): EntityUpdateReturningQuery<Pair<A?, B?>?>
 
+    /**
+     * Indicates to retrieve a property triple.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @param expression3 the third property
+     * @return the query
+     */
     fun <A : Any, B : Any, C : Any> returning(
         expression1: PropertyMetamodel<ENTITY, A, *>,
         expression2: PropertyMetamodel<ENTITY, B, *>,
         expression3: PropertyMetamodel<ENTITY, C, *>,
     ): EntityUpdateReturningQuery<Triple<A?, B?, C?>?>
+
     override fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateSingleQuery<ENTITY>
 }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpdateQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpdateQuery.kt
@@ -21,11 +21,22 @@ interface EntityUpdateQuery<T> : Query<T> {
     fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateQuery<T>
 }
 
-internal data class EntityUpdateSingleQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+interface EntityUpdateSingleQuery<ENTITY> :
+    EntityUpdateQuery<ENTITY> {
+    fun returning(): EntityUpdateReturningQuery<ENTITY>
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateSingleQuery<ENTITY>
+}
+
+internal data class EntityUpdateSingleQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
     private val context: EntityUpdateContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) : EntityUpdateQuery<ENTITY> {
-    override fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateQuery<ENTITY> {
+) : EntityUpdateSingleQuery<T> {
+    override fun returning(): EntityUpdateReturningQuery<T> {
+        val newContext = context.copy(returning = true)
+        return EntityUpdateSingleReturningQuery(newContext, entity)
+    }
+
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateSingleQuery<T> {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpdateReturningQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpdateReturningQuery.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.EntityUpdateContext
+import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.UpdateOptions
 import org.komapper.core.dsl.visitor.QueryVisitor
@@ -21,16 +22,61 @@ interface EntityUpdateReturningQuery<T> : Query<T> {
     fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateReturningQuery<T>
 }
 
-internal data class EntityUpdateSingleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+internal data class EntityUpdateSingleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: EntityUpdateContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) : EntityUpdateReturningQuery<T> {
-    override fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateReturningQuery<T> {
+) : EntityUpdateReturningQuery<ENTITY?> {
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateReturningQuery<ENTITY?> {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
     }
 
     override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
         return visitor.entityUpdateSingleReturningQuery(context, entity)
+    }
+}
+
+internal data class EntityUpdateSingleReturningSingleColumnQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>(
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expression: ColumnExpression<A, *>,
+) : EntityUpdateReturningQuery<A?> {
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateReturningQuery<A?> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpdateSingleReturningSingleColumnQuery(context, entity, expression)
+    }
+}
+
+internal data class EntityUpdateSingleReturningPairColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>(
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+) : EntityUpdateReturningQuery<Pair<A?, B?>?> {
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateReturningQuery<Pair<A?, B?>?> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpdateSingleReturningPairColumnsQuery(context, entity, expressions)
+    }
+}
+
+internal data class EntityUpdateSingleReturningTripleColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>(
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+) : EntityUpdateReturningQuery<Triple<A?, B?, C?>?> {
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateReturningQuery<Triple<A?, B?, C?>?> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpdateSingleReturningTripleColumnsQuery(context, entity, expressions)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpdateReturningQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpdateReturningQuery.kt
@@ -1,0 +1,36 @@
+package org.komapper.core.dsl.query
+
+import org.komapper.core.dsl.context.EntityUpdateContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.options.UpdateOptions
+import org.komapper.core.dsl.visitor.QueryVisitor
+
+/**
+ * Represents a query to update entities.
+ * This query returns new entity or entities.
+ *
+ * @param T the entity type
+ */
+interface EntityUpdateReturningQuery<T> : Query<T> {
+    /**
+     * Builds a query with the options applied.
+     *
+     * @param configure the configure function to apply options
+     * @return the query
+     */
+    fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateReturningQuery<T>
+}
+
+internal data class EntityUpdateSingleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : EntityUpdateReturningQuery<T> {
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): EntityUpdateReturningQuery<T> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpdateSingleReturningQuery(context, entity)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertQuery.kt
@@ -27,22 +27,45 @@ interface EntityUpsertQuery<T> : Query<T> {
 
 /**
  * Represents a query to upsert a single entity.
+ * The [returning] functions fetch the result with the [single] function.
  *
  * @param ENTITY the entity type
  */
 interface EntityUpsertSingleQueryNonNull<ENTITY : Any> : EntityUpsertQuery<Long> {
     /**
-     * Indicates to retrieve an upserted entity.
+     * Indicates to retrieve an entity.
+     * @return the query
      */
     fun returning(): EntityUpsertReturningQuery<ENTITY>
 
+    /**
+     * Indicates to retrieve a property.
+     *
+     * @param expression the property
+     * @return the query
+     */
     fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityUpsertReturningQuery<A?>
 
+    /**
+     * Indicates to retrieve a property pair.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @return the query
+     */
     fun <A : Any, B : Any> returning(
         expression1: PropertyMetamodel<ENTITY, A, *>,
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): EntityUpsertReturningQuery<Pair<A?, B?>>
 
+    /**
+     * Indicates to retrieve a property triple.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @param expression3 the third property
+     * @return the query
+     */
     fun <A : Any, B : Any, C : Any> returning(
         expression1: PropertyMetamodel<ENTITY, A, *>,
         expression2: PropertyMetamodel<ENTITY, B, *>,
@@ -52,19 +75,47 @@ interface EntityUpsertSingleQueryNonNull<ENTITY : Any> : EntityUpsertQuery<Long>
     override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertSingleQueryNonNull<ENTITY>
 }
 
+/**
+ * Represents a query to upsert a single entity.
+ * The [returning] functions fetch the result with the [singleOrNull] function.
+ *
+ * @param ENTITY the entity type
+ */
 interface EntityUpsertSingleQueryNullable<ENTITY : Any> : EntityUpsertQuery<Long> {
     /**
-     * Indicates to retrieve an upserted entity.
+     * Indicates to retrieve an entity.
+     * @return the query
      */
     fun returning(): EntityUpsertReturningQuery<ENTITY?>
 
+    /**
+     * Indicates to retrieve a property.
+     *
+     * @param expression the property
+     * @return the query
+     */
     fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityUpsertReturningQuery<A?>
 
+    /**
+     * Indicates to retrieve a property pair.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @return the query
+     */
     fun <A : Any, B : Any> returning(
         expression1: PropertyMetamodel<ENTITY, A, *>,
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): EntityUpsertReturningQuery<Pair<A?, B?>?>
 
+    /**
+     * Indicates to retrieve a property triple.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @param expression3 the third property
+     * @return the query
+     */
     fun <A : Any, B : Any, C : Any> returning(
         expression1: PropertyMetamodel<ENTITY, A, *>,
         expression2: PropertyMetamodel<ENTITY, B, *>,
@@ -81,17 +132,39 @@ interface EntityUpsertSingleQueryNullable<ENTITY : Any> : EntityUpsertQuery<Long
  */
 interface EntityUpsertMultipleQuery<ENTITY : Any> : EntityUpsertQuery<Long> {
     /**
-     * Indicates to retrieve upserted entities.
+     * Indicates to retrieve an entity.
+     * @return the query
      */
     fun returning(): EntityUpsertReturningQuery<List<ENTITY>>
 
+    /**
+     * Indicates to retrieve a property.
+     *
+     * @param expression the property
+     * @return the query
+     */
     fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityUpsertReturningQuery<List<A?>>
 
+    /**
+     * Indicates to retrieve a property pair.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @return the query
+     */
     fun <A : Any, B : Any> returning(
         expression1: PropertyMetamodel<ENTITY, A, *>,
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): EntityUpsertReturningQuery<List<Pair<A?, B?>>>
 
+    /**
+     * Indicates to retrieve a property triple.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @param expression3 the third property
+     * @return the query
+     */
     fun <A : Any, B : Any, C : Any> returning(
         expression1: PropertyMetamodel<ENTITY, A, *>,
         expression2: PropertyMetamodel<ENTITY, B, *>,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertQuery.kt
@@ -3,7 +3,7 @@ package org.komapper.core.dsl.query
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.singleOrNull
 import org.komapper.core.dsl.context.EntityUpsertContext
-import org.komapper.core.dsl.element.Output
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.options.InsertOptions
@@ -179,12 +179,12 @@ internal data class EntityUpsertSingleQueryNonNullImpl<ENTITY : Any, ID : Any, M
     private val entity: ENTITY,
 ) : EntityUpsertSingleQueryNonNull<ENTITY> {
     override fun returning(): EntityUpsertReturningQuery<ENTITY> {
-        val newContext = context.copy(returning = Output.Metamodel(context.target))
+        val newContext = context.copy(returning = Returning.Metamodel(context.target))
         return EntityUpsertSingleReturningQuery(newContext, entity) { it.single() }
     }
 
     override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityUpsertReturningQuery<A?> {
-        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        val newContext = context.copy(returning = Returning.Expressions(listOf(expression)))
         return EntityUpsertSingleReturningSingleColumnQuery(newContext, entity, expression) { it.single() }
     }
 
@@ -193,7 +193,7 @@ internal data class EntityUpsertSingleQueryNonNullImpl<ENTITY : Any, ID : Any, M
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): EntityUpsertReturningQuery<Pair<A?, B?>> {
         val expressions = expression1 to expression2
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityUpsertSingleReturningPairColumnsQuery(newContext, entity, expressions) { it.single() }
     }
 
@@ -203,7 +203,7 @@ internal data class EntityUpsertSingleQueryNonNullImpl<ENTITY : Any, ID : Any, M
         expression3: PropertyMetamodel<ENTITY, C, *>,
     ): EntityUpsertReturningQuery<Triple<A?, B?, C?>> {
         val expressions = Triple(expression1, expression2, expression3)
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityUpsertSingleReturningTripleColumnsQuery(newContext, entity, expressions) { it.single() }
     }
 
@@ -221,12 +221,12 @@ internal data class EntityUpsertSingleQueryNullableImpl<ENTITY : Any, ID : Any, 
     private val entity: ENTITY,
 ) : EntityUpsertSingleQueryNullable<ENTITY> {
     override fun returning(): EntityUpsertReturningQuery<ENTITY?> {
-        val newContext = context.copy(returning = Output.Metamodel(context.target))
+        val newContext = context.copy(returning = Returning.Metamodel(context.target))
         return EntityUpsertSingleReturningQuery(newContext, entity) { it.singleOrNull() }
     }
 
     override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityUpsertReturningQuery<A?> {
-        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        val newContext = context.copy(returning = Returning.Expressions(listOf(expression)))
         return EntityUpsertSingleReturningSingleColumnQuery(newContext, entity, expression) { it.singleOrNull() }
     }
 
@@ -235,7 +235,7 @@ internal data class EntityUpsertSingleQueryNullableImpl<ENTITY : Any, ID : Any, 
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): EntityUpsertReturningQuery<Pair<A?, B?>?> {
         val expressions = expression1 to expression2
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityUpsertSingleReturningPairColumnsQuery(newContext, entity, expressions) { it.singleOrNull() }
     }
 
@@ -245,7 +245,7 @@ internal data class EntityUpsertSingleQueryNullableImpl<ENTITY : Any, ID : Any, 
         expression3: PropertyMetamodel<ENTITY, C, *>,
     ): EntityUpsertReturningQuery<Triple<A?, B?, C?>?> {
         val expressions = Triple(expression1, expression2, expression3)
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityUpsertSingleReturningTripleColumnsQuery(newContext, entity, expressions) { it.single() }
     }
 
@@ -286,12 +286,12 @@ internal data class EntityUpsertMultipleQueryImpl<ENTITY : Any, ID : Any, META :
     private val entities: List<ENTITY>,
 ) : EntityUpsertMultipleQuery<ENTITY> {
     override fun returning(): EntityUpsertReturningQuery<List<ENTITY>> {
-        val newContext = context.copy(returning = Output.Metamodel(context.target))
+        val newContext = context.copy(returning = Returning.Metamodel(context.target))
         return EntityUpsertMultipleReturningQuery(newContext, entities)
     }
 
     override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityUpsertReturningQuery<List<A?>> {
-        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        val newContext = context.copy(returning = Returning.Expressions(listOf(expression)))
         return EntityUpsertMultipleReturningSingleColumnQuery(newContext, entities, expression)
     }
 
@@ -300,7 +300,7 @@ internal data class EntityUpsertMultipleQueryImpl<ENTITY : Any, ID : Any, META :
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): EntityUpsertReturningQuery<List<Pair<A?, B?>>> {
         val expressions = expression1 to expression2
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityUpsertMultipleReturningPairColumnsQuery(newContext, entities, expressions)
     }
 
@@ -310,7 +310,7 @@ internal data class EntityUpsertMultipleQueryImpl<ENTITY : Any, ID : Any, META :
         expression3: PropertyMetamodel<ENTITY, C, *>,
     ): EntityUpsertReturningQuery<List<Triple<A?, B?, C?>>> {
         val expressions = Triple(expression1, expression2, expression3)
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return EntityUpsertMultipleReturningTripleColumnsQuery(newContext, entities, expressions)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertQuery.kt
@@ -31,6 +31,8 @@ interface EntityUpsertSingleQuery<ENTITY> : EntityUpsertQuery<Long> {
      * Indicates to retrieve an upserted entity.
      */
     fun returning(): EntityUpsertReturningQuery<ENTITY>
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertSingleQuery<ENTITY>
 }
 
 /**
@@ -43,6 +45,8 @@ interface EntityUpsertMultipleQuery<ENTITY : Any> : EntityUpsertQuery<Long> {
      * Indicates to retrieve upserted entities.
      */
     fun returning(): EntityUpsertReturningQuery<List<ENTITY>>
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertMultipleQuery<ENTITY>
 }
 
 internal data class EntityUpsertSingleQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
@@ -95,7 +99,7 @@ internal data class EntityUpsertMultipleQueryImpl<ENTITY : Any, ID : Any, META :
         return EntityUpsertMultipleReturningQuery(newContext, entities)
     }
 
-    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertQuery<Long> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertMultipleQuery<ENTITY> {
         return copy(context = context.copyConfigure(configure))
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertQueryBuilder.kt
@@ -17,20 +17,20 @@ internal interface EntityUpsertQueryBuilder<ENTITY : Any, ID : Any, META : Entit
     fun batch(entities: List<ENTITY>, batchSize: Int? = null): EntityUpsertQuery<List<Long>>
 }
 
-internal interface EntityUpsertQueryBuilderReturningSingle<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : EntityUpsertQueryBuilder<ENTITY, ID, META> {
-    fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY>
+internal interface EntityUpsertQueryBuilderNonNull<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : EntityUpsertQueryBuilder<ENTITY, ID, META> {
+    fun single(entity: ENTITY): EntityUpsertSingleQueryNonNull<ENTITY>
 }
 
-internal interface EntityUpsertQueryBuilderReturningSingleOrNull<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : EntityUpsertQueryBuilder<ENTITY, ID, META> {
-    fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY?>
+internal interface EntityUpsertQueryBuilderNullable<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : EntityUpsertQueryBuilder<ENTITY, ID, META> {
+    fun single(entity: ENTITY): EntityUpsertSingleQueryNullable<ENTITY>
 }
 
-internal data class EntityUpsertQueryBuilderReturningSingleImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+internal data class EntityUpsertQueryBuilderNonNullImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: EntityUpsertContext<ENTITY, ID, META>,
-) : EntityUpsertQueryBuilderReturningSingle<ENTITY, ID, META> {
+) : EntityUpsertQueryBuilderNonNull<ENTITY, ID, META> {
 
-    override fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY> {
-        return EntityUpsertSingleQueryImpl(context, entity)
+    override fun single(entity: ENTITY): EntityUpsertSingleQueryNonNull<ENTITY> {
+        return EntityUpsertSingleQueryNonNullImpl(context, entity)
     }
 
     override fun multiple(entities: List<ENTITY>): EntityUpsertMultipleQuery<ENTITY> {
@@ -42,12 +42,12 @@ internal data class EntityUpsertQueryBuilderReturningSingleImpl<ENTITY : Any, ID
     }
 }
 
-internal data class EntityUpsertQueryBuilderReturningSingleOrNullImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+internal data class EntityUpsertQueryBuilderNullableImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: EntityUpsertContext<ENTITY, ID, META>,
-) : EntityUpsertQueryBuilderReturningSingleOrNull<ENTITY, ID, META> {
+) : EntityUpsertQueryBuilderNullable<ENTITY, ID, META> {
 
-    override fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY?> {
-        return EntityUpsertSingleQueryImpl(context, entity)
+    override fun single(entity: ENTITY): EntityUpsertSingleQueryNullable<ENTITY> {
+        return EntityUpsertSingleQueryNullableImpl(context, entity)
     }
 
     override fun multiple(entities: List<ENTITY>): EntityUpsertMultipleQuery<ENTITY> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertReturningQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertReturningQuery.kt
@@ -1,0 +1,48 @@
+package org.komapper.core.dsl.query
+
+import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.options.InsertOptions
+import org.komapper.core.dsl.visitor.QueryVisitor
+
+/**
+ * Represents a query to upsert entities and retrieve inserted or updated entities.
+ *
+ * @param T the result type
+ */
+interface EntityUpsertReturningQuery<T> : Query<T> {
+    /**
+     * Builds a query with the options applied.
+     *
+     * @param configure the configure function to apply options
+     * @return the query
+     */
+    fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<T>
+}
+
+internal data class EntityUpsertSingleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : EntityUpsertReturningQuery<T> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<T> {
+        return copy(context = context.copyConfigure(configure))
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpsertSingleReturningQuery(context, entity)
+    }
+}
+
+internal data class EntityUpsertMultipleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+) : EntityUpsertReturningQuery<List<ENTITY>> {
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<List<ENTITY>> {
+        return copy(context = context.copyConfigure(configure))
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpsertMultipleReturningQuery(context, entities)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertReturningQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityUpsertReturningQuery.kt
@@ -1,6 +1,8 @@
 package org.komapper.core.dsl.query
 
+import kotlinx.coroutines.flow.Flow
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.options.InsertOptions
 import org.komapper.core.dsl.visitor.QueryVisitor
@@ -20,16 +22,62 @@ interface EntityUpsertReturningQuery<T> : Query<T> {
     fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<T>
 }
 
-internal data class EntityUpsertSingleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+internal data class EntityUpsertSingleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, R>(
     private val context: EntityUpsertContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) : EntityUpsertReturningQuery<T> {
-    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<T> {
+    private val collect: suspend (Flow<ENTITY>) -> R,
+) : EntityUpsertReturningQuery<R> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<R> {
         return copy(context = context.copyConfigure(configure))
     }
 
     override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
-        return visitor.entityUpsertSingleReturningQuery(context, entity)
+        return visitor.entityUpsertSingleReturningQuery(context, entity, collect)
+    }
+}
+
+internal data class EntityUpsertSingleReturningSingleColumnQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, R>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expression: ColumnExpression<A, *>,
+    private val collect: suspend (Flow<A?>) -> R,
+) : EntityUpsertReturningQuery<R> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<R> {
+        return copy(context = context.copyConfigure(configure))
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpsertSingleReturningSingleColumnQuery(context, entity, expression, collect)
+    }
+}
+
+internal data class EntityUpsertSingleReturningPairColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, R>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    private val collect: suspend (Flow<Pair<A?, B?>>) -> R,
+) : EntityUpsertReturningQuery<R> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<R> {
+        return copy(context = context.copyConfigure(configure))
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpsertSingleReturningPairColumnsQuery(context, entity, expressions, collect)
+    }
+}
+
+internal data class EntityUpsertSingleReturningTripleColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any, R>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    private val collect: suspend (Flow<Triple<A?, B?, C?>>) -> R,
+) : EntityUpsertReturningQuery<R> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<R> {
+        return copy(context = context.copyConfigure(configure))
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpsertSingleReturningTripleColumnsQuery(context, entity, expressions, collect)
     }
 }
 
@@ -44,5 +92,50 @@ internal data class EntityUpsertMultipleReturningQuery<ENTITY : Any, ID : Any, M
 
     override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
         return visitor.entityUpsertMultipleReturningQuery(context, entities)
+    }
+}
+
+internal data class EntityUpsertMultipleReturningSingleColumnQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+    private val expression: ColumnExpression<A, *>,
+) : EntityUpsertReturningQuery<List<A?>> {
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<List<A?>> {
+        return copy(context = context.copyConfigure(configure))
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpsertMultipleReturningSingleColumnQuery(context, entities, expression)
+    }
+}
+
+internal data class EntityUpsertMultipleReturningPairColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+    private val expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+) : EntityUpsertReturningQuery<List<Pair<A?, B?>>> {
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<List<Pair<A?, B?>>> {
+        return copy(context = context.copyConfigure(configure))
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpsertMultipleReturningPairColumnsQuery(context, entities, expressions)
+    }
+}
+
+internal data class EntityUpsertMultipleReturningTripleColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+    private val expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+) : EntityUpsertReturningQuery<List<Triple<A?, B?, C?>>> {
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): EntityUpsertReturningQuery<List<Triple<A?, B?, C?>>> {
+        return copy(context = context.copyConfigure(configure))
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityUpsertMultipleReturningTripleColumnsQuery(context, entities, expressions)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyIgnoreQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyIgnoreQueryBuilder.kt
@@ -19,7 +19,7 @@ interface InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY : Any, ID : Any, META : 
      * @param entity the entity to be inserted
      * @return the query
      */
-    fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY?>
+    fun single(entity: ENTITY): EntityUpsertSingleQueryNullable<ENTITY>
 
     /**
      * Builds a query to bulk insert a list of entities.
@@ -66,9 +66,9 @@ internal data class InsertOnDuplicateKeyIgnoreQueryBuilderImpl<ENTITY : Any, ID 
     private val context: EntityUpsertContext<ENTITY, ID, META>,
 ) : InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META> {
 
-    private val builder: EntityUpsertQueryBuilderReturningSingleOrNull<ENTITY, ID, META> = EntityUpsertQueryBuilderReturningSingleOrNullImpl(context)
+    private val builder: EntityUpsertQueryBuilderNullable<ENTITY, ID, META> = EntityUpsertQueryBuilderNullableImpl(context)
 
-    override fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY?> {
+    override fun single(entity: ENTITY): EntityUpsertSingleQueryNullable<ENTITY> {
         return builder.single(entity)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyIgnoreQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyIgnoreQueryBuilder.kt
@@ -19,7 +19,7 @@ interface InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY : Any, ID : Any, META : 
      * @param entity the entity to be inserted
      * @return the query
      */
-    fun single(entity: ENTITY): EntityUpsertQuery<Long>
+    fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY?>
 
     /**
      * Builds a query to bulk insert a list of entities.
@@ -27,7 +27,7 @@ interface InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY : Any, ID : Any, META : 
      * @param entities the entities to be inserted
      * @return the query
      */
-    fun multiple(entities: List<ENTITY>): EntityUpsertQuery<Long>
+    fun multiple(entities: List<ENTITY>): EntityUpsertMultipleQuery<ENTITY>
 
     /**
      * Builds a query to bulk insert an array of entities.
@@ -66,17 +66,17 @@ internal data class InsertOnDuplicateKeyIgnoreQueryBuilderImpl<ENTITY : Any, ID 
     private val context: EntityUpsertContext<ENTITY, ID, META>,
 ) : InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META> {
 
-    private val builder: EntityUpsertQueryBuilder<ENTITY, ID, META> = EntityUpsertQueryBuilderImpl(context)
+    private val builder: EntityUpsertQueryBuilderReturningSingleOrNull<ENTITY, ID, META> = EntityUpsertQueryBuilderReturningSingleOrNullImpl(context)
 
-    override fun single(entity: ENTITY): EntityUpsertQuery<Long> {
+    override fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY?> {
         return builder.single(entity)
     }
 
-    override fun multiple(entities: List<ENTITY>): EntityUpsertQuery<Long> {
+    override fun multiple(entities: List<ENTITY>): EntityUpsertMultipleQuery<ENTITY> {
         return builder.multiple(entities)
     }
 
-    override fun multiple(vararg entities: ENTITY): EntityUpsertQuery<Long> {
+    override fun multiple(vararg entities: ENTITY): EntityUpsertMultipleQuery<ENTITY> {
         return builder.multiple(entities.toList())
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyUpdateQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyUpdateQueryBuilder.kt
@@ -16,16 +16,17 @@ import org.komapper.core.dsl.scope.AssignmentScope
  * @param ENTITY the entity type
  * @param ID the entity id type
  * @param META the entity metamodel type
+ * @param BUILDER the builder type
  */
 @ThreadSafe
-interface InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> {
+interface InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, BUILDER : InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META, BUILDER>> {
     /**
      * Sets the values to be updated.
      *
      * @param declaration the assignment declaration
      * @return the builder
      */
-    fun set(declaration: AssignmentScope<ENTITY>.(META) -> Unit): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META>
+    fun set(declaration: AssignmentScope<ENTITY>.(META) -> Unit): BUILDER
 
     /**
      * Sets search conditions.
@@ -33,15 +34,7 @@ interface InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY : Any, ID : Any, META : 
      * @param declaration the where declaration
      * @return the builder
      * */
-    fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META>
-
-    /**
-     * Builds a query to insert or update a single entity.
-     *
-     * @param entity the entity to be inserted or updated
-     * @return the query
-     */
-    fun single(entity: ENTITY): EntityUpsertQuery<Long>
+    fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META>
 
     /**
      * Builds a query to bulk insert or update a list of entities.
@@ -49,7 +42,7 @@ interface InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY : Any, ID : Any, META : 
      * @param entities the entities to be inserted or updated
      * @return the query
      */
-    fun multiple(entities: List<ENTITY>): EntityUpsertQuery<Long>
+    fun multiple(entities: List<ENTITY>): EntityUpsertMultipleQuery<ENTITY>
 
     /**
      * Builds a query to bulk insert or update an array of entities.
@@ -84,31 +77,69 @@ interface InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY : Any, ID : Any, META : 
     fun executeAndGet(entity: ENTITY): Query<ENTITY>
 }
 
-internal data class InsertOnDuplicateKeyUpdateQueryBuilderImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+/**
+ * The builder of the query that inserts or updates entities.
+ * This builder provides the function to retrieve an inserted or updated entity as a non-nullable instance.
+ *
+ * @param ENTITY the entity type
+ * @param ID the entity id type
+ * @param META the entity metamodel type
+ */
+interface InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META, InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META>> {
+    /**
+     * Builds a query to insert or update a single entity.
+     * The query returns a non-nullable entity if [EntityUpsertSingleQuery.returning] is called.
+     *
+     * @param entity the entity to be inserted or updated
+     * @return the query
+     */
+    fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY>
+}
+
+/**
+ * The builder of the query that inserts or updates entities.
+ * This builder provides the function to retrieve an inserted or updated entity as a nullable instance.
+ *
+ * @param ENTITY the entity type
+ * @param ID the entity id type
+ * @param META the entity metamodel type
+ */
+interface InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META, InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META>> {
+    /**
+     * Builds a query to insert or update a single entity.
+     * The query returns a nullable entity if [EntityUpsertSingleQuery.returning] is called.
+     *
+     * @param entity the entity to be inserted or updated
+     * @return the query
+     */
+    fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY?>
+}
+
+internal data class InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: EntityUpsertContext<ENTITY, ID, META>,
-) : InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META> {
+) : InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META> {
 
-    private val builder: EntityUpsertQueryBuilder<ENTITY, ID, META> = EntityUpsertQueryBuilderImpl(context)
+    private val builder: EntityUpsertQueryBuilderReturningSingle<ENTITY, ID, META> = EntityUpsertQueryBuilderReturningSingleImpl(context)
 
-    override fun set(declaration: AssignmentDeclaration<ENTITY, META>): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META> {
+    override fun set(declaration: AssignmentDeclaration<ENTITY, META>): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META> {
         val newContext = context.copy(set = context.set + declaration)
         return copy(context = newContext)
     }
 
-    override fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META> {
+    override fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META> {
         val newContext = context.copy(where = context.where + declaration)
-        return copy(context = newContext)
+        return InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNullImpl(newContext)
     }
 
-    override fun single(entity: ENTITY): EntityUpsertQuery<Long> {
+    override fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY> {
         return builder.single(entity)
     }
 
-    override fun multiple(entities: List<ENTITY>): EntityUpsertQuery<Long> {
+    override fun multiple(entities: List<ENTITY>): EntityUpsertMultipleQuery<ENTITY> {
         return builder.multiple(entities)
     }
 
-    override fun multiple(vararg entities: ENTITY): EntityUpsertQuery<Long> {
+    override fun multiple(vararg entities: ENTITY): EntityUpsertMultipleQuery<ENTITY> {
         return builder.multiple(entities.toList())
     }
 
@@ -121,19 +152,64 @@ internal data class InsertOnDuplicateKeyUpdateQueryBuilderImpl<ENTITY : Any, ID 
     }
 
     override fun executeAndGet(entity: ENTITY): Query<ENTITY> {
-        return EntityUpsertSingleUpdateQuery(context, entity).flatMap { newEntity ->
-            val keys = context.keys.map { it to it.getter(newEntity) }
-            QueryDsl.from(context.target).where {
-                for ((property, value) in keys) {
-                    @Suppress("UNCHECKED_CAST")
-                    property as ColumnExpression<Any, Any>
-                    if (value == null) {
-                        property.isNull()
-                    } else {
-                        property eq value
-                    }
+        return executeAndGet(context, entity)
+    }
+}
+
+internal data class InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNullImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+) : InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META> {
+
+    private val builder: EntityUpsertQueryBuilderReturningSingleOrNull<ENTITY, ID, META> = EntityUpsertQueryBuilderReturningSingleOrNullImpl(context)
+
+    override fun set(declaration: AssignmentDeclaration<ENTITY, META>): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META> {
+        val newContext = context.copy(set = context.set + declaration)
+        return copy(context = newContext)
+    }
+
+    override fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META> {
+        val newContext = context.copy(where = context.where + declaration)
+        return copy(context = newContext)
+    }
+
+    override fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY?> {
+        return builder.single(entity)
+    }
+
+    override fun multiple(entities: List<ENTITY>): EntityUpsertMultipleQuery<ENTITY> {
+        return builder.multiple(entities)
+    }
+
+    override fun multiple(vararg entities: ENTITY): EntityUpsertMultipleQuery<ENTITY> {
+        return builder.multiple(entities.toList())
+    }
+
+    override fun batch(entities: List<ENTITY>, batchSize: Int?): EntityUpsertQuery<List<Long>> {
+        return builder.batch(entities, batchSize)
+    }
+
+    override fun batch(vararg entities: ENTITY, batchSize: Int?): EntityUpsertQuery<List<Long>> {
+        return builder.batch(entities.toList(), batchSize)
+    }
+
+    override fun executeAndGet(entity: ENTITY): Query<ENTITY> {
+        return executeAndGet(context, entity)
+    }
+}
+
+private fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> executeAndGet(context: EntityUpsertContext<ENTITY, ID, META>, entity: ENTITY): Query<ENTITY> {
+    return EntityUpsertSingleUpdateQuery(context, entity).flatMap { newEntity ->
+        val keys = context.keys.map { it to it.getter(newEntity) }
+        QueryDsl.from(context.target).where {
+            for ((property, value) in keys) {
+                @Suppress("UNCHECKED_CAST")
+                property as ColumnExpression<Any, Any>
+                if (value == null) {
+                    property.isNull()
+                } else {
+                    property eq value
                 }
-            }.first()
-        }
+            }
+        }.first()
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyUpdateQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyUpdateQueryBuilder.kt
@@ -34,7 +34,7 @@ interface InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY : Any, ID : Any, META : 
      * @param declaration the where declaration
      * @return the builder
      * */
-    fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META>
+    fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilderNullable<ENTITY, ID, META>
 
     /**
      * Builds a query to bulk insert or update a list of entities.
@@ -85,53 +85,45 @@ interface InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY : Any, ID : Any, META : 
  * @param ID the entity id type
  * @param META the entity metamodel type
  */
-interface InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META, InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META>> {
+interface InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META, InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY, ID, META>> {
     /**
      * Builds a query to insert or update a single entity.
-     * The query returns a non-nullable entity if [EntityUpsertSingleQuery.returning] is called.
+     * The query returns a non-nullable entity if [EntityUpsertSingleQueryNonNull.returning] is called.
      *
      * @param entity the entity to be inserted or updated
      * @return the query
      */
-    fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY>
+    fun single(entity: ENTITY): EntityUpsertSingleQueryNonNull<ENTITY>
 }
 
-/**
- * The builder of the query that inserts or updates entities.
- * This builder provides the function to retrieve an inserted or updated entity as a nullable instance.
- *
- * @param ENTITY the entity type
- * @param ID the entity id type
- * @param META the entity metamodel type
- */
-interface InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META, InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META>> {
+interface InsertOnDuplicateKeyUpdateQueryBuilderNullable<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META, InsertOnDuplicateKeyUpdateQueryBuilderNullable<ENTITY, ID, META>> {
     /**
      * Builds a query to insert or update a single entity.
-     * The query returns a nullable entity if [EntityUpsertSingleQuery.returning] is called.
+     * The query returns a non-nullable entity if [EntityUpsertSingleQueryNullable.returning] is called.
      *
      * @param entity the entity to be inserted or updated
      * @return the query
      */
-    fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY?>
+    fun single(entity: ENTITY): EntityUpsertSingleQueryNullable<ENTITY>
 }
 
-internal data class InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+internal data class InsertOnDuplicateKeyUpdateQueryBuilderNonNullImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: EntityUpsertContext<ENTITY, ID, META>,
-) : InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META> {
+) : InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY, ID, META> {
 
-    private val builder: EntityUpsertQueryBuilderReturningSingle<ENTITY, ID, META> = EntityUpsertQueryBuilderReturningSingleImpl(context)
+    private val builder: EntityUpsertQueryBuilderNonNull<ENTITY, ID, META> = EntityUpsertQueryBuilderNonNullImpl(context)
 
-    override fun set(declaration: AssignmentDeclaration<ENTITY, META>): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META> {
+    override fun set(declaration: AssignmentDeclaration<ENTITY, META>): InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY, ID, META> {
         val newContext = context.copy(set = context.set + declaration)
         return copy(context = newContext)
     }
 
-    override fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META> {
+    override fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilderNullable<ENTITY, ID, META> {
         val newContext = context.copy(where = context.where + declaration)
-        return InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNullImpl(newContext)
+        return InsertOnDuplicateKeyUpdateQueryBuilderNullableImpl(newContext)
     }
 
-    override fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY> {
+    override fun single(entity: ENTITY): EntityUpsertSingleQueryNonNull<ENTITY> {
         return builder.single(entity)
     }
 
@@ -156,23 +148,23 @@ internal data class InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleImpl<EN
     }
 }
 
-internal data class InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNullImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+internal data class InsertOnDuplicateKeyUpdateQueryBuilderNullableImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: EntityUpsertContext<ENTITY, ID, META>,
-) : InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META> {
+) : InsertOnDuplicateKeyUpdateQueryBuilderNullable<ENTITY, ID, META> {
 
-    private val builder: EntityUpsertQueryBuilderReturningSingleOrNull<ENTITY, ID, META> = EntityUpsertQueryBuilderReturningSingleOrNullImpl(context)
+    private val builder: EntityUpsertQueryBuilderNullable<ENTITY, ID, META> = EntityUpsertQueryBuilderNullableImpl(context)
 
-    override fun set(declaration: AssignmentDeclaration<ENTITY, META>): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META> {
+    override fun set(declaration: AssignmentDeclaration<ENTITY, META>): InsertOnDuplicateKeyUpdateQueryBuilderNullable<ENTITY, ID, META> {
         val newContext = context.copy(set = context.set + declaration)
         return copy(context = newContext)
     }
 
-    override fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleOrNull<ENTITY, ID, META> {
+    override fun where(declaration: WhereDeclaration): InsertOnDuplicateKeyUpdateQueryBuilderNullable<ENTITY, ID, META> {
         val newContext = context.copy(where = context.where + declaration)
         return copy(context = newContext)
     }
 
-    override fun single(entity: ENTITY): EntityUpsertSingleQuery<ENTITY?> {
+    override fun single(entity: ENTITY): EntityUpsertSingleQueryNullable<ENTITY> {
         return builder.single(entity)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertQueryBuilder.kt
@@ -23,7 +23,7 @@ interface InsertQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * @param keys the keys used for duplicate checking
      * @return the query
      */
-    fun onDuplicateKeyUpdate(vararg keys: PropertyMetamodel<ENTITY, *, *> = emptyArray()): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META>
+    fun onDuplicateKeyUpdate(vararg keys: PropertyMetamodel<ENTITY, *, *> = emptyArray()): InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY, ID, META>
 
     /**
      * Creates a builder of the query that inserts or updates entities.
@@ -32,7 +32,7 @@ interface InsertQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * @param conflictTarget the hint to perform unique index inference
      * @return the query
      */
-    fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META>
+    fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY, ID, META>
 
     /**
      * Creates a builder of the query that inserts entities and ignores duplicate keys.
@@ -121,14 +121,14 @@ internal data class InsertQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
 ) :
     InsertQueryBuilder<ENTITY, ID, META> {
 
-    override fun onDuplicateKeyUpdate(vararg keys: PropertyMetamodel<ENTITY, *, *>): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META> {
+    override fun onDuplicateKeyUpdate(vararg keys: PropertyMetamodel<ENTITY, *, *>): InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY, ID, META> {
         val newContext = context.asEntityUpsertContext(keys.toList(), DuplicateKeyType.UPDATE)
-        return InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleImpl(newContext)
+        return InsertOnDuplicateKeyUpdateQueryBuilderNonNullImpl(newContext)
     }
 
-    override fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META> {
+    override fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY, ID, META> {
         val newContext = context.asEntityUpsertContext(conflictTarget, DuplicateKeyType.UPDATE)
-        return InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleImpl(newContext)
+        return InsertOnDuplicateKeyUpdateQueryBuilderNonNullImpl(newContext)
     }
 
     override fun onDuplicateKeyIgnore(vararg keys: PropertyMetamodel<ENTITY, *, *>): InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertQueryBuilder.kt
@@ -23,7 +23,7 @@ interface InsertQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * @param keys the keys used for duplicate checking
      * @return the query
      */
-    fun onDuplicateKeyUpdate(vararg keys: PropertyMetamodel<ENTITY, *, *> = emptyArray()): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META>
+    fun onDuplicateKeyUpdate(vararg keys: PropertyMetamodel<ENTITY, *, *> = emptyArray()): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META>
 
     /**
      * Creates a builder of the query that inserts or updates entities.
@@ -32,7 +32,7 @@ interface InsertQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * @param conflictTarget the hint to perform unique index inference
      * @return the query
      */
-    fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META>
+    fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META>
 
     /**
      * Creates a builder of the query that inserts entities and ignores duplicate keys.
@@ -57,7 +57,7 @@ interface InsertQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * @param entity the entity to be inserted
      * @return the query
      */
-    fun single(entity: ENTITY): EntityInsertQuery<ENTITY>
+    fun single(entity: ENTITY): EntityInsertSingleQuery<ENTITY>
 
     /**
      * Builds a query to bulk insert a list of entities.
@@ -65,7 +65,7 @@ interface InsertQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * @param entities the entities to be inserted
      * @return the query
      */
-    fun multiple(entities: List<ENTITY>): EntityInsertQuery<List<ENTITY>>
+    fun multiple(entities: List<ENTITY>): EntityInsertMultipleQuery<ENTITY>
 
     /**
      * Builds a query to bulk insert an array of entities.
@@ -121,14 +121,14 @@ internal data class InsertQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
 ) :
     InsertQueryBuilder<ENTITY, ID, META> {
 
-    override fun onDuplicateKeyUpdate(vararg keys: PropertyMetamodel<ENTITY, *, *>): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META> {
+    override fun onDuplicateKeyUpdate(vararg keys: PropertyMetamodel<ENTITY, *, *>): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META> {
         val newContext = context.asEntityUpsertContext(keys.toList(), DuplicateKeyType.UPDATE)
-        return InsertOnDuplicateKeyUpdateQueryBuilderImpl(newContext)
+        return InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleImpl(newContext)
     }
 
-    override fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY, ID, META> {
+    override fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilderReturningSingle<ENTITY, ID, META> {
         val newContext = context.asEntityUpsertContext(conflictTarget, DuplicateKeyType.UPDATE)
-        return InsertOnDuplicateKeyUpdateQueryBuilderImpl(newContext)
+        return InsertOnDuplicateKeyUpdateQueryBuilderReturningSingleImpl(newContext)
     }
 
     override fun onDuplicateKeyIgnore(vararg keys: PropertyMetamodel<ENTITY, *, *>): InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META> {
@@ -141,15 +141,15 @@ internal data class InsertQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
         return InsertOnDuplicateKeyIgnoreQueryBuilderImpl(newContext)
     }
 
-    override fun single(entity: ENTITY): EntityInsertQuery<ENTITY> {
-        return EntityInsertSingleQuery(context, entity)
+    override fun single(entity: ENTITY): EntityInsertSingleQuery<ENTITY> {
+        return EntityInsertSingleQueryImpl(context, entity)
     }
 
-    override fun multiple(entities: List<ENTITY>): EntityInsertQuery<List<ENTITY>> {
-        return EntityInsertMultipleQuery(context, entities)
+    override fun multiple(entities: List<ENTITY>): EntityInsertMultipleQuery<ENTITY> {
+        return EntityInsertMultipleQueryImpl(context, entities)
     }
 
-    override fun multiple(vararg entities: ENTITY): EntityInsertQuery<List<ENTITY>> {
+    override fun multiple(vararg entities: ENTITY): EntityInsertMultipleQuery<ENTITY> {
         return multiple(entities.toList())
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertQueryBuilder.kt
@@ -113,7 +113,7 @@ interface InsertQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * @param declaration the assignment declaration
      * @return the query
      */
-    fun values(declaration: AssignmentDeclaration<ENTITY, META>): RelationInsertQuery<ENTITY, ID, META, Pair<Long, ID?>>
+    fun values(declaration: AssignmentDeclaration<ENTITY, META>): RelationInsertValuesQuery<ENTITY, ID, META>
 }
 
 internal data class InsertQueryBuilderImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
@@ -176,8 +176,8 @@ internal data class InsertQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
         return RelationInsertSelectQuery(newContext)
     }
 
-    override fun values(declaration: AssignmentDeclaration<ENTITY, META>): RelationInsertQuery<ENTITY, ID, META, Pair<Long, ID?>> {
+    override fun values(declaration: AssignmentDeclaration<ENTITY, META>): RelationInsertValuesQuery<ENTITY, ID, META> {
         val newContext = context.asRelationInsertValuesContext(declaration)
-        return RelationInsertValuesQuery(newContext)
+        return RelationInsertValuesQueryImpl(newContext)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationInsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationInsertQuery.kt
@@ -2,7 +2,7 @@ package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.RelationInsertSelectContext
 import org.komapper.core.dsl.context.RelationInsertValuesContext
-import org.komapper.core.dsl.element.Output
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
@@ -110,12 +110,12 @@ internal data class RelationInsertValuesQueryImpl<ENTITY : Any, ID : Any, META :
     }
 
     override fun returning(): RelationInsertReturningQuery<ENTITY> {
-        val newContext = context.copy(returning = Output.Metamodel(context.target))
+        val newContext = context.copy(returning = Returning.Metamodel(context.target))
         return RelationInsertValuesReturningQuery(newContext)
     }
 
     override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): RelationInsertReturningQuery<A?> {
-        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        val newContext = context.copy(returning = Returning.Expressions(listOf(expression)))
         return RelationInsertValuesReturningSingleColumnQuery(newContext, expression)
     }
 
@@ -124,7 +124,7 @@ internal data class RelationInsertValuesQueryImpl<ENTITY : Any, ID : Any, META :
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): RelationInsertReturningQuery<Pair<A?, B?>> {
         val expressions = expression1 to expression2
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return RelationInsertValuesReturningPairColumnsQuery(newContext, expressions)
     }
 
@@ -134,7 +134,7 @@ internal data class RelationInsertValuesQueryImpl<ENTITY : Any, ID : Any, META :
         expression3: PropertyMetamodel<ENTITY, C, *>,
     ): RelationInsertReturningQuery<Triple<A?, B?, C?>> {
         val expressions = Triple(expression1, expression2, expression3)
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return RelationInsertValuesReturningTripleColumnsQuery(newContext, expressions)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationInsertQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationInsertQuery.kt
@@ -2,8 +2,10 @@ package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.RelationInsertSelectContext
 import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.element.Output
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.operator.plus
 import org.komapper.core.dsl.options.InsertOptions
 import org.komapper.core.dsl.visitor.QueryVisitor
@@ -35,6 +37,45 @@ interface RelationInsertQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENT
     fun options(configure: (InsertOptions) -> InsertOptions): RelationInsertQuery<ENTITY, ID, META, R>
 }
 
+interface RelationInsertValuesQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : RelationInsertQuery<ENTITY, ID, META, Pair<Long, ID?>> {
+
+    /**
+     * Indicates to retrieve an entity.
+     *
+     * @return the query
+     */
+    fun returning(): RelationInsertReturningQuery<ENTITY>
+
+    /**
+     * Indicates to retrieve a property.
+     *
+     * @param expression the property
+     * @return the query
+     */
+    fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): RelationInsertReturningQuery<A?>
+
+    /**
+     * Indicates to retrieve a property pair.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @return the query
+     */
+    fun <A : Any, B : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>): RelationInsertReturningQuery<Pair<A?, B?>>
+
+    /**
+     * Indicates to retrieve a property triple.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @param expression3 the third property
+     * @return the query
+     */
+    fun <A : Any, B : Any, C : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>, expression3: PropertyMetamodel<ENTITY, C, *>): RelationInsertReturningQuery<Triple<A?, B?, C?>>
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): RelationInsertValuesQuery<ENTITY, ID, META>
+}
+
 internal data class RelationInsertSelectQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: RelationInsertSelectContext<ENTITY, ID, META>,
 ) : RelationInsertQuery<ENTITY, ID, META, Pair<Long, List<ID>>> {
@@ -46,7 +87,7 @@ internal data class RelationInsertSelectQuery<ENTITY : Any, ID : Any, META : Ent
 
     override fun values(declaration: AssignmentDeclaration<ENTITY, META>): RelationInsertQuery<ENTITY, ID, META, Pair<Long, ID?>> {
         val newContext = context.asRelationInsertValuesContext(declaration)
-        return RelationInsertValuesQuery(newContext)
+        return RelationInsertValuesQueryImpl(newContext)
     }
 
     override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
@@ -54,18 +95,47 @@ internal data class RelationInsertSelectQuery<ENTITY : Any, ID : Any, META : Ent
     }
 }
 
-internal data class RelationInsertValuesQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+internal data class RelationInsertValuesQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: RelationInsertValuesContext<ENTITY, ID, META>,
-) : RelationInsertQuery<ENTITY, ID, META, Pair<Long, ID?>> {
+) : RelationInsertValuesQuery<ENTITY, ID, META> {
 
-    override fun options(configure: (InsertOptions) -> InsertOptions): RelationInsertQuery<ENTITY, ID, META, Pair<Long, ID?>> {
+    override fun options(configure: (InsertOptions) -> InsertOptions): RelationInsertValuesQuery<ENTITY, ID, META> {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
     }
 
-    override fun values(declaration: AssignmentDeclaration<ENTITY, META>): RelationInsertQuery<ENTITY, ID, META, Pair<Long, ID?>> {
+    override fun values(declaration: AssignmentDeclaration<ENTITY, META>): RelationInsertValuesQuery<ENTITY, ID, META> {
         val newContext = context.copy(values = context.values + declaration)
         return copy(context = newContext)
+    }
+
+    override fun returning(): RelationInsertReturningQuery<ENTITY> {
+        val newContext = context.copy(returning = Output.Metamodel(context.target))
+        return RelationInsertValuesReturningQuery(newContext)
+    }
+
+    override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): RelationInsertReturningQuery<A?> {
+        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        return RelationInsertValuesReturningSingleColumnQuery(newContext, expression)
+    }
+
+    override fun <A : Any, B : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+    ): RelationInsertReturningQuery<Pair<A?, B?>> {
+        val expressions = expression1 to expression2
+        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        return RelationInsertValuesReturningPairColumnsQuery(newContext, expressions)
+    }
+
+    override fun <A : Any, B : Any, C : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+        expression3: PropertyMetamodel<ENTITY, C, *>,
+    ): RelationInsertReturningQuery<Triple<A?, B?, C?>> {
+        val expressions = Triple(expression1, expression2, expression3)
+        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        return RelationInsertValuesReturningTripleColumnsQuery(newContext, expressions)
     }
 
     override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationInsertReturningQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationInsertReturningQuery.kt
@@ -1,0 +1,71 @@
+package org.komapper.core.dsl.query
+
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.operator.plus
+import org.komapper.core.dsl.options.InsertOptions
+import org.komapper.core.dsl.visitor.QueryVisitor
+
+interface RelationInsertReturningQuery<T> : Query<T> {
+    fun options(configure: (InsertOptions) -> InsertOptions): RelationInsertReturningQuery<T>
+}
+
+internal data class RelationInsertValuesReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+) : RelationInsertReturningQuery<ENTITY> {
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): RelationInsertReturningQuery<ENTITY> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationInsertValuesReturningQuery(context)
+    }
+}
+
+internal data class RelationInsertValuesReturningSingleColumnQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>(
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+    private val expression: ColumnExpression<A, *>,
+) : RelationInsertReturningQuery<A?> {
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): RelationInsertReturningQuery<A?> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationInsertValuesReturningSingleColumnQuery(context, expression)
+    }
+}
+
+internal data class RelationInsertValuesReturningPairColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>(
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+    private val expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+) : RelationInsertReturningQuery<Pair<A?, B?>> {
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): RelationInsertReturningQuery<Pair<A?, B?>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationInsertValuesReturningPairColumnsQuery(context, expressions)
+    }
+}
+
+internal data class RelationInsertValuesReturningTripleColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>(
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+    private val expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+) : RelationInsertReturningQuery<Triple<A?, B?, C?>> {
+
+    override fun options(configure: (InsertOptions) -> InsertOptions): RelationInsertReturningQuery<Triple<A?, B?, C?>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationInsertValuesReturningTripleColumnsQuery(context, expressions)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationUpdateQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationUpdateQuery.kt
@@ -1,9 +1,11 @@
 package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.RelationUpdateContext
+import org.komapper.core.dsl.element.Output
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.operator.plus
 import org.komapper.core.dsl.options.UpdateOptions
 import org.komapper.core.dsl.visitor.QueryVisitor
@@ -40,6 +42,47 @@ interface RelationUpdateQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENT
      * @return the query
      */
     fun options(configure: (UpdateOptions) -> UpdateOptions): RelationUpdateQuery<ENTITY, ID, META>
+
+    /**
+     * Indicates to retrieve an entity.
+     *
+     * @return the query
+     */
+    fun returning(): RelationUpdateReturningQuery<List<ENTITY>>
+
+    /**
+     * Indicates to retrieve a property.
+     *
+     * @param expression the property
+     * @return the query
+     */
+    fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): RelationUpdateReturningQuery<List<A?>>
+
+    /**
+     * Indicates to retrieve a property pair.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @return the query
+     */
+    fun <A : Any, B : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+    ): RelationUpdateReturningQuery<List<Pair<A?, B?>>>
+
+    /**
+     * Indicates to retrieve a property triple.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @param expression3 the third property
+     * @return the query
+     */
+    fun <A : Any, B : Any, C : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+        expression3: PropertyMetamodel<ENTITY, C, *>,
+    ): RelationUpdateReturningQuery<List<Triple<A?, B?, C?>>>
 }
 
 internal data class RelationUpdateQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
@@ -59,6 +102,35 @@ internal data class RelationUpdateQueryImpl<ENTITY : Any, ID : Any, META : Entit
     override fun options(configure: (UpdateOptions) -> UpdateOptions): RelationUpdateQuery<ENTITY, ID, META> {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
+    }
+
+    override fun returning(): RelationUpdateReturningQuery<List<ENTITY>> {
+        val newContext = context.copy(returning = Output.Metamodel(context.target))
+        return RelationUpdateReturningQueryImpl(newContext)
+    }
+
+    override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): RelationUpdateReturningQuery<List<A?>> {
+        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        return RelationUpdateReturningSingleColumnQuery(newContext, expression)
+    }
+
+    override fun <A : Any, B : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+    ): RelationUpdateReturningQuery<List<Pair<A?, B?>>> {
+        val expressions = expression1 to expression2
+        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        return RelationUpdateReturningPairColumnsQuery(newContext, expressions)
+    }
+
+    override fun <A : Any, B : Any, C : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+        expression3: PropertyMetamodel<ENTITY, C, *>,
+    ): RelationUpdateReturningQuery<List<Triple<A?, B?, C?>>> {
+        val expressions = Triple(expression1, expression2, expression3)
+        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        return RelationUpdateReturningTripleColumnsQuery(newContext, expressions)
     }
 
     override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationUpdateQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationUpdateQuery.kt
@@ -1,7 +1,7 @@
 package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.RelationUpdateContext
-import org.komapper.core.dsl.element.Output
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -105,12 +105,12 @@ internal data class RelationUpdateQueryImpl<ENTITY : Any, ID : Any, META : Entit
     }
 
     override fun returning(): RelationUpdateReturningQuery<List<ENTITY>> {
-        val newContext = context.copy(returning = Output.Metamodel(context.target))
+        val newContext = context.copy(returning = Returning.Metamodel(context.target))
         return RelationUpdateReturningQueryImpl(newContext)
     }
 
     override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): RelationUpdateReturningQuery<List<A?>> {
-        val newContext = context.copy(returning = Output.Expressions(listOf(expression)))
+        val newContext = context.copy(returning = Returning.Expressions(listOf(expression)))
         return RelationUpdateReturningSingleColumnQuery(newContext, expression)
     }
 
@@ -119,7 +119,7 @@ internal data class RelationUpdateQueryImpl<ENTITY : Any, ID : Any, META : Entit
         expression2: PropertyMetamodel<ENTITY, B, *>,
     ): RelationUpdateReturningQuery<List<Pair<A?, B?>>> {
         val expressions = expression1 to expression2
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return RelationUpdateReturningPairColumnsQuery(newContext, expressions)
     }
 
@@ -129,7 +129,7 @@ internal data class RelationUpdateQueryImpl<ENTITY : Any, ID : Any, META : Entit
         expression3: PropertyMetamodel<ENTITY, C, *>,
     ): RelationUpdateReturningQuery<List<Triple<A?, B?, C?>>> {
         val expressions = Triple(expression1, expression2, expression3)
-        val newContext = context.copy(returning = Output.Expressions(expressions.toList()))
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
         return RelationUpdateReturningTripleColumnsQuery(newContext, expressions)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationUpdateReturningQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationUpdateReturningQuery.kt
@@ -1,0 +1,70 @@
+package org.komapper.core.dsl.query
+
+import org.komapper.core.dsl.context.RelationUpdateContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.options.UpdateOptions
+import org.komapper.core.dsl.visitor.QueryVisitor
+
+interface RelationUpdateReturningQuery<T> : Query<T> {
+    fun options(configure: (UpdateOptions) -> UpdateOptions): RelationUpdateReturningQuery<T>
+}
+
+internal data class RelationUpdateReturningQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: RelationUpdateContext<ENTITY, ID, META>,
+) : RelationUpdateReturningQuery<List<ENTITY>> {
+
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): RelationUpdateReturningQuery<List<ENTITY>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationUpdateReturningQuery(context)
+    }
+}
+
+internal data class RelationUpdateReturningSingleColumnQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>(
+    private val context: RelationUpdateContext<ENTITY, ID, META>,
+    private val expression: ColumnExpression<A, *>,
+) : RelationUpdateReturningQuery<List<A?>> {
+
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): RelationUpdateReturningQuery<List<A?>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationUpdateReturningSingleColumnQuery(context, expression)
+    }
+}
+
+internal data class RelationUpdateReturningPairColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>(
+    private val context: RelationUpdateContext<ENTITY, ID, META>,
+    private val expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+) : RelationUpdateReturningQuery<List<Pair<A?, B?>>> {
+
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): RelationUpdateReturningQuery<List<Pair<A?, B?>>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationUpdateReturningPairColumnsQuery(context, expressions)
+    }
+}
+
+internal data class RelationUpdateReturningTripleColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>(
+    private val context: RelationUpdateContext<ENTITY, ID, META>,
+    private val expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+) : RelationUpdateReturningQuery<List<Triple<A?, B?, C?>>> {
+
+    override fun options(configure: (UpdateOptions) -> UpdateOptions): RelationUpdateReturningQuery<List<Triple<A?, B?, C?>>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationUpdateReturningTripleColumnsQuery(context, expressions)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/UpdateQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/UpdateQueryBuilder.kt
@@ -38,7 +38,7 @@ interface UpdateQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * @param entity the entity to be updated
      * @return the query
      */
-    fun single(entity: ENTITY): EntityUpdateQuery<ENTITY>
+    fun single(entity: ENTITY): EntityUpdateSingleQuery<ENTITY?>
 
     /**
      * Builds a query to update a list of entities in a batch.
@@ -95,9 +95,9 @@ internal data class UpdateQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
         }
     }
 
-    override fun single(entity: ENTITY): EntityUpdateQuery<ENTITY> {
+    override fun single(entity: ENTITY): EntityUpdateSingleQuery<ENTITY?> {
         context.target.checkIdValueNotNull(entity)
-        return EntityUpdateSingleQuery(context, entity)
+        return EntityUpdateSingleQueryImpl(context, entity)
     }
 
     override fun batch(entities: List<ENTITY>, batchSize: Int?): EntityUpdateQuery<List<ENTITY>> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/UpdateQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/UpdateQueryBuilder.kt
@@ -38,7 +38,7 @@ interface UpdateQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * @param entity the entity to be updated
      * @return the query
      */
-    fun single(entity: ENTITY): EntityUpdateSingleQuery<ENTITY?>
+    fun single(entity: ENTITY): EntityUpdateSingleQuery<ENTITY>
 
     /**
      * Builds a query to update a list of entities in a batch.
@@ -95,7 +95,7 @@ internal data class UpdateQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
         }
     }
 
-    override fun single(entity: ENTITY): EntityUpdateSingleQuery<ENTITY?> {
+    override fun single(entity: ENTITY): EntityUpdateSingleQuery<ENTITY> {
         context.target.checkIdValueNotNull(entity)
         return EntityUpdateSingleQueryImpl(context, entity)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityInsertMultipleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityInsertMultipleReturningRunner.kt
@@ -1,0 +1,27 @@
+package org.komapper.core.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.Statement
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class EntityInsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    context: EntityInsertContext<ENTITY, ID, META>,
+    entities: List<ENTITY>,
+) : Runner {
+
+    private val runner: EntityInsertMultipleRunner<ENTITY, ID, META> = EntityInsertMultipleRunner(context, entities)
+
+    override fun check(config: DatabaseConfig) {
+        checkInsertReturning(config)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+
+    fun buildStatement(config: DatabaseConfig, entities: List<ENTITY>): Statement {
+        return runner.buildStatement(config, entities)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityInsertSingleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityInsertSingleReturningRunner.kt
@@ -1,0 +1,27 @@
+package org.komapper.core.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.Statement
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class EntityInsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    context: EntityInsertContext<ENTITY, ID, META>,
+    entity: ENTITY,
+) : Runner {
+
+    private val runner: EntityInsertSingleRunner<ENTITY, ID, META> = EntityInsertSingleRunner(context, entity)
+
+    override fun check(config: DatabaseConfig) {
+        checkInsertReturning(config)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+
+    fun buildStatement(config: DatabaseConfig, entity: ENTITY): Statement {
+        return runner.buildStatement(config, entity)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateRunnerSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateRunnerSupport.kt
@@ -3,7 +3,6 @@ package org.komapper.core.dsl.runner
 import org.komapper.core.BuilderDialect
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.Statement
-import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
@@ -12,7 +11,7 @@ internal class EntityUpdateRunnerSupport<ENTITY : Any, ID : Any, META : EntityMe
 ) {
 
     fun buildStatement(config: DatabaseConfig, entity: ENTITY): Statement {
-        val builder = EntityUpdateStatementBuilder(BuilderDialect(config), context, entity)
+        val builder = config.dialect.getEntityUpdateStatementBuilder(BuilderDialect(config), context, entity)
         return builder.build()
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateSingleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateSingleReturningRunner.kt
@@ -1,0 +1,40 @@
+package org.komapper.core.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.Statement
+import org.komapper.core.dsl.context.EntityUpdateContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class EntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+    entity: ENTITY,
+) : Runner {
+
+    private val runner: EntityUpdateSingleRunner<ENTITY, ID, META> =
+        EntityUpdateSingleRunner(context, entity)
+
+    override fun check(config: DatabaseConfig) {
+        checkUpdateReturning(config)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+
+    fun buildStatement(config: DatabaseConfig, entity: ENTITY): Statement {
+        return runner.buildStatement(config, entity)
+    }
+
+    fun preUpdate(config: DatabaseConfig, entity: ENTITY): ENTITY {
+        return runner.preUpdate(config, entity)
+    }
+
+    fun postUpdate(entity: ENTITY?): ENTITY? {
+        if (context.target.versionProperty() != null) {
+            val count = if (entity == null) 0L else 1L
+            checkOptimisticLock(context.options, count, null)
+        }
+        return entity
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateSingleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateSingleReturningRunner.kt
@@ -30,11 +30,10 @@ class EntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMet
         return runner.preUpdate(config, entity)
     }
 
-    fun postUpdate(entity: ENTITY?): ENTITY? {
+    fun postUpdate(result: Any?) {
         if (context.target.versionProperty() != null) {
-            val count = if (entity == null) 0L else 1L
+            val count = if (result == null) 0L else 1L
             checkOptimisticLock(context.options, count, null)
         }
-        return entity
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertMultipleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertMultipleReturningRunner.kt
@@ -1,0 +1,28 @@
+package org.komapper.core.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.Statement
+import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class EntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    context: EntityUpsertContext<ENTITY, ID, META>,
+    entities: List<ENTITY>,
+) : Runner {
+
+    private val runner: EntityUpsertMultipleRunner<ENTITY, ID, META> = EntityUpsertMultipleRunner(context, entities)
+
+    override fun check(config: DatabaseConfig) {
+        checkInsertReturning(config)
+        runner.check(config)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+
+    fun buildStatement(config: DatabaseConfig, entities: List<ENTITY>): Statement {
+        return runner.buildStatement(config, entities)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertSingleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertSingleReturningRunner.kt
@@ -1,0 +1,28 @@
+package org.komapper.core.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.Statement
+import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class EntityUpsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    context: EntityUpsertContext<ENTITY, ID, META>,
+    entity: ENTITY,
+) : Runner {
+
+    private val runner: EntityUpsertSingleRunner<ENTITY, ID, META> = EntityUpsertSingleRunner(context, entity)
+
+    override fun check(config: DatabaseConfig) {
+        checkInsertReturning(config)
+        runner.check(config)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+
+    fun buildStatement(config: DatabaseConfig, entity: ENTITY): Statement {
+        return runner.buildStatement(config, entity)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationInsertValuesReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationInsertValuesReturningRunner.kt
@@ -1,0 +1,36 @@
+package org.komapper.core.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.Statement
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+
+class RelationInsertValuesReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    context: RelationInsertValuesContext<ENTITY, ID, META>,
+) : Runner {
+
+    private val runner: RelationInsertValuesRunner<ENTITY, ID, META> = RelationInsertValuesRunner(context)
+
+    override fun check(config: DatabaseConfig) {
+        checkInsertReturning(config)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+
+    fun buildStatement(
+        config: DatabaseConfig,
+        idAssignment: Pair<PropertyMetamodel<ENTITY, ID, *>, Operand>?,
+    ): Statement {
+        return runner.buildStatement(config, idAssignment)
+    }
+
+    fun preInsertUsingSequence(idGenerator: IdGenerator.Sequence<ENTITY, ID>, id: ID): Pair<PropertyMetamodel<ENTITY, ID, *>, Operand> {
+        return runner.preInsertUsingSequence(idGenerator, id)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationInsertValuesRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationInsertValuesRunner.kt
@@ -4,7 +4,6 @@ import org.komapper.core.BuilderDialect
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.DryRunStatement
 import org.komapper.core.Statement
-import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.getAssignments
 import org.komapper.core.dsl.context.RelationInsertValuesContext
 import org.komapper.core.dsl.expression.Operand
@@ -36,7 +35,7 @@ class RelationInsertValuesRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<
         idAssignment: Pair<PropertyMetamodel<ENTITY, ID, *>, Operand>?,
     ): Statement {
         val assignments = getAssignments(config, idAssignment)
-        val builder = RelationInsertValuesStatementBuilder(BuilderDialect(config), context)
+        val builder = config.dialect.getRelationInsertValuesStatementBuilder(BuilderDialect(config), context)
         return builder.build(assignments)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationUpdateReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationUpdateReturningRunner.kt
@@ -1,0 +1,31 @@
+package org.komapper.core.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.Statement
+import org.komapper.core.dsl.context.RelationUpdateContext
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+
+class RelationUpdateReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    context: RelationUpdateContext<ENTITY, ID, META>,
+) : Runner {
+
+    val runner: RelationUpdateRunner<ENTITY, ID, META> = RelationUpdateRunner(context)
+
+    override fun check(config: DatabaseConfig) {
+        checkUpdateReturning(config)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+
+    fun buildStatement(
+        config: DatabaseConfig,
+        updatedAtAssignment: Pair<PropertyMetamodel<ENTITY, *, *>, Operand>? = null,
+    ): Result<Statement> {
+        return runner.buildStatement(config, updatedAtAssignment)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationUpdateRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationUpdateRunner.kt
@@ -4,7 +4,6 @@ import org.komapper.core.BuilderDialect
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.DryRunStatement
 import org.komapper.core.Statement
-import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
 import org.komapper.core.dsl.builder.getAssignments
 import org.komapper.core.dsl.context.RelationUpdateContext
 import org.komapper.core.dsl.expression.Operand
@@ -36,7 +35,7 @@ class RelationUpdateRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY
                 IllegalStateException("No update statement is generated because no assignment is specified."),
             )
         }
-        val builder = RelationUpdateStatementBuilder(BuilderDialect(config), context)
+        val builder = config.dialect.getRelationUpdateStatementBuilder(BuilderDialect(config), context)
         val statement = builder.build(assignments)
         return Result.success(statement)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
@@ -86,6 +86,16 @@ internal fun checkGeneratedKeysReturningWhenInsertingMultipleRows(
     }
 }
 
+internal fun checkInsertReturning(config: DatabaseConfig) {
+    val dialect = config.dialect
+    if (!config.dialect.supportsInsertReturning()) {
+        throw UnsupportedOperationException(
+            "The dialect(driver=${dialect.driver}) does not support `INSERT RETURNING`. " +
+                "Do not use the `returning` function in your query.",
+        )
+    }
+}
+
 internal fun checkOptimisticLockOfBatchExecution(config: DatabaseConfig, options: OptimisticLockOptions) {
     val dialect = config.dialect
     if (!config.dialect.supportsOptimisticLockOfBatchExecution() &&

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
@@ -120,3 +120,13 @@ internal fun checkSearchConditionInUpsertStatement(config: DatabaseConfig, where
         }
     }
 }
+
+internal fun checkUpdateReturning(config: DatabaseConfig) {
+    val dialect = config.dialect
+    if (!config.dialect.supportsUpdateReturning()) {
+        throw UnsupportedOperationException(
+            "The dialect(driver=${dialect.driver}) does not support `UPDATE RETURNING`. " +
+                "Do not use the `returning` function in your query.",
+        )
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
@@ -38,7 +38,9 @@ import org.komapper.core.dsl.runner.EntityUpsertSingleReturningRunner
 import org.komapper.core.dsl.runner.EntityUpsertSingleRunner
 import org.komapper.core.dsl.runner.RelationDeleteRunner
 import org.komapper.core.dsl.runner.RelationInsertSelectRunner
+import org.komapper.core.dsl.runner.RelationInsertValuesReturningRunner
 import org.komapper.core.dsl.runner.RelationInsertValuesRunner
+import org.komapper.core.dsl.runner.RelationUpdateReturningRunner
 import org.komapper.core.dsl.runner.RelationUpdateRunner
 import org.komapper.core.dsl.runner.Runner
 import org.komapper.core.dsl.runner.SchemaCreateRunner
@@ -500,6 +502,33 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         return RelationInsertValuesRunner(context)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationInsertValuesReturningQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+    ): Runner {
+        return RelationInsertValuesReturningRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> relationInsertValuesReturningSingleColumnQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): Runner {
+        return RelationInsertValuesReturningRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> relationInsertValuesReturningPairColumnsQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): Runner {
+        return RelationInsertValuesReturningRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> relationInsertValuesReturningTripleColumnsQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): Runner {
+        return RelationInsertValuesReturningRunner(context)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationInsertSelectQuery(context: RelationInsertSelectContext<ENTITY, ID, META>): Runner {
         return RelationInsertSelectRunner(context)
     }
@@ -508,6 +537,31 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         context: RelationUpdateContext<ENTITY, ID, META>,
     ): Runner {
         return RelationUpdateRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationUpdateReturningQuery(context: RelationUpdateContext<ENTITY, ID, META>): Runner {
+        return RelationUpdateReturningRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> relationUpdateReturningSingleColumnQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): Runner {
+        return RelationUpdateReturningRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> relationUpdateReturningPairColumnsQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): Runner {
+        return RelationUpdateReturningRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> relationUpdateReturningTripleColumnsQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): Runner {
+        return RelationUpdateReturningRunner(context)
     }
 
     override fun templateExecuteQuery(

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
@@ -122,6 +122,30 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         return EntityInsertMultipleReturningRunner(context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityInsertMultipleReturningSingleColumnQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expression: ColumnExpression<A, *>,
+    ): Runner {
+        return EntityInsertMultipleReturningRunner(context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityInsertMultipleReturningPairColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): Runner {
+        return EntityInsertMultipleReturningRunner(context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityInsertMultipleReturningTripleColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): Runner {
+        return EntityInsertMultipleReturningRunner(context, entities)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertBatchQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
@@ -139,6 +163,30 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertSingleReturningQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entity: ENTITY,
+    ): Runner {
+        return EntityInsertSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityInsertSingleReturningSingleColumnQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): Runner {
+        return EntityInsertSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityInsertSingleReturningPairColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): Runner {
+        return EntityInsertSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityInsertSingleReturningTripleColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
     ): Runner {
         return EntityInsertSingleReturningRunner(context, entity)
     }
@@ -166,6 +214,30 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         return EntityUpdateSingleReturningRunner(context, entity)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityUpdateSingleReturningSingleColumnQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): Runner {
+        return EntityUpdateSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityUpdateSingleReturningPairColumnsQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): Runner {
+        return EntityUpdateSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityUpdateSingleReturningTripleColumnsQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): Runner {
+        return EntityUpdateSingleReturningRunner(context, entity)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityUpsertBatchQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
@@ -189,6 +261,30 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         return EntityUpsertMultipleReturningRunner(context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityUpsertMultipleReturningSingleColumnQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expression: ColumnExpression<A, *>,
+    ): Runner {
+        return EntityUpsertMultipleReturningRunner(context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityUpsertMultipleReturningPairColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): Runner {
+        return EntityUpsertMultipleReturningRunner(context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityUpsertMultipleReturningTripleColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): Runner {
+        return EntityUpsertMultipleReturningRunner(context, entities)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityUpsertSingleQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
@@ -197,9 +293,37 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         return EntityUpsertSingleRunner(context, entity)
     }
 
-    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertSingleReturningQuery(
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, R> entityUpsertSingleReturningQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
         entity: ENTITY,
+        collect: suspend (Flow<ENTITY>) -> R,
+    ): Runner {
+        return EntityUpsertSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, R> entityUpsertSingleReturningSingleColumnQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+        collect: suspend (Flow<A?>) -> R,
+    ): Runner {
+        return EntityUpsertSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, R> entityUpsertSingleReturningPairColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+        collect: suspend (Flow<Pair<A?, B?>>) -> R,
+    ): Runner {
+        return EntityUpsertSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any, R> entityUpsertSingleReturningTripleColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+        collect: suspend (Flow<Triple<A?, B?, C?>>) -> R,
     ): Runner {
         return EntityUpsertSingleReturningRunner(context, entity)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
@@ -24,12 +24,16 @@ import org.komapper.core.dsl.query.Row
 import org.komapper.core.dsl.runner.EntityDeleteBatchRunner
 import org.komapper.core.dsl.runner.EntityDeleteSingleRunner
 import org.komapper.core.dsl.runner.EntityInsertBatchRunner
+import org.komapper.core.dsl.runner.EntityInsertMultipleReturningRunner
 import org.komapper.core.dsl.runner.EntityInsertMultipleRunner
+import org.komapper.core.dsl.runner.EntityInsertSingleReturningRunner
 import org.komapper.core.dsl.runner.EntityInsertSingleRunner
 import org.komapper.core.dsl.runner.EntityUpdateBatchRunner
 import org.komapper.core.dsl.runner.EntityUpdateSingleRunner
 import org.komapper.core.dsl.runner.EntityUpsertBatchRunner
+import org.komapper.core.dsl.runner.EntityUpsertMultipleReturningRunner
 import org.komapper.core.dsl.runner.EntityUpsertMultipleRunner
+import org.komapper.core.dsl.runner.EntityUpsertSingleReturningRunner
 import org.komapper.core.dsl.runner.EntityUpsertSingleRunner
 import org.komapper.core.dsl.runner.RelationDeleteRunner
 import org.komapper.core.dsl.runner.RelationInsertSelectRunner
@@ -110,6 +114,13 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         return EntityInsertMultipleRunner(context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertMultipleReturningQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): Runner {
+        return EntityInsertMultipleReturningRunner(context, entities)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertBatchQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
@@ -122,6 +133,13 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         entity: ENTITY,
     ): Runner {
         return EntityInsertSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertSingleReturningQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): Runner {
+        return EntityInsertSingleReturningRunner(context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -156,12 +174,26 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         return EntityUpsertMultipleRunner(context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertMultipleReturningQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): Runner {
+        return EntityUpsertMultipleReturningRunner(context, entities)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityUpsertSingleQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
         entity: ENTITY,
     ): Runner {
         return EntityUpsertSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertSingleReturningQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): Runner {
+        return EntityUpsertSingleReturningRunner(context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertSingleUpdateQuery(

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
@@ -29,6 +29,7 @@ import org.komapper.core.dsl.runner.EntityInsertMultipleRunner
 import org.komapper.core.dsl.runner.EntityInsertSingleReturningRunner
 import org.komapper.core.dsl.runner.EntityInsertSingleRunner
 import org.komapper.core.dsl.runner.EntityUpdateBatchRunner
+import org.komapper.core.dsl.runner.EntityUpdateSingleReturningRunner
 import org.komapper.core.dsl.runner.EntityUpdateSingleRunner
 import org.komapper.core.dsl.runner.EntityUpsertBatchRunner
 import org.komapper.core.dsl.runner.EntityUpsertMultipleReturningRunner
@@ -156,6 +157,13 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         entity: ENTITY,
     ): Runner {
         return EntityUpdateSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpdateSingleReturningQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): Runner {
+        return EntityUpdateSingleReturningRunner(context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
@@ -100,6 +100,12 @@ interface QueryVisitor<VISIT_RESULT> {
     ): VISIT_RESULT
 
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
+    entityUpdateSingleReturningQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityUpsertBatchQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
@@ -64,6 +64,12 @@ interface QueryVisitor<VISIT_RESULT> {
     ): VISIT_RESULT
 
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
+    entityInsertMultipleReturningQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityInsertBatchQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
@@ -71,6 +77,12 @@ interface QueryVisitor<VISIT_RESULT> {
 
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityInsertSingleQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
+    entityInsertSingleReturningQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entity: ENTITY,
     ): VISIT_RESULT
@@ -100,7 +112,19 @@ interface QueryVisitor<VISIT_RESULT> {
     ): VISIT_RESULT
 
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
+    entityUpsertMultipleReturningQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityUpsertSingleQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
+    entityUpsertSingleReturningQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
         entity: ENTITY,
     ): VISIT_RESULT

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
@@ -69,6 +69,27 @@ interface QueryVisitor<VISIT_RESULT> {
         entities: List<ENTITY>,
     ): VISIT_RESULT
 
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>
+    entityInsertMultipleReturningSingleColumnQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expression: ColumnExpression<A, *>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>
+    entityInsertMultipleReturningPairColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>
+    entityInsertMultipleReturningTripleColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): VISIT_RESULT
+
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityInsertBatchQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
@@ -85,6 +106,27 @@ interface QueryVisitor<VISIT_RESULT> {
     entityInsertSingleReturningQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entity: ENTITY,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>
+    entityInsertSingleReturningSingleColumnQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>
+    entityInsertSingleReturningPairColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>
+    entityInsertSingleReturningTripleColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
     ): VISIT_RESULT
 
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -105,6 +147,27 @@ interface QueryVisitor<VISIT_RESULT> {
         entity: ENTITY,
     ): VISIT_RESULT
 
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>
+    entityUpdateSingleReturningSingleColumnQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>
+    entityUpdateSingleReturningPairColumnsQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>
+    entityUpdateSingleReturningTripleColumnsQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): VISIT_RESULT
+
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityUpsertBatchQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
@@ -123,16 +186,62 @@ interface QueryVisitor<VISIT_RESULT> {
         entities: List<ENTITY>,
     ): VISIT_RESULT
 
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>
+    entityUpsertMultipleReturningSingleColumnQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expression: ColumnExpression<A, *>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>
+    entityUpsertMultipleReturningPairColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>
+    entityUpsertMultipleReturningTripleColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): VISIT_RESULT
+
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityUpsertSingleQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
         entity: ENTITY,
     ): VISIT_RESULT
 
-    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, R>
     entityUpsertSingleReturningQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
         entity: ENTITY,
+        collect: suspend (Flow<ENTITY>) -> R,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, R>
+    entityUpsertSingleReturningSingleColumnQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+        collect: suspend (Flow<A?>) -> R,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, R>
+    entityUpsertSingleReturningPairColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+        collect: suspend (Flow<Pair<A?, B?>>) -> R,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any, R>
+    entityUpsertSingleReturningTripleColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+        collect: suspend (Flow<Triple<A?, B?, C?>>) -> R,
     ): VISIT_RESULT
 
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
@@ -388,6 +388,29 @@ interface QueryVisitor<VISIT_RESULT> {
     ): VISIT_RESULT
 
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
+    relationInsertValuesReturningQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>
+    relationInsertValuesReturningSingleColumnQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>
+    relationInsertValuesReturningPairColumnsQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>
+    relationInsertValuesReturningTripleColumnsQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     relationInsertSelectQuery(
         context: RelationInsertSelectContext<ENTITY, ID, META>,
     ): VISIT_RESULT
@@ -395,6 +418,29 @@ interface QueryVisitor<VISIT_RESULT> {
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     relationUpdateQuery(
         context: RelationUpdateContext<ENTITY, ID, META>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
+    relationUpdateReturningQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>
+    relationUpdateReturningSingleColumnQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>
+    relationUpdateReturningPairColumnsQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>
+    relationUpdateReturningTripleColumnsQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
     ): VISIT_RESULT
 
     fun templateExecuteQuery(

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
@@ -2,8 +2,10 @@ package org.komapper.dialect.h2
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
@@ -27,6 +29,14 @@ interface H2Dialect : Dialect {
         return H2SchemaStatementBuilder(dialect)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityInsertStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): EntityInsertStatementBuilder<ENTITY, ID, META> {
+        return H2EntityInsertStatementBuilder(dialect, context, entities)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpsertStatementBuilder(
         dialect: BuilderDialect,
         context: EntityUpsertContext<ENTITY, ID, META>,
@@ -36,6 +46,8 @@ interface H2Dialect : Dialect {
     }
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
+    override fun supportsInsertReturning(): Boolean = true
 
     override fun supportsSearchConditionInUpsertStatement(): Boolean = true
 }

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
@@ -4,9 +4,11 @@ import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
+import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationInsertValuesContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 interface H2Dialect : Dialect {
@@ -43,6 +45,13 @@ interface H2Dialect : Dialect {
         entities: List<ENTITY>,
     ): EntityUpsertStatementBuilder<ENTITY> {
         return H2EntityUpsertStatementBuilder(dialect, context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+    ): RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+        return H2RelationInsertValuesStatementBuilder(dialect, context)
     }
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityInsertStatementBuilder.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityInsertStatementBuilder.kt
@@ -19,17 +19,18 @@ class H2EntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamo
     private val builder = DefaultEntityInsertStatementBuilder(dialect, context, entities)
 
     override fun build(): Statement {
-        if (context.returning) {
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
             buf.append("select ")
-            for (p in context.target.properties()) {
-                column(p)
+            for (e in outputExpressions) {
+                column(e)
                 buf.append(", ")
             }
             buf.cutBack(2)
             buf.append(" from final table (")
         }
         buf.append(builder.build())
-        if (context.returning) {
+        if (outputExpressions.isNotEmpty()) {
             buf.append(")")
         }
         return buf.toStatement()

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityInsertStatementBuilder.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityInsertStatementBuilder.kt
@@ -1,0 +1,42 @@
+package org.komapper.dialect.h2
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityInsertStatementBuilder
+import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class H2EntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    entities: List<ENTITY>,
+) : EntityInsertStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultEntityInsertStatementBuilder(dialect, context, entities)
+
+    override fun build(): Statement {
+        if (context.returning) {
+            buf.append("select ")
+            for (p in context.target.properties()) {
+                column(p)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+            buf.append(" from final table (")
+        }
+        buf.append(builder.build())
+        if (context.returning) {
+            buf.append(")")
+        }
+        return buf.toStatement()
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+}

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityUpsertStatementBuilder.kt
@@ -32,6 +32,15 @@ internal class H2EntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Ent
     private val sourceStatementBuilder = SourceStatementBuilder(dialect, context, entities)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        if (context.returning) {
+            buf.append("select ")
+            for (p in target.properties()) {
+                buf.append(p.getCanonicalColumnName(dialect::enquote))
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+            buf.append(" from final table (")
+        }
         buf.append("merge into ")
         table(target, TableNameType.NAME_AND_ALIAS)
         buf.append(" using (")
@@ -77,6 +86,9 @@ internal class H2EntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Ent
                 buf.append(", ")
             }
             buf.cutBack(2)
+        }
+        if (context.returning) {
+            buf.append(")")
         }
         return buf.toStatement()
     }

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityUpsertStatementBuilder.kt
@@ -32,10 +32,11 @@ internal class H2EntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Ent
     private val sourceStatementBuilder = SourceStatementBuilder(dialect, context, entities)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
-        if (context.returning) {
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
             buf.append("select ")
-            for (p in target.properties()) {
-                buf.append(p.getCanonicalColumnName(dialect::enquote))
+            for (e in outputExpressions) {
+                buf.append(e.getCanonicalColumnName(dialect::enquote))
                 buf.append(", ")
             }
             buf.cutBack(2)
@@ -87,7 +88,7 @@ internal class H2EntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Ent
             }
             buf.cutBack(2)
         }
-        if (context.returning) {
+        if (outputExpressions.isNotEmpty()) {
             buf.append(")")
         }
         return buf.toStatement()

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2RelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2RelationInsertValuesStatementBuilder.kt
@@ -1,0 +1,42 @@
+package org.komapper.dialect.h2
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+
+class H2RelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+    private val buf = StatementBuffer()
+    private val builder = RelationInsertValuesStatementBuilder(dialect, context)
+
+    override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
+            buf.append("select ")
+            for (e in outputExpressions) {
+                column(e)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+            buf.append(" from final table (")
+        }
+        buf.append(builder.build(assignments))
+        if (outputExpressions.isNotEmpty()) {
+            buf.append(")")
+        }
+        return buf.toStatement()
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+}

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
@@ -2,11 +2,14 @@ package org.komapper.dialect.mariadb
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.dialect.h2.MariaDbEntityInsertStatementBuilder
 
 interface MariaDbDialect : Dialect {
 
@@ -36,6 +39,14 @@ interface MariaDbDialect : Dialect {
         return MariaDbSchemaStatementBuilder(dialect)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityInsertStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): EntityInsertStatementBuilder<ENTITY, ID, META> {
+        return MariaDbEntityInsertStatementBuilder(dialect, context, entities)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpsertStatementBuilder(
         dialect: BuilderDialect,
         context: EntityUpsertContext<ENTITY, ID, META>,
@@ -49,6 +60,8 @@ interface MariaDbDialect : Dialect {
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false
 
     override fun supportsGeneratedKeysReturningWhenInsertingMultipleRows(): Boolean = false
+
+    override fun supportsInsertReturning(): Boolean = true
 
     override fun supportsLockOptionNowait(): Boolean = true
 

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
@@ -9,7 +9,6 @@ import org.komapper.core.dsl.builder.SchemaStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
-import org.komapper.dialect.h2.MariaDbEntityInsertStatementBuilder
 
 interface MariaDbDialect : Dialect {
 

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
@@ -5,9 +5,11 @@ import org.komapper.core.Dialect
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
+import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationInsertValuesContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 interface MariaDbDialect : Dialect {
@@ -52,6 +54,13 @@ interface MariaDbDialect : Dialect {
         entities: List<ENTITY>,
     ): EntityUpsertStatementBuilder<ENTITY> {
         return MariaDbEntityUpsertStatementBuilder(dialect, context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+    ): RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+        return MariaDbRelationInsertValuesStatementBuilder(dialect, context)
     }
 
     override fun supportsAliasForDeleteStatement() = false

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityInsertStatementBuilder.kt
@@ -20,10 +20,10 @@ class MariaDbEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityM
 
     override fun build(): Statement {
         buf.append(builder.build())
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
+        val expressions = context.returning.expressions()
+        if (expressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (e in outputExpressions) {
+            for (e in expressions) {
                 column(e)
                 buf.append(", ")
             }

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityInsertStatementBuilder.kt
@@ -1,0 +1,38 @@
+package org.komapper.dialect.h2
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityInsertStatementBuilder
+import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class MariaDbEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    entities: List<ENTITY>,
+) : EntityInsertStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultEntityInsertStatementBuilder(dialect, context, entities)
+
+    override fun build(): Statement {
+        buf.append(builder.build())
+        if (context.returning) {
+            buf.append(" returning ")
+            for (p in context.target.properties()) {
+                column(p)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        return buf.toStatement()
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+}

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityInsertStatementBuilder.kt
@@ -1,4 +1,4 @@
-package org.komapper.dialect.h2
+package org.komapper.dialect.mariadb
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
@@ -20,10 +20,11 @@ class MariaDbEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityM
 
     override fun build(): Statement {
         buf.append(builder.build())
-        if (context.returning) {
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (p in context.target.properties()) {
-                column(p)
+            for (e in outputExpressions) {
+                column(e)
                 buf.append(", ")
             }
             buf.cutBack(2)

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityUpsertStatementBuilder.kt
@@ -66,6 +66,14 @@ class MariaDbEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityM
             }
             buf.cutBack(2)
         }
+        if (context.returning) {
+            buf.append(" returning ")
+            for (p in target.properties()) {
+                column(p)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
         return buf.toStatement()
     }
 

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityUpsertStatementBuilder.kt
@@ -66,10 +66,11 @@ class MariaDbEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityM
             }
             buf.cutBack(2)
         }
-        if (context.returning) {
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (p in target.properties()) {
-                column(p)
+            for (e in outputExpressions) {
+                column(e)
                 buf.append(", ")
             }
             buf.cutBack(2)

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityUpsertStatementBuilder.kt
@@ -66,10 +66,10 @@ class MariaDbEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityM
             }
             buf.cutBack(2)
         }
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
+        val expressions = context.returning.expressions()
+        if (expressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (e in outputExpressions) {
+            for (e in expressions) {
                 column(e)
                 buf.append(", ")
             }

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbRelationInsertValuesStatementBuilder.kt
@@ -19,10 +19,10 @@ class MariaDbRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META :
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         buf.append(builder.build(assignments))
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
+        val expressions = context.returning.expressions()
+        if (expressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (e in outputExpressions) {
+            for (e in expressions) {
                 column(e)
                 buf.append(", ")
             }

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbRelationInsertValuesStatementBuilder.kt
@@ -1,0 +1,38 @@
+package org.komapper.dialect.mariadb
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+
+class MariaDbRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+    private val buf = StatementBuffer()
+    private val builder = RelationInsertValuesStatementBuilder(dialect, context)
+
+    override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        buf.append(builder.build(assignments))
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
+            buf.append(" returning ")
+            for (e in outputExpressions) {
+                column(e)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        return buf.toStatement()
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+}

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
@@ -5,10 +5,14 @@ import org.komapper.core.Dialect
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
+import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
+import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.context.RelationUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 interface PostgreSqlDialect : Dialect {
@@ -53,6 +57,20 @@ interface PostgreSqlDialect : Dialect {
         entities: List<ENTITY>,
     ): EntityUpsertStatementBuilder<ENTITY> {
         return PostgreSqlEntityUpsertStatementBuilder(dialect, context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+    ): RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+        return PostgreSqlRelationInsertValuesStatementBuilder(dialect, context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationUpdateStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationUpdateContext<ENTITY, ID, META>,
+    ): RelationUpdateStatementBuilder<ENTITY, ID, META> {
+        return PostgreSqlRelationUpdateStatementBuilder(dialect, context)
     }
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = true

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
@@ -3,12 +3,15 @@ package org.komapper.dialect.postgresql
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
+import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.dialect.h2.PostgreSqlEntityInsertStatementBuilder
+import org.komapper.dialect.h2.PostgreSqlEntityUpdateStatementBuilder
 
 interface PostgreSqlDialect : Dialect {
 
@@ -38,6 +41,14 @@ interface PostgreSqlDialect : Dialect {
         return PostgreSqlEntityInsertStatementBuilder(dialect, context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpdateStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): EntityUpdateStatementBuilder<ENTITY, ID, META> {
+        return PostgreSqlEntityUpdateStatementBuilder(dialect, context, entity)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpsertStatementBuilder(
         dialect: BuilderDialect,
         context: EntityUpsertContext<ENTITY, ID, META>,
@@ -57,4 +68,6 @@ interface PostgreSqlDialect : Dialect {
     override fun supportsInsertReturning(): Boolean = true
 
     override fun supportsSearchConditionInUpsertStatement(): Boolean = true
+
+    override fun supportsUpdateReturning(): Boolean = true
 }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
@@ -10,8 +10,6 @@ import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
-import org.komapper.dialect.h2.PostgreSqlEntityInsertStatementBuilder
-import org.komapper.dialect.h2.PostgreSqlEntityUpdateStatementBuilder
 
 interface PostgreSqlDialect : Dialect {
 

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
@@ -2,10 +2,13 @@ package org.komapper.dialect.postgresql
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.dialect.h2.PostgreSqlEntityInsertStatementBuilder
 
 interface PostgreSqlDialect : Dialect {
 
@@ -27,6 +30,14 @@ interface PostgreSqlDialect : Dialect {
         return PostgreSqlSchemaStatementBuilder(dialect)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityInsertStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): EntityInsertStatementBuilder<ENTITY, ID, META> {
+        return PostgreSqlEntityInsertStatementBuilder(dialect, context, entities)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpsertStatementBuilder(
         dialect: BuilderDialect,
         context: EntityUpsertContext<ENTITY, ID, META>,
@@ -42,6 +53,8 @@ interface PostgreSqlDialect : Dialect {
     override fun supportsLockOptionNowait(): Boolean = true
 
     override fun supportsLockOptionSkipLocked(): Boolean = true
+
+    override fun supportsInsertReturning(): Boolean = true
 
     override fun supportsSearchConditionInUpsertStatement(): Boolean = true
 }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityInsertStatementBuilder.kt
@@ -20,10 +20,10 @@ class PostgreSqlEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
 
     override fun build(): Statement {
         buf.append(builder.build())
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
+        val expressions = context.returning.expressions()
+        if (expressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (e in outputExpressions) {
+            for (e in expressions) {
                 column(e)
                 buf.append(", ")
             }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityInsertStatementBuilder.kt
@@ -1,4 +1,4 @@
-package org.komapper.dialect.h2
+package org.komapper.dialect.postgresql
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
@@ -20,10 +20,11 @@ class PostgreSqlEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
 
     override fun build(): Statement {
         buf.append(builder.build())
-        if (context.returning) {
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (p in context.target.properties()) {
-                column(p)
+            for (e in outputExpressions) {
+                column(e)
                 buf.append(", ")
             }
             buf.cutBack(2)

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityInsertStatementBuilder.kt
@@ -1,0 +1,38 @@
+package org.komapper.dialect.h2
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityInsertStatementBuilder
+import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class PostgreSqlEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    entities: List<ENTITY>,
+) : EntityInsertStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultEntityInsertStatementBuilder(dialect, context, entities)
+
+    override fun build(): Statement {
+        buf.append(builder.build())
+        if (context.returning) {
+            buf.append(" returning ")
+            for (p in context.target.properties()) {
+                column(p)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        return buf.toStatement()
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+}

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpdateStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpdateStatementBuilder.kt
@@ -1,0 +1,38 @@
+package org.komapper.dialect.h2
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityUpdateStatementBuilder
+import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
+import org.komapper.core.dsl.context.EntityUpdateContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class PostgreSqlEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+    entity: ENTITY,
+) : EntityUpdateStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultEntityUpdateStatementBuilder(dialect, context, entity)
+
+    override fun build(): Statement {
+        buf.append(builder.build())
+        if (context.returning) {
+            buf.append(" returning ")
+            for (p in context.target.properties()) {
+                column(p)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        return buf.toStatement()
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+}

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpdateStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpdateStatementBuilder.kt
@@ -20,10 +20,10 @@ class PostgreSqlEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : Enti
 
     override fun build(): Statement {
         buf.append(builder.build())
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
+        val expressions = context.returning.expressions()
+        if (expressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (e in outputExpressions) {
+            for (e in expressions) {
                 column(e)
                 buf.append(", ")
             }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpdateStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpdateStatementBuilder.kt
@@ -1,4 +1,4 @@
-package org.komapper.dialect.h2
+package org.komapper.dialect.postgresql
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
@@ -20,10 +20,11 @@ class PostgreSqlEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : Enti
 
     override fun build(): Statement {
         buf.append(builder.build())
-        if (context.returning) {
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (p in context.target.properties()) {
-                column(p)
+            for (e in outputExpressions) {
+                column(e)
                 buf.append(", ")
             }
             buf.cutBack(2)

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
@@ -88,10 +88,10 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
                 }
             }
         }
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
+        val expressions = context.returning.expressions()
+        if (expressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (e in outputExpressions) {
+            for (e in expressions) {
                 column(e)
                 buf.append(", ")
             }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
@@ -88,6 +88,14 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
                 }
             }
         }
+        if (context.returning) {
+            buf.append(" returning ")
+            for (p in target.properties()) {
+                column(p)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
         return buf.toStatement()
     }
 

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
@@ -88,10 +88,11 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
                 }
             }
         }
-        if (context.returning) {
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (p in target.properties()) {
-                column(p)
+            for (e in outputExpressions) {
+                column(e)
                 buf.append(", ")
             }
             buf.cutBack(2)

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationInsertValuesStatementBuilder.kt
@@ -19,10 +19,10 @@ class PostgreSqlRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, MET
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         buf.append(builder.build(assignments))
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
+        val expressions = context.returning.expressions()
+        if (expressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (e in outputExpressions) {
+            for (e in expressions) {
                 column(e)
                 buf.append(", ")
             }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationInsertValuesStatementBuilder.kt
@@ -1,0 +1,38 @@
+package org.komapper.dialect.postgresql
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+
+class PostgreSqlRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+    private val buf = StatementBuffer()
+    private val builder = RelationInsertValuesStatementBuilder(dialect, context)
+
+    override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        buf.append(builder.build(assignments))
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
+            buf.append(" returning ")
+            for (e in outputExpressions) {
+                column(e)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        return buf.toStatement()
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+}

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationUpdateStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationUpdateStatementBuilder.kt
@@ -1,0 +1,39 @@
+package org.komapper.dialect.postgresql
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
+import org.komapper.core.dsl.context.RelationUpdateContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+
+class PostgreSqlRelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: RelationUpdateContext<ENTITY, ID, META>,
+) : RelationUpdateStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = RelationUpdateStatementBuilder(dialect, context)
+
+    override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        buf.append(builder.build(assignments))
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
+            buf.append(" returning ")
+            for (e in outputExpressions) {
+                column(e)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        return buf.toStatement()
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+}

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationUpdateStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationUpdateStatementBuilder.kt
@@ -20,10 +20,10 @@ class PostgreSqlRelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : En
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         buf.append(builder.build(assignments))
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
+        val expressions = context.returning.expressions()
+        if (expressions.isNotEmpty()) {
             buf.append(" returning ")
-            for (e in outputExpressions) {
+            for (e in expressions) {
                 column(e)
                 buf.append(", ")
             }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerBuilderSupport.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerBuilderSupport.kt
@@ -1,0 +1,35 @@
+package org.komapper.dialect.sqlserver
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.context.ReturningProvider
+import org.komapper.core.dsl.expression.ColumnExpression
+
+class SqlServerBuilderSupport(
+    private val dialect: BuilderDialect,
+    private val returningProvider: ReturningProvider,
+) {
+
+    fun buildOutput(): Statement {
+        val buf = StatementBuffer()
+        with(buf) {
+            val expressions = returningProvider.returning.expressions()
+            if (expressions.isNotEmpty()) {
+                append(" output ")
+                for (e in expressions) {
+                    append("inserted.")
+                    column(e)
+                    append(", ")
+                }
+                cutBack(2)
+            }
+        }
+        return buf.toStatement()
+    }
+
+    private fun StatementBuffer.column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        append(name)
+    }
+}

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
@@ -2,10 +2,18 @@ package org.komapper.dialect.sqlserver
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
+import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
+import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
+import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.context.RelationUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 interface SqlServerDialect : Dialect {
@@ -41,12 +49,42 @@ interface SqlServerDialect : Dialect {
         return SqlServerSchemaStatementBuilder(dialect)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityInsertStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): EntityInsertStatementBuilder<ENTITY, ID, META> {
+        return SqlServerEntityInsertStatementBuilder(dialect, context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpdateStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): EntityUpdateStatementBuilder<ENTITY, ID, META> {
+        return SqlServerEntityUpdateStatementBuilder(dialect, context, entity)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpsertStatementBuilder(
         dialect: BuilderDialect,
         context: EntityUpsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
     ): EntityUpsertStatementBuilder<ENTITY> {
         return SqlServerEntityUpsertStatementBuilder(dialect, context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+    ): RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+        return SqlServerRelationInsertValuesStatementBuilder(dialect, context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationUpdateStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationUpdateContext<ENTITY, ID, META>,
+    ): RelationUpdateStatementBuilder<ENTITY, ID, META> {
+        return SqlServerRelationUpdateStatementBuilder(dialect, context)
     }
 
     override fun getDefaultLengthForSubstringFunction(): Int? = Int.MAX_VALUE
@@ -69,9 +107,13 @@ interface SqlServerDialect : Dialect {
 
     override fun supportsForUpdateClause(): Boolean = false
 
+    override fun supportsInsertReturning(): Boolean = true
+
     override fun supportsMultipleColumnsInInPredicate(): Boolean = false
 
     override fun supportsTableHint(): Boolean = true
+
+    override fun supportsUpdateReturning(): Boolean = true
 
     override fun supportsLockOptionNowait(): Boolean = true
 

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityInsertStatementBuilder.kt
@@ -3,62 +3,31 @@ package org.komapper.dialect.sqlserver
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
-import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
-import org.komapper.core.dsl.metamodel.getNonAutoIncrementProperties
 
 class SqlServerEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val dialect: BuilderDialect,
-    private val context: EntityInsertContext<ENTITY, ID, META>,
-    private val entities: List<ENTITY>,
+    dialect: BuilderDialect,
+    context: EntityInsertContext<ENTITY, ID, META>,
+    entities: List<ENTITY>,
 ) : EntityInsertStatementBuilder<ENTITY, ID, META> {
 
-    private val buf = StatementBuffer()
+    private val builder = DefaultEntityInsertStatementBuilder(dialect, context, entities)
+
+    private val support = SqlServerBuilderSupport(dialect, context)
 
     override fun build(): Statement {
-        val target = context.target
-        val properties = target.getNonAutoIncrementProperties()
-        buf.append("insert into ")
-        table(target)
-        buf.append(" (")
-        for (p in properties) {
-            column(p)
-            buf.append(", ")
+        val buf = StatementBuffer()
+        buf.append(builder.buildInsertInto())
+        val outputStatement = support.buildOutput()
+        if (outputStatement.parts.isNotEmpty()) {
+            buf.append(" ")
+            buf.append(outputStatement)
         }
-        buf.cutBack(2)
-        buf.append(")")
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
-            buf.append(" output ")
-            for (e in outputExpressions) {
-                buf.append("inserted.")
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
-        buf.append(" values ")
-        for (entity in entities) {
-            buf.append("(")
-            for (p in properties) {
-                buf.bind(p.toValue(entity))
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-            buf.append("), ")
-        }
-        buf.cutBack(2)
+        buf.append(" ")
+        buf.append(builder.buildValues())
         return buf.toStatement()
     }
-
-    private fun table(metamodel: EntityMetamodel<*, *, *>) {
-        val name = metamodel.getCanonicalTableName(dialect::enquote)
-        buf.append(name)
-    }
-
-    private fun column(expression: ColumnExpression<*, *>) {
-        val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
-    } }
+}

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityInsertStatementBuilder.kt
@@ -1,0 +1,64 @@
+package org.komapper.dialect.sqlserver
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.getNonAutoIncrementProperties
+
+class SqlServerEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+) : EntityInsertStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+
+    override fun build(): Statement {
+        val target = context.target
+        val properties = target.getNonAutoIncrementProperties()
+        buf.append("insert into ")
+        table(target)
+        buf.append(" (")
+        for (p in properties) {
+            column(p)
+            buf.append(", ")
+        }
+        buf.cutBack(2)
+        buf.append(")")
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
+            buf.append(" output ")
+            for (e in outputExpressions) {
+                buf.append("inserted.")
+                column(e)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        buf.append(" values ")
+        for (entity in entities) {
+            buf.append("(")
+            for (p in properties) {
+                buf.bind(p.toValue(entity))
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+            buf.append("), ")
+        }
+        buf.cutBack(2)
+        return buf.toStatement()
+    }
+
+    private fun table(metamodel: EntityMetamodel<*, *, *>) {
+        val name = metamodel.getCanonicalTableName(dialect::enquote)
+        buf.append(name)
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    } }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpdateStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpdateStatementBuilder.kt
@@ -1,0 +1,94 @@
+package org.komapper.dialect.sqlserver
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.BuilderSupport
+import org.komapper.core.dsl.builder.EmptyAliasManager
+import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
+import org.komapper.core.dsl.builder.TableNameType
+import org.komapper.core.dsl.builder.getWhereCriteria
+import org.komapper.core.dsl.context.EntityUpdateContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Criterion
+import org.komapper.core.dsl.expression.TableExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class SqlServerEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : EntityUpdateStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val support = BuilderSupport(dialect, EmptyAliasManager, buf)
+
+    override fun build(): Statement {
+        val target = context.target
+        val idProperties = target.idProperties()
+        val versionProperty = target.versionProperty()
+        buf.append("update ")
+        table(target)
+        buf.append(" set ")
+        for (p in context.getTargetProperties()) {
+            column(p)
+            buf.append(" = ")
+            buf.bind(p.toValue(entity))
+            if (p == versionProperty) {
+                buf.append(" + 1")
+            }
+            buf.append(", ")
+        }
+        buf.cutBack(2)
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
+            buf.append(" output ")
+            for (e in outputExpressions) {
+                buf.append("inserted.")
+                column(e)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        val criteria = context.getWhereCriteria()
+        val versionRequired = versionProperty != null && !context.options.disableOptimisticLock
+        if (criteria.isNotEmpty() || idProperties.isNotEmpty() || versionRequired) {
+            buf.append(" where ")
+            for ((index, criterion) in criteria.withIndex()) {
+                criterion(index, criterion)
+                buf.append(" and ")
+            }
+            if (idProperties.isNotEmpty()) {
+                for (p in idProperties) {
+                    column(p)
+                    buf.append(" = ")
+                    buf.bind(p.toValue(entity))
+                    buf.append(" and ")
+                }
+                if (!versionRequired) {
+                    buf.cutBack(5)
+                }
+            }
+            if (versionRequired) {
+                checkNotNull(versionProperty)
+                column(versionProperty)
+                buf.append(" = ")
+                buf.bind(versionProperty.toValue(entity))
+            }
+        }
+        return buf.toStatement()
+    }
+
+    private fun table(expression: TableExpression<*>) {
+        support.visitTableExpression(expression, TableNameType.NAME_ONLY)
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+
+    private fun criterion(index: Int, c: Criterion) {
+        support.visitCriterion(index, c)
+    }
+}

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpdateStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpdateStatementBuilder.kt
@@ -3,92 +3,30 @@ package org.komapper.dialect.sqlserver
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
-import org.komapper.core.dsl.builder.BuilderSupport
-import org.komapper.core.dsl.builder.EmptyAliasManager
+import org.komapper.core.dsl.builder.DefaultEntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
-import org.komapper.core.dsl.builder.TableNameType
-import org.komapper.core.dsl.builder.getWhereCriteria
 import org.komapper.core.dsl.context.EntityUpdateContext
-import org.komapper.core.dsl.expression.ColumnExpression
-import org.komapper.core.dsl.expression.Criterion
-import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 class SqlServerEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val dialect: BuilderDialect,
-    private val context: EntityUpdateContext<ENTITY, ID, META>,
-    private val entity: ENTITY,
+    dialect: BuilderDialect,
+    context: EntityUpdateContext<ENTITY, ID, META>,
+    entity: ENTITY,
 ) : EntityUpdateStatementBuilder<ENTITY, ID, META> {
 
-    private val buf = StatementBuffer()
-    private val support = BuilderSupport(dialect, EmptyAliasManager, buf)
+    private val builder = DefaultEntityUpdateStatementBuilder(dialect, context, entity)
+    private val support = SqlServerBuilderSupport(dialect, context)
 
     override fun build(): Statement {
-        val target = context.target
-        val idProperties = target.idProperties()
-        val versionProperty = target.versionProperty()
-        buf.append("update ")
-        table(target)
-        buf.append(" set ")
-        for (p in context.getTargetProperties()) {
-            column(p)
-            buf.append(" = ")
-            buf.bind(p.toValue(entity))
-            if (p == versionProperty) {
-                buf.append(" + 1")
-            }
-            buf.append(", ")
+        val buf = StatementBuffer()
+        buf.append(builder.buildUpdateSet())
+        val outputStatement = support.buildOutput()
+        if (outputStatement.parts.isNotEmpty()) {
+            buf.append(" ")
+            buf.append(outputStatement)
         }
-        buf.cutBack(2)
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
-            buf.append(" output ")
-            for (e in outputExpressions) {
-                buf.append("inserted.")
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
-        val criteria = context.getWhereCriteria()
-        val versionRequired = versionProperty != null && !context.options.disableOptimisticLock
-        if (criteria.isNotEmpty() || idProperties.isNotEmpty() || versionRequired) {
-            buf.append(" where ")
-            for ((index, criterion) in criteria.withIndex()) {
-                criterion(index, criterion)
-                buf.append(" and ")
-            }
-            if (idProperties.isNotEmpty()) {
-                for (p in idProperties) {
-                    column(p)
-                    buf.append(" = ")
-                    buf.bind(p.toValue(entity))
-                    buf.append(" and ")
-                }
-                if (!versionRequired) {
-                    buf.cutBack(5)
-                }
-            }
-            if (versionRequired) {
-                checkNotNull(versionProperty)
-                column(versionProperty)
-                buf.append(" = ")
-                buf.bind(versionProperty.toValue(entity))
-            }
-        }
+        buf.append(" ")
+        buf.append(builder.buildWhere())
         return buf.toStatement()
-    }
-
-    private fun table(expression: TableExpression<*>) {
-        support.visitTableExpression(expression, TableNameType.NAME_ONLY)
-    }
-
-    private fun column(expression: ColumnExpression<*, *>) {
-        val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
-    }
-
-    private fun criterion(index: Int, c: Criterion) {
-        support.visitCriterion(index, c)
     }
 }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpsertStatementBuilder.kt
@@ -85,6 +85,16 @@ internal class SqlServerEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, MET
         }
         buf.cutBack(2)
         buf.append(")")
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
+            buf.append(" output ")
+            for (e in outputExpressions) {
+                buf.append("inserted.")
+                columnWithoutAlias(e)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
         buf.append(";")
         return buf.toStatement()
     }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpsertStatementBuilder.kt
@@ -29,6 +29,7 @@ internal class SqlServerEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, MET
     private val aliasManager = UpsertAliasManager(target, excluded)
     private val buf = StatementBuffer()
     private val support = BuilderSupport(dialect, aliasManager, buf, context.insertContext.options.escapeSequence)
+    private val sqlServerSupport = SqlServerBuilderSupport(dialect, context)
     private val sourceStatementBuilder = SourceStatementBuilder(dialect, context, entities)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
@@ -85,15 +86,10 @@ internal class SqlServerEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, MET
         }
         buf.cutBack(2)
         buf.append(")")
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
-            buf.append(" output ")
-            for (e in outputExpressions) {
-                buf.append("inserted.")
-                columnWithoutAlias(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
+        val outputStatement = sqlServerSupport.buildOutput()
+        if (outputStatement.parts.isNotEmpty()) {
+            buf.append(" ")
+            buf.append(outputStatement)
         }
         buf.append(";")
         return buf.toStatement()

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationInsertValuesStatementBuilder.kt
@@ -1,0 +1,71 @@
+package org.komapper.dialect.sqlserver
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.BuilderSupport
+import org.komapper.core.dsl.builder.DefaultAliasManager
+import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+
+class SqlServerRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+    private val aliasManager = DefaultAliasManager(context)
+    private val buf = StatementBuffer()
+    private val support = BuilderSupport(dialect, aliasManager, buf)
+
+    override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        val target = context.target
+        buf.append("insert into ")
+        table(target)
+        buf.append(" (")
+        if (assignments.isNotEmpty()) {
+            for ((property, _) in assignments) {
+                column(property)
+                buf.append(", ")
+            }
+        }
+        buf.cutBack(2)
+        buf.append(")")
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
+            buf.append(" output ")
+            for (e in outputExpressions) {
+                buf.append("inserted.")
+                column(e)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        buf.append(" values (")
+        if (assignments.isNotEmpty()) {
+            for ((_, operand) in assignments) {
+                operand(operand)
+                buf.append(", ")
+            }
+        }
+        buf.cutBack(2)
+        buf.append(")")
+        return buf.toStatement()
+    }
+
+    private fun table(metamodel: EntityMetamodel<*, *, *>) {
+        val name = metamodel.getCanonicalTableName(dialect::enquote)
+        buf.append(name)
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+
+    private fun operand(operand: Operand) {
+        support.visitOperand(operand)
+    }
+}

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationInsertValuesStatementBuilder.kt
@@ -3,69 +3,32 @@ package org.komapper.dialect.sqlserver
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
-import org.komapper.core.dsl.builder.BuilderSupport
-import org.komapper.core.dsl.builder.DefaultAliasManager
+import org.komapper.core.dsl.builder.DefaultRelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.context.RelationInsertValuesContext
-import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 
 class SqlServerRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val dialect: BuilderDialect,
-    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+    dialect: BuilderDialect,
+    context: RelationInsertValuesContext<ENTITY, ID, META>,
 ) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
-    private val aliasManager = DefaultAliasManager(context)
-    private val buf = StatementBuffer()
-    private val support = BuilderSupport(dialect, aliasManager, buf)
+
+    private val builder = DefaultRelationInsertValuesStatementBuilder(dialect, context)
+
+    private val support = SqlServerBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
-        val target = context.target
-        buf.append("insert into ")
-        table(target)
-        buf.append(" (")
-        if (assignments.isNotEmpty()) {
-            for ((property, _) in assignments) {
-                column(property)
-                buf.append(", ")
-            }
+        val buf = StatementBuffer()
+        buf.append(builder.buildInsertInto(assignments))
+        val outputStatement = support.buildOutput()
+        if (outputStatement.parts.isNotEmpty()) {
+            buf.append(" ")
+            buf.append(outputStatement)
         }
-        buf.cutBack(2)
-        buf.append(")")
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
-            buf.append(" output ")
-            for (e in outputExpressions) {
-                buf.append("inserted.")
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
-        buf.append(" values (")
-        if (assignments.isNotEmpty()) {
-            for ((_, operand) in assignments) {
-                operand(operand)
-                buf.append(", ")
-            }
-        }
-        buf.cutBack(2)
-        buf.append(")")
+        buf.append(" ")
+        buf.append(builder.buildValues(assignments))
         return buf.toStatement()
-    }
-
-    private fun table(metamodel: EntityMetamodel<*, *, *>) {
-        val name = metamodel.getCanonicalTableName(dialect::enquote)
-        buf.append(name)
-    }
-
-    private fun column(expression: ColumnExpression<*, *>) {
-        val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
-    }
-
-    private fun operand(operand: Operand) {
-        support.visitOperand(operand)
     }
 }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationUpdateStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationUpdateStatementBuilder.kt
@@ -3,86 +3,32 @@ package org.komapper.dialect.sqlserver
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
-import org.komapper.core.dsl.builder.BuilderSupport
-import org.komapper.core.dsl.builder.EmptyAliasManager
+import org.komapper.core.dsl.builder.DefaultRelationUpdateStatementBuilder
 import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
-import org.komapper.core.dsl.builder.TableNameType
-import org.komapper.core.dsl.builder.getWhereCriteria
 import org.komapper.core.dsl.context.RelationUpdateContext
-import org.komapper.core.dsl.expression.ColumnExpression
-import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.Operand
-import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 
 class SqlServerRelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val dialect: BuilderDialect,
-    private val context: RelationUpdateContext<ENTITY, ID, META>,
+    dialect: BuilderDialect,
+    context: RelationUpdateContext<ENTITY, ID, META>,
 ) : RelationUpdateStatementBuilder<ENTITY, ID, META> {
 
-    private val buf = StatementBuffer()
-    private val support = BuilderSupport(dialect, EmptyAliasManager, buf, context.options.escapeSequence)
+    private val builder = DefaultRelationUpdateStatementBuilder(dialect, context)
+
+    private val support = SqlServerBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
-        buf.append("update ")
-        table(context.target)
-        buf.append(" set ")
-        if (assignments.isNotEmpty()) {
-            for ((left, right) in assignments) {
-                column(left)
-                buf.append(" = ")
-                operand(right)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
+        val buf = StatementBuffer()
+        buf.append(builder.buildUpdateSet(assignments))
+        val outputStatement = support.buildOutput()
+        if (outputStatement.parts.isNotEmpty()) {
+            buf.append(" ")
+            buf.append(outputStatement)
         }
-        val version = context.target.versionProperty()
-        if (version != null && version !in assignments.map { it.first }) {
-            if (assignments.isNotEmpty()) {
-                buf.append(", ")
-            }
-            column(version)
-            buf.append(" = ")
-            column(version)
-            buf.append(" + 1")
-        }
-        val outputExpressions = context.returning.expressions()
-        if (outputExpressions.isNotEmpty()) {
-            buf.append(" output ")
-            for (e in outputExpressions) {
-                buf.append("inserted.")
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
-        val criteria = context.getWhereCriteria()
-        if (criteria.isNotEmpty()) {
-            buf.append(" where ")
-            for ((index, criterion) in criteria.withIndex()) {
-                criterion(index, criterion)
-                buf.append(" and ")
-            }
-            buf.cutBack(5)
-        }
+        buf.append(" ")
+        buf.append(builder.buildWhere())
         return buf.toStatement()
-    }
-
-    private fun table(expression: TableExpression<*>) {
-        support.visitTableExpression(expression, TableNameType.NAME_AND_ALIAS)
-    }
-
-    private fun column(expression: ColumnExpression<*, *>) {
-        val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
-    }
-
-    private fun criterion(index: Int, c: Criterion) {
-        return support.visitCriterion(index, c)
-    }
-
-    private fun operand(operand: Operand) {
-        support.visitOperand(operand)
     }
 }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationUpdateStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationUpdateStatementBuilder.kt
@@ -1,0 +1,88 @@
+package org.komapper.dialect.sqlserver
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.BuilderSupport
+import org.komapper.core.dsl.builder.EmptyAliasManager
+import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
+import org.komapper.core.dsl.builder.TableNameType
+import org.komapper.core.dsl.builder.getWhereCriteria
+import org.komapper.core.dsl.context.RelationUpdateContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Criterion
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.expression.TableExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+
+class SqlServerRelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: RelationUpdateContext<ENTITY, ID, META>,
+) : RelationUpdateStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val support = BuilderSupport(dialect, EmptyAliasManager, buf, context.options.escapeSequence)
+
+    override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        buf.append("update ")
+        table(context.target)
+        buf.append(" set ")
+        if (assignments.isNotEmpty()) {
+            for ((left, right) in assignments) {
+                column(left)
+                buf.append(" = ")
+                operand(right)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        val version = context.target.versionProperty()
+        if (version != null && version !in assignments.map { it.first }) {
+            if (assignments.isNotEmpty()) {
+                buf.append(", ")
+            }
+            column(version)
+            buf.append(" = ")
+            column(version)
+            buf.append(" + 1")
+        }
+        val outputExpressions = context.returning.expressions()
+        if (outputExpressions.isNotEmpty()) {
+            buf.append(" output ")
+            for (e in outputExpressions) {
+                buf.append("inserted.")
+                column(e)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+        val criteria = context.getWhereCriteria()
+        if (criteria.isNotEmpty()) {
+            buf.append(" where ")
+            for ((index, criterion) in criteria.withIndex()) {
+                criterion(index, criterion)
+                buf.append(" and ")
+            }
+            buf.cutBack(5)
+        }
+        return buf.toStatement()
+    }
+
+    private fun table(expression: TableExpression<*>) {
+        support.visitTableExpression(expression, TableNameType.NAME_AND_ALIAS)
+    }
+
+    private fun column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        buf.append(name)
+    }
+
+    private fun criterion(index: Int, c: Criterion) {
+        return support.visitCriterion(index, c)
+    }
+
+    private fun operand(operand: Operand) {
+        support.visitOperand(operand)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcExecutor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcExecutor.kt
@@ -53,15 +53,9 @@ internal class JdbcExecutor(
                     log(statement)
                     bind(ps, statement)
                     ps.executeQuery().use { rs ->
-                        val iterator = object : Iterator<T> {
-                            var hasNext = rs.next()
-                            override fun hasNext() = hasNext
-                            override fun next(): T {
-                                return transform(config.dataOperator, rs).also { hasNext = rs.next() }
-                            }
-                        }
+                        val sequence = createSequence(rs, transform)
                         runBlocking {
-                            collect(iterator.asFlow())
+                            collect(sequence.asFlow())
                         }
                     }
                 }
@@ -146,6 +140,29 @@ internal class JdbcExecutor(
         }
     }
 
+    fun <T, R> execute(
+        statement: Statement,
+        transform: (JdbcDataOperator, ResultSet) -> T,
+        handle: (Sequence<T>) -> R,
+    ): R {
+        return withExceptionTranslator {
+            @Suppress("NAME_SHADOWING")
+            val statement = inspect(statement)
+            config.session.useConnection { con ->
+                prepare(con, statement).use { ps ->
+                    setUp(ps)
+                    log(statement)
+                    bind(ps, statement)
+                    ps.execute()
+                    ps.resultSet.use { rs ->
+                        val sequence = createSequence(rs, transform)
+                        handle(sequence)
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * Translates a [Exception] to a [RuntimeException].
      */
@@ -215,6 +232,14 @@ internal class JdbcExecutor(
                 keys.add(key)
             }
             keys
+        }
+    }
+
+    private fun <T> createSequence(rs: ResultSet, transform: (JdbcDataOperator, ResultSet) -> T): Sequence<T> {
+        return sequence {
+            while (rs.next()) {
+                yield(transform(config.dataOperator, rs))
+            }
         }
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertMultipleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertMultipleReturningRunner.kt
@@ -1,0 +1,47 @@
+package org.komapper.jdbc.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityInsertMultipleReturningRunner
+import org.komapper.jdbc.JdbcDatabaseConfig
+
+internal class JdbcEntityInsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+) :
+    JdbcRunner<List<ENTITY>> {
+
+    private val runner: EntityInsertMultipleReturningRunner<ENTITY, ID, META> =
+        EntityInsertMultipleReturningRunner(context, entities)
+
+    private val support: JdbcEntityInsertReturningRunnerSupport<ENTITY, ID, META> =
+        JdbcEntityInsertReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override fun run(config: JdbcDatabaseConfig): List<ENTITY> {
+        if (entities.isEmpty()) return emptyList()
+        val newEntities = preInsert(config)
+        return insert(config, newEntities)
+    }
+
+    private fun preInsert(config: JdbcDatabaseConfig): List<ENTITY> {
+        return entities.map { support.preInsert(config, it) }
+    }
+
+    private fun insert(config: JdbcDatabaseConfig, entities: List<ENTITY>): List<ENTITY> {
+        val statement = runner.buildStatement(config, entities)
+        return support.insert(config) { executor ->
+            val transform = JdbcResultSetTransformers.singleEntity(context.target)
+            executor.execute(statement, transform) { it.toList() }
+        }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertReturningRunnerSupport.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertReturningRunnerSupport.kt
@@ -1,0 +1,32 @@
+package org.komapper.jdbc.dsl.runner
+
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.jdbc.JdbcDatabaseConfig
+import org.komapper.jdbc.JdbcExecutor
+
+internal class JdbcEntityInsertReturningRunnerSupport<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+) {
+
+    fun preInsert(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY {
+        val newEntity = when (val idGenerator = context.target.idGenerator()) {
+            is IdGenerator.Sequence<ENTITY, ID> ->
+                if (!context.target.disableSequenceAssignment() && !context.options.disableSequenceAssignment) {
+                    val id = idGenerator.execute(config, context.options)
+                    idGenerator.property.setter(entity, id)
+                } else {
+                    null
+                }
+            else -> null
+        }
+        val clock = config.clockProvider.now()
+        return context.target.preInsert(newEntity ?: entity, clock)
+    }
+
+    fun <T> insert(config: JdbcDatabaseConfig, execute: (JdbcExecutor) -> T): T {
+        val executor = JdbcExecutor(config, context.options)
+        return execute(executor)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertSingleReturningRunner.kt
@@ -1,0 +1,45 @@
+package org.komapper.jdbc.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityInsertSingleReturningRunner
+import org.komapper.jdbc.JdbcDatabaseConfig
+
+internal class JdbcEntityInsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : JdbcRunner<ENTITY> {
+
+    private val runner: EntityInsertSingleReturningRunner<ENTITY, ID, META> =
+        EntityInsertSingleReturningRunner(context, entity)
+
+    private val support: JdbcEntityInsertReturningRunnerSupport<ENTITY, ID, META> =
+        JdbcEntityInsertReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override fun run(config: JdbcDatabaseConfig): ENTITY {
+        val newEntity = preInsert(config)
+        return insert(config, newEntity)
+    }
+
+    private fun preInsert(config: JdbcDatabaseConfig): ENTITY {
+        return support.preInsert(config, entity)
+    }
+
+    private fun insert(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY {
+        val statement = runner.buildStatement(config, entity)
+        return support.insert(config) { executor ->
+            val transform = JdbcResultSetTransformers.singleEntity(context.target)
+            executor.execute(statement, transform) { it.first() }
+        }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateReturningRunnerSupport.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateReturningRunnerSupport.kt
@@ -1,0 +1,16 @@
+package org.komapper.jdbc.dsl.runner
+
+import org.komapper.core.dsl.context.EntityUpdateContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.jdbc.JdbcDatabaseConfig
+import org.komapper.jdbc.JdbcExecutor
+
+internal class JdbcEntityUpdateReturningRunnerSupport<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+) {
+
+    fun <T> update(config: JdbcDatabaseConfig, execute: (JdbcExecutor) -> T): T {
+        val executor = JdbcExecutor(config, context.options)
+        return execute(executor)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateSingleReturningRunner.kt
@@ -1,0 +1,50 @@
+package org.komapper.jdbc.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityUpdateContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityUpdateSingleReturningRunner
+import org.komapper.jdbc.JdbcDatabaseConfig
+
+internal class JdbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : JdbcRunner<ENTITY?> {
+
+    private val runner: EntityUpdateSingleReturningRunner<ENTITY, ID, META> =
+        EntityUpdateSingleReturningRunner(context, entity)
+
+    private val support: JdbcEntityUpdateReturningRunnerSupport<ENTITY, ID, META> =
+        JdbcEntityUpdateReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override fun run(config: JdbcDatabaseConfig): ENTITY? {
+        val newEntity = preUpdate(config, entity)
+        val entity = update(config, newEntity)
+        return postUpdate(entity)
+    }
+
+    private fun preUpdate(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY {
+        return runner.preUpdate(config, entity)
+    }
+
+    private fun update(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY? {
+        val statement = runner.buildStatement(config, entity)
+        return support.update(config) { executor ->
+            val transform = JdbcResultSetTransformers.singleEntity(context.target)
+            executor.execute(statement, transform) { it.firstOrNull() }
+        }
+    }
+
+    private fun postUpdate(entity: ENTITY?): ENTITY? {
+        return runner.postUpdate(entity)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateSingleReturningRunner.kt
@@ -1,16 +1,20 @@
 package org.komapper.jdbc.dsl.runner
 
+import kotlinx.coroutines.flow.singleOrNull
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.runner.EntityUpdateSingleReturningRunner
+import org.komapper.jdbc.JdbcDataOperator
 import org.komapper.jdbc.JdbcDatabaseConfig
+import java.sql.ResultSet
 
-internal class JdbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val context: EntityUpdateContext<ENTITY, ID, META>,
+internal class JdbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    context: EntityUpdateContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) : JdbcRunner<ENTITY?> {
+    private val transform: (JdbcDataOperator, ResultSet) -> T,
+) : JdbcRunner<T?> {
 
     private val runner: EntityUpdateSingleReturningRunner<ENTITY, ID, META> =
         EntityUpdateSingleReturningRunner(context, entity)
@@ -22,26 +26,26 @@ internal class JdbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, MET
         runner.check(config)
     }
 
-    override fun run(config: JdbcDatabaseConfig): ENTITY? {
+    override fun run(config: JdbcDatabaseConfig): T? {
         val newEntity = preUpdate(config, entity)
-        val entity = update(config, newEntity)
-        return postUpdate(entity)
+        return update(config, newEntity).also {
+            postUpdate(it)
+        }
     }
 
     private fun preUpdate(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY {
         return runner.preUpdate(config, entity)
     }
 
-    private fun update(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY? {
+    private fun update(config: JdbcDatabaseConfig, entity: ENTITY): T? {
         val statement = runner.buildStatement(config, entity)
         return support.update(config) { executor ->
-            val transform = JdbcResultSetTransformers.singleEntity(context.target)
-            executor.execute(statement, transform) { it.firstOrNull() }
+            executor.executeQuery(statement, transform) { it.singleOrNull() }
         }
     }
 
-    private fun postUpdate(entity: ENTITY?): ENTITY? {
-        return runner.postUpdate(entity)
+    private fun postUpdate(result: Any?) {
+        runner.postUpdate(result)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertMultipleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertMultipleReturningRunner.kt
@@ -1,16 +1,20 @@
 package org.komapper.jdbc.dsl.runner
 
+import kotlinx.coroutines.flow.toList
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.runner.EntityUpsertMultipleReturningRunner
+import org.komapper.jdbc.JdbcDataOperator
 import org.komapper.jdbc.JdbcDatabaseConfig
+import java.sql.ResultSet
 
-internal class JdbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val context: EntityUpsertContext<ENTITY, ID, META>,
+internal class JdbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    context: EntityUpsertContext<ENTITY, ID, META>,
     private val entities: List<ENTITY>,
-) : JdbcRunner<List<ENTITY>> {
+    private val transform: (JdbcDataOperator, ResultSet) -> T,
+) : JdbcRunner<List<T>> {
 
     private val runner: EntityUpsertMultipleReturningRunner<ENTITY, ID, META> =
         EntityUpsertMultipleReturningRunner(context, entities)
@@ -22,7 +26,7 @@ internal class JdbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, M
         runner.check(config)
     }
 
-    override fun run(config: JdbcDatabaseConfig): List<ENTITY> {
+    override fun run(config: JdbcDatabaseConfig): List<T> {
         if (entities.isEmpty()) return emptyList()
         val newEntities = entities.map { preUpsert(config, it) }
         return upsert(config, newEntities)
@@ -32,11 +36,10 @@ internal class JdbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, M
         return support.preUpsert(config, entity)
     }
 
-    private fun upsert(config: JdbcDatabaseConfig, entities: List<ENTITY>): List<ENTITY> {
+    private fun upsert(config: JdbcDatabaseConfig, entities: List<ENTITY>): List<T> {
         val statement = runner.buildStatement(config, entities)
         return support.upsert(config) { executor ->
-            val transform = JdbcResultSetTransformers.singleEntity(context.target)
-            executor.execute(statement, transform) { it.toList() }
+            executor.executeQuery(statement, transform) { it.toList() }
         }
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertMultipleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertMultipleReturningRunner.kt
@@ -1,0 +1,46 @@
+package org.komapper.jdbc.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityUpsertMultipleReturningRunner
+import org.komapper.jdbc.JdbcDatabaseConfig
+
+internal class JdbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+) : JdbcRunner<List<ENTITY>> {
+
+    private val runner: EntityUpsertMultipleReturningRunner<ENTITY, ID, META> =
+        EntityUpsertMultipleReturningRunner(context, entities)
+
+    private val support: JdbcEntityUpsertReturningRunnerSupport<ENTITY, ID, META> =
+        JdbcEntityUpsertReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override fun run(config: JdbcDatabaseConfig): List<ENTITY> {
+        if (entities.isEmpty()) return emptyList()
+        val newEntities = entities.map { preUpsert(config, it) }
+        return upsert(config, newEntities)
+    }
+
+    private fun preUpsert(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY {
+        return support.preUpsert(config, entity)
+    }
+
+    private fun upsert(config: JdbcDatabaseConfig, entities: List<ENTITY>): List<ENTITY> {
+        val statement = runner.buildStatement(config, entities)
+        return support.upsert(config) { executor ->
+            val transform = JdbcResultSetTransformers.singleEntity(context.target)
+            executor.execute(statement, transform) { it.toList() }
+        }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertReturningRunnerSupport.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertReturningRunnerSupport.kt
@@ -1,0 +1,22 @@
+package org.komapper.jdbc.dsl.runner
+
+import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.jdbc.JdbcDatabaseConfig
+import org.komapper.jdbc.JdbcExecutor
+
+internal class JdbcEntityUpsertReturningRunnerSupport<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    context: EntityUpsertContext<ENTITY, ID, META>,
+) {
+
+    private val support: JdbcEntityInsertReturningRunnerSupport<ENTITY, ID, META> =
+        JdbcEntityInsertReturningRunnerSupport(context.insertContext)
+
+    fun preUpsert(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY {
+        return support.preInsert(config, entity)
+    }
+
+    fun <T> upsert(config: JdbcDatabaseConfig, execute: (JdbcExecutor) -> T): T {
+        return support.insert(config, execute)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertSingleReturningRunner.kt
@@ -1,0 +1,45 @@
+package org.komapper.jdbc.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityUpsertSingleReturningRunner
+import org.komapper.jdbc.JdbcDatabaseConfig
+
+internal class JdbcEntityUpsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : JdbcRunner<ENTITY?> {
+
+    private val runner: EntityUpsertSingleReturningRunner<ENTITY, ID, META> =
+        EntityUpsertSingleReturningRunner(context, entity)
+
+    private val support: JdbcEntityUpsertReturningRunnerSupport<ENTITY, ID, META> =
+        JdbcEntityUpsertReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override fun run(config: JdbcDatabaseConfig): ENTITY? {
+        val newEntity = preUpsert(config, entity)
+        return upsert(config, newEntity)
+    }
+
+    private fun preUpsert(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY {
+        return support.preUpsert(config, entity)
+    }
+
+    private fun upsert(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY? {
+        val statement = runner.buildStatement(config, entity)
+        return support.upsert(config) { executor ->
+            val transform = JdbcResultSetTransformers.singleEntity(context.target)
+            executor.execute(statement, transform) { it.singleOrNull() }
+        }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertSingleReturningRunner.kt
@@ -1,16 +1,21 @@
 package org.komapper.jdbc.dsl.runner
 
+import kotlinx.coroutines.flow.Flow
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.runner.EntityUpsertSingleReturningRunner
+import org.komapper.jdbc.JdbcDataOperator
 import org.komapper.jdbc.JdbcDatabaseConfig
+import java.sql.ResultSet
 
-internal class JdbcEntityUpsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val context: EntityUpsertContext<ENTITY, ID, META>,
+internal class JdbcEntityUpsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T, R>(
+    context: EntityUpsertContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) : JdbcRunner<ENTITY?> {
+    private val transform: (JdbcDataOperator, ResultSet) -> T,
+    private val collect: suspend (Flow<T>) -> R,
+) : JdbcRunner<R> {
 
     private val runner: EntityUpsertSingleReturningRunner<ENTITY, ID, META> =
         EntityUpsertSingleReturningRunner(context, entity)
@@ -22,7 +27,7 @@ internal class JdbcEntityUpsertSingleReturningRunner<ENTITY : Any, ID : Any, MET
         runner.check(config)
     }
 
-    override fun run(config: JdbcDatabaseConfig): ENTITY? {
+    override fun run(config: JdbcDatabaseConfig): R {
         val newEntity = preUpsert(config, entity)
         return upsert(config, newEntity)
     }
@@ -31,11 +36,10 @@ internal class JdbcEntityUpsertSingleReturningRunner<ENTITY : Any, ID : Any, MET
         return support.preUpsert(config, entity)
     }
 
-    private fun upsert(config: JdbcDatabaseConfig, entity: ENTITY): ENTITY? {
+    private fun upsert(config: JdbcDatabaseConfig, entity: ENTITY): R {
         val statement = runner.buildStatement(config, entity)
         return support.upsert(config) { executor ->
-            val transform = JdbcResultSetTransformers.singleEntity(context.target)
-            executor.execute(statement, transform) { it.singleOrNull() }
+            executor.executeQuery(statement, transform, collect)
         }
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertValuesReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertValuesReturningRunner.kt
@@ -1,0 +1,62 @@
+package org.komapper.jdbc.dsl.runner
+
+import kotlinx.coroutines.flow.single
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+import org.komapper.core.dsl.runner.RelationInsertValuesReturningRunner
+import org.komapper.jdbc.JdbcDataOperator
+import org.komapper.jdbc.JdbcDatabaseConfig
+import org.komapper.jdbc.JdbcExecutor
+import java.sql.ResultSet
+
+internal class JdbcRelationInsertValuesReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+    private val transform: (JdbcDataOperator, ResultSet) -> T,
+) : JdbcRunner<T> {
+
+    private val runner: RelationInsertValuesReturningRunner<ENTITY, ID, META> = RelationInsertValuesReturningRunner(context)
+
+    private val support: JdbcRelationInsertValuesSupport<ENTITY, ID, META> = JdbcRelationInsertValuesSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override fun run(config: JdbcDatabaseConfig): T {
+        return support.handleIdGenerator(
+            config,
+            object : JdbcRelationInsertValuesSupport.Callback<ENTITY, ID, T> {
+                override fun autoIncrement(idGenerator: IdGenerator.AutoIncrement<ENTITY, ID>): T {
+                    return insert(config)
+                }
+
+                override fun sequence(idGenerator: IdGenerator.Sequence<ENTITY, ID>, id: ID): T {
+                    val idAssignment = runner.preInsertUsingSequence(idGenerator, id)
+                    return insert(config, idAssignment)
+                }
+
+                override fun other(): T {
+                    return insert(config)
+                }
+            },
+        )
+    }
+
+    private fun insert(
+        config: JdbcDatabaseConfig,
+        idAssignment: Pair<PropertyMetamodel<ENTITY, ID, *>, Operand>? = null,
+    ): T {
+        val statement = runner.buildStatement(config, idAssignment)
+        val executor = JdbcExecutor(config, context.options)
+        return executor.executeQuery(statement, transform) { it.single() }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertValuesRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertValuesRunner.kt
@@ -17,36 +17,34 @@ internal class JdbcRelationInsertValuesRunner<ENTITY : Any, ID : Any, META : Ent
 
     private val runner: RelationInsertValuesRunner<ENTITY, ID, META> = RelationInsertValuesRunner(context)
 
+    private val support: JdbcRelationInsertValuesSupport<ENTITY, ID, META> = JdbcRelationInsertValuesSupport(context)
+
     override fun check(config: DatabaseConfig) {
         runner.check(config)
     }
 
     override fun run(config: JdbcDatabaseConfig): Pair<Long, ID?> {
-        fun returnWithoutId(): Pair<Long, ID?> {
-            val (count, _) = insert(config)
-            return count to null
-        }
+        return support.handleIdGenerator(
+            config,
+            object : JdbcRelationInsertValuesSupport.Callback<ENTITY, ID, Pair<Long, ID?>> {
+                override fun autoIncrement(idGenerator: IdGenerator.AutoIncrement<ENTITY, ID>): Pair<Long, ID?> {
+                    val generatedColumn = runner.preInsertUsingAutoIncrement(idGenerator)
+                    val (count, keys) = insert(config, generatedColumn = generatedColumn)
+                    return runner.postInsertUsingAutoIncrement(count, keys)
+                }
 
-        return when (val idGenerator = context.target.idGenerator()) {
-            is IdGenerator.AutoIncrement<ENTITY, ID> -> {
-                val generatedColumn = runner.preInsertUsingAutoIncrement(idGenerator)
-                val (count, keys) = insert(config, generatedColumn = generatedColumn)
-                runner.postInsertUsingAutoIncrement(count, keys)
-            }
-            is IdGenerator.Sequence<ENTITY, ID> -> {
-                if (context.target.disableSequenceAssignment() || context.options.disableSequenceAssignment) {
-                    returnWithoutId()
-                } else {
-                    val id = idGenerator.execute(config, context.options)
+                override fun sequence(idGenerator: IdGenerator.Sequence<ENTITY, ID>, id: ID): Pair<Long, ID?> {
                     val idAssignment = runner.preInsertUsingSequence(idGenerator, id)
                     val (count, _) = insert(config, idAssignment)
-                    count to id
+                    return count to id
                 }
-            }
-            else -> {
-                returnWithoutId()
-            }
-        }
+
+                override fun other(): Pair<Long, ID?> {
+                    val (count, _) = insert(config)
+                    return count to null
+                }
+            },
+        )
     }
 
     private fun insert(

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertValuesSupport.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertValuesSupport.kt
@@ -1,0 +1,38 @@
+package org.komapper.jdbc.dsl.runner
+
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.jdbc.JdbcDatabaseConfig
+
+internal class JdbcRelationInsertValuesSupport<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+) {
+
+    fun <R> handleIdGenerator(config: JdbcDatabaseConfig, callback: Callback<ENTITY, ID, R>): R {
+        return when (val idGenerator = context.target.idGenerator()) {
+            is IdGenerator.AutoIncrement<ENTITY, ID> -> {
+                callback.autoIncrement(idGenerator)
+            }
+
+            is IdGenerator.Sequence<ENTITY, ID> -> {
+                if (context.target.disableSequenceAssignment() || context.options.disableSequenceAssignment) {
+                    callback.other()
+                } else {
+                    val id = idGenerator.execute(config, context.options)
+                    callback.sequence(idGenerator, id)
+                }
+            }
+
+            else -> {
+                callback.other()
+            }
+        }
+    }
+
+    internal interface Callback<ENTITY : Any, ID : Any, R> {
+        fun autoIncrement(idGenerator: IdGenerator.AutoIncrement<ENTITY, ID>): R
+        fun sequence(idGenerator: IdGenerator.Sequence<ENTITY, ID>, id: ID): R
+        fun other(): R
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationUpdateReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationUpdateReturningRunner.kt
@@ -1,0 +1,41 @@
+package org.komapper.jdbc.dsl.runner
+
+import kotlinx.coroutines.flow.toList
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.RelationUpdateContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.RelationUpdateReturningRunner
+import org.komapper.jdbc.JdbcDataOperator
+import org.komapper.jdbc.JdbcDatabaseConfig
+import org.komapper.jdbc.JdbcExecutor
+import java.sql.ResultSet
+
+internal class JdbcRelationUpdateReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    private val context: RelationUpdateContext<ENTITY, ID, META>,
+    private val transform: (JdbcDataOperator, ResultSet) -> T,
+) : JdbcRunner<List<T>> {
+
+    private val runner: RelationUpdateReturningRunner<ENTITY, ID, META> = RelationUpdateReturningRunner(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override fun run(config: JdbcDatabaseConfig): List<T> {
+        val clock = config.clockProvider.now()
+        val updatedAtAssignment = context.target.updatedAtAssignment(clock)
+        val result = runner.buildStatement(config, updatedAtAssignment)
+        val statement = result.getOrNull()
+        return if (statement != null) {
+            val executor = JdbcExecutor(config, context.options)
+            executor.executeQuery(statement, transform) { it.toList() }
+        } else {
+            emptyList()
+        }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
@@ -42,7 +42,9 @@ import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertSingleRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertSingleUpdateRunner
 import org.komapper.jdbc.dsl.runner.JdbcRelationDeleteRunner
 import org.komapper.jdbc.dsl.runner.JdbcRelationInsertSelectRunner
+import org.komapper.jdbc.dsl.runner.JdbcRelationInsertValuesReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcRelationInsertValuesRunner
+import org.komapper.jdbc.dsl.runner.JdbcRelationUpdateReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcRelationUpdateRunner
 import org.komapper.jdbc.dsl.runner.JdbcResultSetTransformers
 import org.komapper.jdbc.dsl.runner.JdbcRunner
@@ -554,6 +556,37 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         return JdbcRelationInsertValuesRunner(context)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationInsertValuesReturningQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+    ): JdbcRunner<ENTITY> {
+        val transform = JdbcResultSetTransformers.singleEntity(context.target)
+        return JdbcRelationInsertValuesReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> relationInsertValuesReturningSingleColumnQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): JdbcRunner<A?> {
+        val transform = JdbcResultSetTransformers.singleColumn(expression)
+        return JdbcRelationInsertValuesReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> relationInsertValuesReturningPairColumnsQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): JdbcRunner<Pair<A?, B?>> {
+        val transform = JdbcResultSetTransformers.pairColumns(expressions)
+        return JdbcRelationInsertValuesReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> relationInsertValuesReturningTripleColumnsQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): JdbcRunner<Triple<A?, B?, C?>> {
+        val transform = JdbcResultSetTransformers.tripleColumns(expressions)
+        return JdbcRelationInsertValuesReturningRunner(context, transform)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationInsertSelectQuery(
         context: RelationInsertSelectContext<ENTITY, ID, META>,
     ): JdbcRunner<Pair<Long, List<ID>>> {
@@ -564,6 +597,35 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         context: RelationUpdateContext<ENTITY, ID, META>,
     ): JdbcRunner<Long> {
         return JdbcRelationUpdateRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationUpdateReturningQuery(context: RelationUpdateContext<ENTITY, ID, META>): JdbcRunner<List<ENTITY>> {
+        val transform = JdbcResultSetTransformers.singleEntity(context.target)
+        return JdbcRelationUpdateReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> relationUpdateReturningSingleColumnQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): JdbcRunner<List<A?>> {
+        val transform = JdbcResultSetTransformers.singleColumn(expression)
+        return JdbcRelationUpdateReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> relationUpdateReturningPairColumnsQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): JdbcRunner<List<Pair<A?, B?>>> {
+        val transform = JdbcResultSetTransformers.pairColumns(expressions)
+        return JdbcRelationUpdateReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> relationUpdateReturningTripleColumnsQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): JdbcRunner<List<Triple<A?, B?, C?>>> {
+        val transform = JdbcResultSetTransformers.tripleColumns(expressions)
+        return JdbcRelationUpdateReturningRunner(context, transform)
     }
 
     override fun templateExecuteQuery(

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
@@ -31,6 +31,7 @@ import org.komapper.jdbc.dsl.runner.JdbcEntityInsertSingleReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityInsertSingleRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityStoreRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpdateBatchRunner
+import org.komapper.jdbc.dsl.runner.JdbcEntityUpdateSingleReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpdateSingleRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertBatchRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertMultipleReturningRunner
@@ -172,6 +173,13 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         entity: ENTITY,
     ): JdbcRunner<ENTITY> {
         return JdbcEntityUpdateSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpdateSingleReturningQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): JdbcRunner<ENTITY?> {
+        return JdbcEntityUpdateSingleReturningRunner(context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
@@ -25,14 +25,18 @@ import org.komapper.core.dsl.visitor.QueryVisitor
 import org.komapper.jdbc.dsl.runner.JdbcEntityDeleteBatchRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityDeleteSingleRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityInsertBatchRunner
+import org.komapper.jdbc.dsl.runner.JdbcEntityInsertMultipleReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityInsertMultipleRunner
+import org.komapper.jdbc.dsl.runner.JdbcEntityInsertSingleReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityInsertSingleRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityStoreRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpdateBatchRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpdateSingleRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertBatchRunner
+import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertMultipleReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertMultipleRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertSingleIgnoreRunner
+import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertSingleReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertSingleRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertSingleUpdateRunner
 import org.komapper.jdbc.dsl.runner.JdbcRelationDeleteRunner
@@ -126,6 +130,13 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         return JdbcEntityInsertMultipleRunner(context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertMultipleReturningQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): JdbcRunner<List<ENTITY>> {
+        return JdbcEntityInsertMultipleReturningRunner(context, entities)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertBatchQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
@@ -138,6 +149,13 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         entity: ENTITY,
     ): JdbcRunner<ENTITY> {
         return JdbcEntityInsertSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertSingleReturningQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): JdbcRunner<*> {
+        return JdbcEntityInsertSingleReturningRunner(context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -172,12 +190,26 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         return JdbcEntityUpsertMultipleRunner(context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertMultipleReturningQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): JdbcRunner<List<ENTITY>> {
+        return JdbcEntityUpsertMultipleReturningRunner(context, entities)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityUpsertSingleQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
         entity: ENTITY,
     ): JdbcRunner<Long> {
         return JdbcEntityUpsertSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertSingleReturningQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): JdbcRunner<*> {
+        return JdbcEntityUpsertSingleReturningRunner(context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
@@ -135,7 +135,35 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         context: EntityInsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
     ): JdbcRunner<List<ENTITY>> {
-        return JdbcEntityInsertMultipleReturningRunner(context, entities)
+        val transform = JdbcResultSetTransformers.singleEntity(context.target)
+        return JdbcEntityInsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityInsertMultipleReturningSingleColumnQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expression: ColumnExpression<A, *>,
+    ): JdbcRunner<List<A?>> {
+        val transform = JdbcResultSetTransformers.singleColumn(expression)
+        return JdbcEntityInsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityInsertMultipleReturningPairColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): JdbcRunner<List<Pair<A?, B?>>> {
+        val transform = JdbcResultSetTransformers.pairColumns(expressions)
+        return JdbcEntityInsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityInsertMultipleReturningTripleColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): JdbcRunner<List<Triple<A?, B?, C?>>> {
+        val transform = JdbcResultSetTransformers.tripleColumns(expressions)
+        return JdbcEntityInsertMultipleReturningRunner(context, entities, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertBatchQuery(
@@ -155,8 +183,36 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertSingleReturningQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entity: ENTITY,
-    ): JdbcRunner<*> {
-        return JdbcEntityInsertSingleReturningRunner(context, entity)
+    ): JdbcRunner<ENTITY> {
+        val transform = JdbcResultSetTransformers.singleEntity(context.target)
+        return JdbcEntityInsertSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityInsertSingleReturningSingleColumnQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): JdbcRunner<A?> {
+        val transform = JdbcResultSetTransformers.singleColumn(expression)
+        return JdbcEntityInsertSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityInsertSingleReturningPairColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): JdbcRunner<Pair<A?, B?>> {
+        val transform = JdbcResultSetTransformers.pairColumns(expressions)
+        return JdbcEntityInsertSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityInsertSingleReturningTripleColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): JdbcRunner<Triple<A?, B?, C?>> {
+        val transform = JdbcResultSetTransformers.tripleColumns(expressions)
+        return JdbcEntityInsertSingleReturningRunner(context, entity, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -179,7 +235,35 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         context: EntityUpdateContext<ENTITY, ID, META>,
         entity: ENTITY,
     ): JdbcRunner<ENTITY?> {
-        return JdbcEntityUpdateSingleReturningRunner(context, entity)
+        val transform = JdbcResultSetTransformers.singleEntity(context.target)
+        return JdbcEntityUpdateSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityUpdateSingleReturningSingleColumnQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): JdbcRunner<A?> {
+        val transform = JdbcResultSetTransformers.singleColumn(expression)
+        return JdbcEntityUpdateSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityUpdateSingleReturningPairColumnsQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): JdbcRunner<Pair<A?, B?>?> {
+        val transform = JdbcResultSetTransformers.pairColumns(expressions)
+        return JdbcEntityUpdateSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityUpdateSingleReturningTripleColumnsQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): JdbcRunner<Triple<A?, B?, C?>?> {
+        val transform = JdbcResultSetTransformers.tripleColumns(expressions)
+        return JdbcEntityUpdateSingleReturningRunner(context, entity, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -202,7 +286,35 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         context: EntityUpsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
     ): JdbcRunner<List<ENTITY>> {
-        return JdbcEntityUpsertMultipleReturningRunner(context, entities)
+        val transform = JdbcResultSetTransformers.singleEntity(context.target)
+        return JdbcEntityUpsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityUpsertMultipleReturningSingleColumnQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expression: ColumnExpression<A, *>,
+    ): JdbcRunner<List<A?>> {
+        val transform = JdbcResultSetTransformers.singleColumn(expression)
+        return JdbcEntityUpsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityUpsertMultipleReturningPairColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): JdbcRunner<List<Pair<A?, B?>>> {
+        val transform = JdbcResultSetTransformers.pairColumns(expressions)
+        return JdbcEntityUpsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityUpsertMultipleReturningTripleColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): JdbcRunner<List<Triple<A?, B?, C?>>> {
+        val transform = JdbcResultSetTransformers.tripleColumns(expressions)
+        return JdbcEntityUpsertMultipleReturningRunner(context, entities, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -213,11 +325,43 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         return JdbcEntityUpsertSingleRunner(context, entity)
     }
 
-    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertSingleReturningQuery(
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, R> entityUpsertSingleReturningQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
         entity: ENTITY,
-    ): JdbcRunner<*> {
-        return JdbcEntityUpsertSingleReturningRunner(context, entity)
+        collect: suspend (Flow<ENTITY>) -> R,
+    ): JdbcRunner<R> {
+        val transform = JdbcResultSetTransformers.singleEntity(context.target)
+        return JdbcEntityUpsertSingleReturningRunner(context, entity, transform, collect)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, R> entityUpsertSingleReturningSingleColumnQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+        collect: suspend (Flow<A?>) -> R,
+    ): JdbcRunner<R> {
+        val transform = JdbcResultSetTransformers.singleColumn(expression)
+        return JdbcEntityUpsertSingleReturningRunner(context, entity, transform, collect)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, R> entityUpsertSingleReturningPairColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+        collect: suspend (Flow<Pair<A?, B?>>) -> R,
+    ): JdbcRunner<R> {
+        val transform = JdbcResultSetTransformers.pairColumns(expressions)
+        return JdbcEntityUpsertSingleReturningRunner(context, entity, transform, collect)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any, R> entityUpsertSingleReturningTripleColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+        collect: suspend (Flow<Triple<A?, B?, C?>>) -> R,
+    ): JdbcRunner<R> {
+        val transform = JdbcResultSetTransformers.tripleColumns(expressions)
+        return JdbcEntityUpsertSingleReturningRunner(context, entity, transform, collect)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityInsertMultipleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityInsertMultipleReturningRunner.kt
@@ -1,0 +1,49 @@
+package org.komapper.r2dbc.dsl.runner
+
+import kotlinx.coroutines.flow.toList
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityInsertMultipleReturningRunner
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+
+internal class R2dbcEntityInsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+) :
+    R2dbcRunner<List<ENTITY>> {
+
+    private val runner: EntityInsertMultipleReturningRunner<ENTITY, ID, META> =
+        EntityInsertMultipleReturningRunner(context, entities)
+
+    private val support: R2dbcEntityInsertReturningRunnerSupport<ENTITY, ID, META> =
+        R2dbcEntityInsertReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override suspend fun run(config: R2dbcDatabaseConfig): List<ENTITY> {
+        if (entities.isEmpty()) return emptyList()
+        val newEntities = preInsert(config)
+        return insert(config, newEntities)
+    }
+
+    private suspend fun preInsert(config: R2dbcDatabaseConfig): List<ENTITY> {
+        return entities.map { support.preInsert(config, it) }
+    }
+
+    private suspend fun insert(config: R2dbcDatabaseConfig, entities: List<ENTITY>): List<ENTITY> {
+        val statement = runner.buildStatement(config, entities)
+        return support.insert(config) { executor ->
+            val transform = R2dbcRowTransformers.singleEntity(context.target)
+            val flow = executor.executeQuery(statement, transform)
+            flow.toList()
+        }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityInsertMultipleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityInsertMultipleReturningRunner.kt
@@ -1,18 +1,21 @@
 package org.komapper.r2dbc.dsl.runner
 
+import io.r2dbc.spi.Row
 import kotlinx.coroutines.flow.toList
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.runner.EntityInsertMultipleReturningRunner
+import org.komapper.r2dbc.R2dbcDataOperator
 import org.komapper.r2dbc.R2dbcDatabaseConfig
 
-internal class R2dbcEntityInsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val context: EntityInsertContext<ENTITY, ID, META>,
+internal class R2dbcEntityInsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    context: EntityInsertContext<ENTITY, ID, META>,
     private val entities: List<ENTITY>,
+    private val transform: (R2dbcDataOperator, Row) -> T,
 ) :
-    R2dbcRunner<List<ENTITY>> {
+    R2dbcRunner<List<T>> {
 
     private val runner: EntityInsertMultipleReturningRunner<ENTITY, ID, META> =
         EntityInsertMultipleReturningRunner(context, entities)
@@ -24,7 +27,7 @@ internal class R2dbcEntityInsertMultipleReturningRunner<ENTITY : Any, ID : Any, 
         runner.check(config)
     }
 
-    override suspend fun run(config: R2dbcDatabaseConfig): List<ENTITY> {
+    override suspend fun run(config: R2dbcDatabaseConfig): List<T> {
         if (entities.isEmpty()) return emptyList()
         val newEntities = preInsert(config)
         return insert(config, newEntities)
@@ -34,10 +37,9 @@ internal class R2dbcEntityInsertMultipleReturningRunner<ENTITY : Any, ID : Any, 
         return entities.map { support.preInsert(config, it) }
     }
 
-    private suspend fun insert(config: R2dbcDatabaseConfig, entities: List<ENTITY>): List<ENTITY> {
+    private suspend fun insert(config: R2dbcDatabaseConfig, entities: List<ENTITY>): List<T> {
         val statement = runner.buildStatement(config, entities)
         return support.insert(config) { executor ->
-            val transform = R2dbcRowTransformers.singleEntity(context.target)
             val flow = executor.executeQuery(statement, transform)
             flow.toList()
         }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityInsertReturningRunnerSupport.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityInsertReturningRunnerSupport.kt
@@ -1,0 +1,33 @@
+package org.komapper.r2dbc.dsl.runner
+
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+import org.komapper.r2dbc.R2dbcExecutor
+
+internal class R2dbcEntityInsertReturningRunnerSupport<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+) {
+
+    suspend fun preInsert(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY {
+        val newEntity = when (val idGenerator = context.target.idGenerator()) {
+            is IdGenerator.Sequence<ENTITY, ID> -> {
+                if (!context.target.disableSequenceAssignment() && !context.options.disableSequenceAssignment) {
+                    val id = idGenerator.execute(config, context.options)
+                    idGenerator.property.setter(entity, id)
+                } else {
+                    null
+                }
+            }
+            else -> null
+        }
+        val clock = config.clockProvider.now()
+        return context.target.preInsert(newEntity ?: entity, clock)
+    }
+
+    suspend fun <T> insert(config: R2dbcDatabaseConfig, execute: suspend (R2dbcExecutor) -> T): T {
+        val executor = R2dbcExecutor(config, context.options)
+        return execute(executor)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityInsertSingleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityInsertSingleReturningRunner.kt
@@ -1,0 +1,47 @@
+package org.komapper.r2dbc.dsl.runner
+
+import kotlinx.coroutines.flow.single
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityInsertSingleReturningRunner
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+
+internal class R2dbcEntityInsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityInsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : R2dbcRunner<ENTITY> {
+
+    private val runner: EntityInsertSingleReturningRunner<ENTITY, ID, META> =
+        EntityInsertSingleReturningRunner(context, entity)
+
+    private val support: R2dbcEntityInsertReturningRunnerSupport<ENTITY, ID, META> =
+        R2dbcEntityInsertReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override suspend fun run(config: R2dbcDatabaseConfig): ENTITY {
+        val newEntity = preInsert(config)
+        return insert(config, newEntity)
+    }
+
+    private suspend fun preInsert(config: R2dbcDatabaseConfig): ENTITY {
+        return support.preInsert(config, entity)
+    }
+
+    private suspend fun insert(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY {
+        val statement = runner.buildStatement(config, entity)
+        return support.insert(config) { executor ->
+            val transform = R2dbcRowTransformers.singleEntity(context.target)
+            val flow = executor.executeQuery(statement, transform)
+            flow.single()
+        }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityInsertSingleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityInsertSingleReturningRunner.kt
@@ -1,17 +1,20 @@
 package org.komapper.r2dbc.dsl.runner
 
+import io.r2dbc.spi.Row
 import kotlinx.coroutines.flow.single
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.runner.EntityInsertSingleReturningRunner
+import org.komapper.r2dbc.R2dbcDataOperator
 import org.komapper.r2dbc.R2dbcDatabaseConfig
 
-internal class R2dbcEntityInsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val context: EntityInsertContext<ENTITY, ID, META>,
+internal class R2dbcEntityInsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    context: EntityInsertContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) : R2dbcRunner<ENTITY> {
+    private val transform: (R2dbcDataOperator, Row) -> T,
+) : R2dbcRunner<T> {
 
     private val runner: EntityInsertSingleReturningRunner<ENTITY, ID, META> =
         EntityInsertSingleReturningRunner(context, entity)
@@ -23,7 +26,7 @@ internal class R2dbcEntityInsertSingleReturningRunner<ENTITY : Any, ID : Any, ME
         runner.check(config)
     }
 
-    override suspend fun run(config: R2dbcDatabaseConfig): ENTITY {
+    override suspend fun run(config: R2dbcDatabaseConfig): T {
         val newEntity = preInsert(config)
         return insert(config, newEntity)
     }
@@ -32,10 +35,9 @@ internal class R2dbcEntityInsertSingleReturningRunner<ENTITY : Any, ID : Any, ME
         return support.preInsert(config, entity)
     }
 
-    private suspend fun insert(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY {
+    private suspend fun insert(config: R2dbcDatabaseConfig, entity: ENTITY): T {
         val statement = runner.buildStatement(config, entity)
         return support.insert(config) { executor ->
-            val transform = R2dbcRowTransformers.singleEntity(context.target)
             val flow = executor.executeQuery(statement, transform)
             flow.single()
         }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpdateReturningRunnerSupport.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpdateReturningRunnerSupport.kt
@@ -1,0 +1,16 @@
+package org.komapper.r2dbc.dsl.runner
+
+import org.komapper.core.dsl.context.EntityUpdateContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+import org.komapper.r2dbc.R2dbcExecutor
+
+internal class R2dbcEntityUpdateReturningRunnerSupport<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+) {
+
+    suspend fun <T> update(config: R2dbcDatabaseConfig, execute: suspend (R2dbcExecutor) -> T): T {
+        val executor = R2dbcExecutor(config, context.options)
+        return execute(executor)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpdateSingleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpdateSingleReturningRunner.kt
@@ -1,17 +1,20 @@
 package org.komapper.r2dbc.dsl.runner
 
+import io.r2dbc.spi.Row
 import kotlinx.coroutines.flow.firstOrNull
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.runner.EntityUpdateSingleReturningRunner
+import org.komapper.r2dbc.R2dbcDataOperator
 import org.komapper.r2dbc.R2dbcDatabaseConfig
 
-internal class R2dbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val context: EntityUpdateContext<ENTITY, ID, META>,
+internal class R2dbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    context: EntityUpdateContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) : R2dbcRunner<ENTITY?> {
+    private val transform: (R2dbcDataOperator, Row) -> T,
+) : R2dbcRunner<T?> {
 
     private val runner: EntityUpdateSingleReturningRunner<ENTITY, ID, META> =
         EntityUpdateSingleReturningRunner(context, entity)
@@ -23,27 +26,27 @@ internal class R2dbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, ME
         runner.check(config)
     }
 
-    override suspend fun run(config: R2dbcDatabaseConfig): ENTITY? {
+    override suspend fun run(config: R2dbcDatabaseConfig): T? {
         val newEntity = preUpdate(config, entity)
-        val entity = update(config, newEntity)
-        return postUpdate(entity)
+        return update(config, newEntity).also {
+            postUpdate(it)
+        }
     }
 
     private fun preUpdate(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY {
         return runner.preUpdate(config, entity)
     }
 
-    private suspend fun update(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY? {
+    private suspend fun update(config: R2dbcDatabaseConfig, entity: ENTITY): T? {
         val statement = runner.buildStatement(config, entity)
         return support.update(config) { executor ->
-            val transform = R2dbcRowTransformers.singleEntity(context.target)
             val flow = executor.executeQuery(statement, transform)
             flow.firstOrNull()
         }
     }
 
-    private fun postUpdate(entity: ENTITY?): ENTITY? {
-        return runner.postUpdate(entity)
+    private fun postUpdate(result: Any?) {
+        runner.postUpdate(result)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpdateSingleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpdateSingleReturningRunner.kt
@@ -1,0 +1,52 @@
+package org.komapper.r2dbc.dsl.runner
+
+import kotlinx.coroutines.flow.firstOrNull
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityUpdateContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityUpdateSingleReturningRunner
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+
+internal class R2dbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : R2dbcRunner<ENTITY?> {
+
+    private val runner: EntityUpdateSingleReturningRunner<ENTITY, ID, META> =
+        EntityUpdateSingleReturningRunner(context, entity)
+
+    private val support: R2dbcEntityUpdateReturningRunnerSupport<ENTITY, ID, META> =
+        R2dbcEntityUpdateReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override suspend fun run(config: R2dbcDatabaseConfig): ENTITY? {
+        val newEntity = preUpdate(config, entity)
+        val entity = update(config, newEntity)
+        return postUpdate(entity)
+    }
+
+    private fun preUpdate(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY {
+        return runner.preUpdate(config, entity)
+    }
+
+    private suspend fun update(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY? {
+        val statement = runner.buildStatement(config, entity)
+        return support.update(config) { executor ->
+            val transform = R2dbcRowTransformers.singleEntity(context.target)
+            val flow = executor.executeQuery(statement, transform)
+            flow.firstOrNull()
+        }
+    }
+
+    private fun postUpdate(entity: ENTITY?): ENTITY? {
+        return runner.postUpdate(entity)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpsertMultipleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpsertMultipleReturningRunner.kt
@@ -1,0 +1,48 @@
+package org.komapper.r2dbc.dsl.runner
+
+import kotlinx.coroutines.flow.toList
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityUpsertMultipleReturningRunner
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+
+internal class R2dbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entities: List<ENTITY>,
+) : R2dbcRunner<List<ENTITY>> {
+
+    private val runner: EntityUpsertMultipleReturningRunner<ENTITY, ID, META> =
+        EntityUpsertMultipleReturningRunner(context, entities)
+
+    private val support: R2dbcEntityUpsertReturningRunnerSupport<ENTITY, ID, META> =
+        R2dbcEntityUpsertReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override suspend fun run(config: R2dbcDatabaseConfig): List<ENTITY> {
+        if (entities.isEmpty()) return emptyList()
+        val newEntities = entities.map { preUpsert(config, it) }
+        return upsert(config, newEntities)
+    }
+
+    private suspend fun preUpsert(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY {
+        return support.preUpsert(config, entity)
+    }
+
+    private suspend fun upsert(config: R2dbcDatabaseConfig, entities: List<ENTITY>): List<ENTITY> {
+        val statement = runner.buildStatement(config, entities)
+        return support.upsert(config, false) { executor ->
+            val transform = R2dbcRowTransformers.singleEntity(context.target)
+            val flow = executor.executeQuery(statement, transform)
+            flow.toList()
+        }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpsertMultipleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpsertMultipleReturningRunner.kt
@@ -1,17 +1,20 @@
 package org.komapper.r2dbc.dsl.runner
 
+import io.r2dbc.spi.Row
 import kotlinx.coroutines.flow.toList
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.EntityUpsertContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.runner.EntityUpsertMultipleReturningRunner
+import org.komapper.r2dbc.R2dbcDataOperator
 import org.komapper.r2dbc.R2dbcDatabaseConfig
 
-internal class R2dbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val context: EntityUpsertContext<ENTITY, ID, META>,
+internal class R2dbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    context: EntityUpsertContext<ENTITY, ID, META>,
     private val entities: List<ENTITY>,
-) : R2dbcRunner<List<ENTITY>> {
+    private val transform: (R2dbcDataOperator, Row) -> T,
+) : R2dbcRunner<List<T>> {
 
     private val runner: EntityUpsertMultipleReturningRunner<ENTITY, ID, META> =
         EntityUpsertMultipleReturningRunner(context, entities)
@@ -23,7 +26,7 @@ internal class R2dbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, 
         runner.check(config)
     }
 
-    override suspend fun run(config: R2dbcDatabaseConfig): List<ENTITY> {
+    override suspend fun run(config: R2dbcDatabaseConfig): List<T> {
         if (entities.isEmpty()) return emptyList()
         val newEntities = entities.map { preUpsert(config, it) }
         return upsert(config, newEntities)
@@ -33,10 +36,9 @@ internal class R2dbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, 
         return support.preUpsert(config, entity)
     }
 
-    private suspend fun upsert(config: R2dbcDatabaseConfig, entities: List<ENTITY>): List<ENTITY> {
+    private suspend fun upsert(config: R2dbcDatabaseConfig, entities: List<ENTITY>): List<T> {
         val statement = runner.buildStatement(config, entities)
         return support.upsert(config, false) { executor ->
-            val transform = R2dbcRowTransformers.singleEntity(context.target)
             val flow = executor.executeQuery(statement, transform)
             flow.toList()
         }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpsertReturningRunnerSupport.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpsertReturningRunnerSupport.kt
@@ -1,0 +1,22 @@
+package org.komapper.r2dbc.dsl.runner
+
+import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+import org.komapper.r2dbc.R2dbcExecutor
+
+internal class R2dbcEntityUpsertReturningRunnerSupport<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    context: EntityUpsertContext<ENTITY, ID, META>,
+) {
+
+    private val support: R2dbcEntityInsertRunnerSupport<ENTITY, ID, META> =
+        R2dbcEntityInsertRunnerSupport(context.insertContext)
+
+    suspend fun preUpsert(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY {
+        return support.preInsert(config, entity)
+    }
+
+    suspend fun <T> upsert(config: R2dbcDatabaseConfig, usesGeneratedKeys: Boolean, execute: suspend (R2dbcExecutor) -> T): T {
+        return support.insert(config, usesGeneratedKeys, execute)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpsertSingleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpsertSingleReturningRunner.kt
@@ -1,0 +1,47 @@
+package org.komapper.r2dbc.dsl.runner
+
+import kotlinx.coroutines.flow.singleOrNull
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityUpsertSingleReturningRunner
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+
+internal class R2dbcEntityUpsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityUpsertContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : R2dbcRunner<ENTITY?> {
+
+    private val runner: EntityUpsertSingleReturningRunner<ENTITY, ID, META> =
+        EntityUpsertSingleReturningRunner(context, entity)
+
+    private val support: R2dbcEntityUpsertReturningRunnerSupport<ENTITY, ID, META> =
+        R2dbcEntityUpsertReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override suspend fun run(config: R2dbcDatabaseConfig): ENTITY? {
+        val newEntity = preUpsert(config, entity)
+        return upsert(config, newEntity)
+    }
+
+    private suspend fun preUpsert(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY {
+        return support.preUpsert(config, entity)
+    }
+
+    private suspend fun upsert(config: R2dbcDatabaseConfig, entity: ENTITY): ENTITY? {
+        val statement = runner.buildStatement(config, entity)
+        return support.upsert(config, false) { executor ->
+            val transform = R2dbcRowTransformers.singleEntity(context.target)
+            val flow = executor.executeQuery(statement, transform)
+            flow.singleOrNull()
+        }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRelationInsertValuesReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRelationInsertValuesReturningRunner.kt
@@ -1,0 +1,63 @@
+package org.komapper.r2dbc.dsl.runner
+
+import io.r2dbc.spi.Row
+import kotlinx.coroutines.flow.single
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+import org.komapper.core.dsl.runner.RelationInsertValuesReturningRunner
+import org.komapper.r2dbc.R2dbcDataOperator
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+import org.komapper.r2dbc.R2dbcExecutor
+
+internal class R2dbcRelationInsertValuesReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+    private val transform: (R2dbcDataOperator, Row) -> T,
+) : R2dbcRunner<T> {
+
+    private val runner: RelationInsertValuesReturningRunner<ENTITY, ID, META> = RelationInsertValuesReturningRunner(context)
+
+    private val support: R2dbcRelationInsertValuesSupport<ENTITY, ID, META> = R2dbcRelationInsertValuesSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override suspend fun run(config: R2dbcDatabaseConfig): T {
+        return support.handleIdGenerator(
+            config,
+            object : R2dbcRelationInsertValuesSupport.Callback<ENTITY, ID, T> {
+                override suspend fun autoIncrement(idGenerator: IdGenerator.AutoIncrement<ENTITY, ID>): T {
+                    return insert(config)
+                }
+
+                override suspend fun sequence(idGenerator: IdGenerator.Sequence<ENTITY, ID>, id: ID): T {
+                    val idAssignment = runner.preInsertUsingSequence(idGenerator, id)
+                    return insert(config, idAssignment)
+                }
+
+                override suspend fun other(): T {
+                    return insert(config)
+                }
+            },
+        )
+    }
+
+    private suspend fun insert(
+        config: R2dbcDatabaseConfig,
+        idAssignment: Pair<PropertyMetamodel<ENTITY, ID, *>, Operand>? = null,
+    ): T {
+        val statement = runner.buildStatement(config, idAssignment)
+        val executor = R2dbcExecutor(config, context.options)
+        val flow = executor.executeQuery(statement, transform)
+        return flow.single()
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRelationInsertValuesRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRelationInsertValuesRunner.kt
@@ -17,36 +17,33 @@ internal class R2dbcRelationInsertValuesRunner<ENTITY : Any, ID : Any, META : En
 
     private val runner: RelationInsertValuesRunner<ENTITY, ID, META> = RelationInsertValuesRunner(context)
 
+    private val support: R2dbcRelationInsertValuesSupport<ENTITY, ID, META> = R2dbcRelationInsertValuesSupport(context)
+
     override fun check(config: DatabaseConfig) {
         runner.check(config)
     }
 
     override suspend fun run(config: R2dbcDatabaseConfig): Pair<Long, ID?> {
-        suspend fun returnWithoutId(): Pair<Long, ID?> {
-            val (count, _) = insert(config)
-            return count to null
-        }
+        return support.handleIdGenerator(
+            config,
+            object : R2dbcRelationInsertValuesSupport.Callback<ENTITY, ID, Pair<Long, ID?>> {
+                override suspend fun autoIncrement(idGenerator: IdGenerator.AutoIncrement<ENTITY, ID>): Pair<Long, ID?> {
+                    val generatedColumn = runner.preInsertUsingAutoIncrement(idGenerator)
+                    val (count, keys) = insert(config, generatedColumn = generatedColumn)
+                    return runner.postInsertUsingAutoIncrement(count, keys)
+                }
 
-        return when (val idGenerator = context.target.idGenerator()) {
-            is IdGenerator.AutoIncrement<ENTITY, ID> -> {
-                val generatedColumn = runner.preInsertUsingAutoIncrement(idGenerator)
-                val (count, keys) = insert(config, generatedColumn = generatedColumn)
-                runner.postInsertUsingAutoIncrement(count, keys)
-            }
-            is IdGenerator.Sequence<ENTITY, ID> -> {
-                if (context.target.disableSequenceAssignment() || context.options.disableSequenceAssignment) {
-                    returnWithoutId()
-                } else {
-                    val id = idGenerator.execute(config, context.options)
+                override suspend fun sequence(idGenerator: IdGenerator.Sequence<ENTITY, ID>, id: ID): Pair<Long, ID?> {
                     val idAssignment = runner.preInsertUsingSequence(idGenerator, id)
                     val (count, _) = insert(config, idAssignment)
-                    count to id
+                    return count to id
                 }
-            }
-            else -> {
-                returnWithoutId()
-            }
-        }
+
+                override suspend fun other(): Pair<Long, ID?> {
+                    val (count, _) = insert(config)
+                    return count to null }
+            },
+        )
     }
 
     private suspend fun insert(

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRelationInsertValuesSupport.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRelationInsertValuesSupport.kt
@@ -1,0 +1,38 @@
+package org.komapper.r2dbc.dsl.runner
+
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.IdGenerator
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+
+internal class R2dbcRelationInsertValuesSupport<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+) {
+
+    suspend fun <R> handleIdGenerator(config: R2dbcDatabaseConfig, callback: Callback<ENTITY, ID, R>): R {
+        return when (val idGenerator = context.target.idGenerator()) {
+            is IdGenerator.AutoIncrement<ENTITY, ID> -> {
+                callback.autoIncrement(idGenerator)
+            }
+
+            is IdGenerator.Sequence<ENTITY, ID> -> {
+                if (context.target.disableSequenceAssignment() || context.options.disableSequenceAssignment) {
+                    callback.other()
+                } else {
+                    val id = idGenerator.execute(config, context.options)
+                    callback.sequence(idGenerator, id)
+                }
+            }
+
+            else -> {
+                callback.other()
+            }
+        }
+    }
+
+    internal interface Callback<ENTITY : Any, ID : Any, R> {
+        suspend fun autoIncrement(idGenerator: IdGenerator.AutoIncrement<ENTITY, ID>): R
+        suspend fun sequence(idGenerator: IdGenerator.Sequence<ENTITY, ID>, id: ID): R
+        suspend fun other(): R
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRelationUpdateReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRelationUpdateReturningRunner.kt
@@ -1,0 +1,42 @@
+package org.komapper.r2dbc.dsl.runner
+
+import io.r2dbc.spi.Row
+import kotlinx.coroutines.flow.toList
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.RelationUpdateContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.RelationUpdateReturningRunner
+import org.komapper.r2dbc.R2dbcDataOperator
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+import org.komapper.r2dbc.R2dbcExecutor
+
+internal class R2dbcRelationUpdateReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    private val context: RelationUpdateContext<ENTITY, ID, META>,
+    private val transform: (R2dbcDataOperator, Row) -> T,
+) : R2dbcRunner<List<T>> {
+
+    private val runner: RelationUpdateReturningRunner<ENTITY, ID, META> = RelationUpdateReturningRunner(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override suspend fun run(config: R2dbcDatabaseConfig): List<T> {
+        val clock = config.clockProvider.now()
+        val updatedAtAssignment = context.target.updatedAtAssignment(clock)
+        val result = runner.buildStatement(config, updatedAtAssignment)
+        val statement = result.getOrNull()
+        return if (statement != null) {
+            val executor = R2dbcExecutor(config, context.options)
+            val flow = executor.executeQuery(statement, transform)
+            flow.toList()
+        } else {
+            emptyList()
+        }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
@@ -25,14 +25,18 @@ import org.komapper.core.dsl.visitor.QueryVisitor
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityDeleteBatchRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityDeleteSingleRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityInsertBatchRunner
+import org.komapper.r2dbc.dsl.runner.R2dbcEntityInsertMultipleReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityInsertMultipleRunner
+import org.komapper.r2dbc.dsl.runner.R2dbcEntityInsertSingleReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityInsertSingleRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityStoreRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpdateBatchRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpdateSingleRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertBatchRunner
+import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertMultipleReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertMultipleRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertSingleIgnoreRunner
+import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertSingleReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertSingleRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertSingleUpdateRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcRelationDeleteRunner
@@ -127,8 +131,8 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertMultipleReturningQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
-    ): R2dbcRunner<*> {
-        TODO("Not yet implemented")
+    ): R2dbcRunner<List<ENTITY>> {
+        return R2dbcEntityInsertMultipleReturningRunner(context, entities)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertBatchQuery(
@@ -148,8 +152,8 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertSingleReturningQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entity: ENTITY,
-    ): R2dbcRunner<*> {
-        TODO("Not yet implemented")
+    ): R2dbcRunner<ENTITY> {
+        return R2dbcEntityInsertSingleReturningRunner(context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -188,7 +192,7 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         context: EntityUpsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
     ): R2dbcRunner<List<ENTITY>> {
-        TODO("Not yet implemented")
+        return R2dbcEntityUpsertMultipleReturningRunner(context, entities)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -203,7 +207,7 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         context: EntityUpsertContext<ENTITY, ID, META>,
         entity: ENTITY,
     ): R2dbcRunner<*> {
-        TODO("Not yet implemented")
+        return R2dbcEntityUpsertSingleReturningRunner(context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertSingleUpdateQuery(

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
@@ -31,6 +31,7 @@ import org.komapper.r2dbc.dsl.runner.R2dbcEntityInsertSingleReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityInsertSingleRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityStoreRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpdateBatchRunner
+import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpdateSingleReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpdateSingleRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertBatchRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertMultipleReturningRunner
@@ -175,8 +176,8 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpdateSingleReturningQuery(
         context: EntityUpdateContext<ENTITY, ID, META>,
         entity: ENTITY,
-    ): R2dbcRunner<*> {
-        TODO("Not yet implemented")
+    ): R2dbcRunner<ENTITY?> {
+        return R2dbcEntityUpdateSingleReturningRunner(context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
@@ -172,6 +172,13 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         return R2dbcEntityUpdateSingleRunner(context, entity)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpdateSingleReturningQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): R2dbcRunner<*> {
+        TODO("Not yet implemented")
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityUpsertBatchQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
@@ -42,7 +42,9 @@ import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertSingleRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertSingleUpdateRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcRelationDeleteRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcRelationInsertSelectRunner
+import org.komapper.r2dbc.dsl.runner.R2dbcRelationInsertValuesReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcRelationInsertValuesRunner
+import org.komapper.r2dbc.dsl.runner.R2dbcRelationUpdateReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcRelationUpdateRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcRowTransformers
 import org.komapper.r2dbc.dsl.runner.R2dbcRunner
@@ -550,6 +552,37 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         return R2dbcRelationInsertValuesRunner(context)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationInsertValuesReturningQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+    ): R2dbcRunner<ENTITY> {
+        val transform = R2dbcRowTransformers.singleEntity(context.target)
+        return R2dbcRelationInsertValuesReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> relationInsertValuesReturningSingleColumnQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): R2dbcRunner<A?> {
+        val transform = R2dbcRowTransformers.singleColumn(expression)
+        return R2dbcRelationInsertValuesReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> relationInsertValuesReturningPairColumnsQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): R2dbcRunner<Pair<A?, B?>> {
+        val transform = R2dbcRowTransformers.pairColumns(expressions)
+        return R2dbcRelationInsertValuesReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> relationInsertValuesReturningTripleColumnsQuery(
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): R2dbcRunner<Triple<A?, B?, C?>> {
+        val transform = R2dbcRowTransformers.tripleColumns(expressions)
+        return R2dbcRelationInsertValuesReturningRunner(context, transform)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationInsertSelectQuery(
         context: RelationInsertSelectContext<ENTITY, ID, META>,
     ): R2dbcRunner<Pair<Long, List<ID>>> {
@@ -560,6 +593,35 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         context: RelationUpdateContext<ENTITY, ID, META>,
     ): R2dbcRunner<Long> {
         return R2dbcRelationUpdateRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationUpdateReturningQuery(context: RelationUpdateContext<ENTITY, ID, META>): R2dbcRunner<List<ENTITY>> {
+        val transform = R2dbcRowTransformers.singleEntity(context.target)
+        return R2dbcRelationUpdateReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> relationUpdateReturningSingleColumnQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): R2dbcRunner<List<A?>> {
+        val transform = R2dbcRowTransformers.singleColumn(expression)
+        return R2dbcRelationUpdateReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> relationUpdateReturningPairColumnsQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): R2dbcRunner<List<Pair<A?, B?>>> {
+        val transform = R2dbcRowTransformers.pairColumns(expressions)
+        return R2dbcRelationUpdateReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> relationUpdateReturningTripleColumnsQuery(
+        context: RelationUpdateContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): R2dbcRunner<List<Triple<A?, B?, C?>>> {
+        val transform = R2dbcRowTransformers.tripleColumns(expressions)
+        return R2dbcRelationUpdateReturningRunner(context, transform)
     }
 
     override fun templateExecuteQuery(

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
@@ -133,7 +133,35 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         context: EntityInsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
     ): R2dbcRunner<List<ENTITY>> {
-        return R2dbcEntityInsertMultipleReturningRunner(context, entities)
+        val transform = R2dbcRowTransformers.singleEntity(context.target)
+        return R2dbcEntityInsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityInsertMultipleReturningSingleColumnQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expression: ColumnExpression<A, *>,
+    ): R2dbcRunner<List<A?>> {
+        val transform = R2dbcRowTransformers.singleColumn(expression)
+        return R2dbcEntityInsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityInsertMultipleReturningPairColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): R2dbcRunner<List<Pair<A?, B?>>> {
+        val transform = R2dbcRowTransformers.pairColumns(expressions)
+        return R2dbcEntityInsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityInsertMultipleReturningTripleColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): R2dbcRunner<List<Triple<A?, B?, C?>>> {
+        val transform = R2dbcRowTransformers.tripleColumns(expressions)
+        return R2dbcEntityInsertMultipleReturningRunner(context, entities, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertBatchQuery(
@@ -154,7 +182,35 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         context: EntityInsertContext<ENTITY, ID, META>,
         entity: ENTITY,
     ): R2dbcRunner<ENTITY> {
-        return R2dbcEntityInsertSingleReturningRunner(context, entity)
+        val transform = R2dbcRowTransformers.singleEntity(context.target)
+        return R2dbcEntityInsertSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityInsertSingleReturningSingleColumnQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): R2dbcRunner<*> {
+        val transform = R2dbcRowTransformers.singleColumn(expression)
+        return R2dbcEntityInsertSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityInsertSingleReturningPairColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): R2dbcRunner<*> {
+        val transform = R2dbcRowTransformers.pairColumns(expressions)
+        return R2dbcEntityInsertSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityInsertSingleReturningTripleColumnsQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): R2dbcRunner<*> {
+        val transform = R2dbcRowTransformers.tripleColumns(expressions)
+        return R2dbcEntityInsertSingleReturningRunner(context, entity, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -177,7 +233,35 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         context: EntityUpdateContext<ENTITY, ID, META>,
         entity: ENTITY,
     ): R2dbcRunner<ENTITY?> {
-        return R2dbcEntityUpdateSingleReturningRunner(context, entity)
+        val transform = R2dbcRowTransformers.singleEntity(context.target)
+        return R2dbcEntityUpdateSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityUpdateSingleReturningSingleColumnQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): R2dbcRunner<A?> {
+        val transform = R2dbcRowTransformers.singleColumn(expression)
+        return R2dbcEntityUpdateSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityUpdateSingleReturningPairColumnsQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): R2dbcRunner<Pair<A?, B?>?> {
+        val transform = R2dbcRowTransformers.pairColumns(expressions)
+        return R2dbcEntityUpdateSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityUpdateSingleReturningTripleColumnsQuery(
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): R2dbcRunner<Triple<A?, B?, C?>?> {
+        val transform = R2dbcRowTransformers.tripleColumns(expressions)
+        return R2dbcEntityUpdateSingleReturningRunner(context, entity, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -200,7 +284,35 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         context: EntityUpsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
     ): R2dbcRunner<List<ENTITY>> {
-        return R2dbcEntityUpsertMultipleReturningRunner(context, entities)
+        val transform = R2dbcRowTransformers.singleEntity(context.target)
+        return R2dbcEntityUpsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityUpsertMultipleReturningSingleColumnQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expression: ColumnExpression<A, *>,
+    ): R2dbcRunner<List<A?>> {
+        val transform = R2dbcRowTransformers.singleColumn(expression)
+        return R2dbcEntityUpsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityUpsertMultipleReturningPairColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): R2dbcRunner<List<Pair<A?, B?>>> {
+        val transform = R2dbcRowTransformers.pairColumns(expressions)
+        return R2dbcEntityUpsertMultipleReturningRunner(context, entities, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityUpsertMultipleReturningTripleColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): R2dbcRunner<List<Triple<A?, B?, C?>>> {
+        val transform = R2dbcRowTransformers.tripleColumns(expressions)
+        return R2dbcEntityUpsertMultipleReturningRunner(context, entities, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -211,11 +323,43 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         return R2dbcEntityUpsertSingleRunner(context, entity)
     }
 
-    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertSingleReturningQuery(
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, R> entityUpsertSingleReturningQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
         entity: ENTITY,
-    ): R2dbcRunner<*> {
-        return R2dbcEntityUpsertSingleReturningRunner(context, entity)
+        collect: suspend (Flow<ENTITY>) -> R,
+    ): R2dbcRunner<R> {
+        val transform = R2dbcRowTransformers.singleEntity(context.target)
+        return R2dbcEntityUpsertSingleReturningRunner(context, entity, transform, collect)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, R> entityUpsertSingleReturningSingleColumnQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+        collect: suspend (Flow<A?>) -> R,
+    ): R2dbcRunner<R> {
+        val transform = R2dbcRowTransformers.singleColumn(expression)
+        return R2dbcEntityUpsertSingleReturningRunner(context, entity, transform, collect)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, R> entityUpsertSingleReturningPairColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+        collect: suspend (Flow<Pair<A?, B?>>) -> R,
+    ): R2dbcRunner<R> {
+        val transform = R2dbcRowTransformers.pairColumns(expressions)
+        return R2dbcEntityUpsertSingleReturningRunner(context, entity, transform, collect)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any, R> entityUpsertSingleReturningTripleColumnsQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+        collect: suspend (Flow<Triple<A?, B?, C?>>) -> R,
+    ): R2dbcRunner<R> {
+        val transform = R2dbcRowTransformers.tripleColumns(expressions)
+        return R2dbcEntityUpsertSingleReturningRunner(context, entity, transform, collect)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertSingleUpdateQuery(

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
@@ -124,6 +124,13 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         return R2dbcEntityInsertMultipleRunner(context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertMultipleReturningQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): R2dbcRunner<*> {
+        TODO("Not yet implemented")
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertBatchQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
@@ -136,6 +143,13 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         entity: ENTITY,
     ): R2dbcRunner<ENTITY> {
         return R2dbcEntityInsertSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertSingleReturningQuery(
+        context: EntityInsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): R2dbcRunner<*> {
+        TODO("Not yet implemented")
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
@@ -170,12 +184,26 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         return R2dbcEntityUpsertMultipleRunner(context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertMultipleReturningQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entities: List<ENTITY>,
+    ): R2dbcRunner<List<ENTITY>> {
+        TODO("Not yet implemented")
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityUpsertSingleQuery(
         context: EntityUpsertContext<ENTITY, ID, META>,
         entity: ENTITY,
     ): R2dbcRunner<Long> {
         return R2dbcEntityUpsertSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertSingleReturningQuery(
+        context: EntityUpsertContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): R2dbcRunner<*> {
+        TODO("Not yet implemented")
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityUpsertSingleUpdateQuery(


### PR DESCRIPTION
We support `INSERT ... RETURNING` for the following databases:

- H2
- MariaDB
- PostgreSQL 
- SQL Server

and support `UPDATE ... RETURNING` for the following databases:

- PostgreSQL
- SQL Server 

### simple example

To use `INSERT ... RETURNING`, invoke the `returning` function:

Kotlin code:
```kotlin
val a = Meta.address
val address = Address(16, "STREET 16", 0)
val address2: Address = db.runQuery { QueryDsl.insert(a).single(address).returning() }
```

generated SQL:
```sql
-- H2
select address_id, street, version from final table (insert into address (address_id, street, version) values (?, ?, ?))

-- MariaDB
insert into address (address_id, street, version) values (?, ?, ?) returning address_id, street, version

-- PostgreSQL
insert into address (address_id, street, version) values (?, ?, ?) returning address_id, street, version
```

### another examples

You can combine `returning` and `onDuplicateKeyUpdate`.
```kotlin
val d = Meta.department
val department = Department(5, 50, "PLANNING", "TOKYO", 0)
val query = QueryDsl.insert(d).onDuplicateKeyUpdate().single(department).returning()
val department2: Department = db.runQuery { query }
````

You can also use `multiple` instead of `single` to process multiple records.
```kotlin
val a = Meta.address
val addressList = listOf(
    Address(16, "STREET 16", 0),
    Address(17, "STREET 17", 0),
    Address(18, "STREET 18", 0),
)
val addressList2: List<Address> = db.runQuery { QueryDsl.insert(a).multiple(addressList).returning() }
```
