### PR TITLE
Support for Oracle RETURNING INTO Clause

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleReturningTest.kt
@@ -28,7 +28,7 @@ import kotlin.test.assertNull
 @ExtendWith(JdbcEnv::class)
 class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test() {
         val a = Meta.address
@@ -37,7 +37,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address, address2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn() {
         val a = Meta.address
@@ -46,7 +46,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address.street, street)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns() {
         val a = Meta.address
@@ -56,7 +56,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address.version, version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns() {
         val a = Meta.address
@@ -67,7 +67,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address.addressId, addressId)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun uniqueConstraintException() {
         val a = Meta.address
@@ -77,7 +77,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun sequenceGenerator() {
         val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
@@ -91,7 +91,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun identityGenerator() {
         for (i in 1..201) {
@@ -252,7 +252,7 @@ class JdbcInsertSingleReturningTest(private val db: JdbcDatabase) {
         assertNull(address2)
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_insertReturning() {
         val a = Meta.address

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertValuesReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertValuesReturningTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertFailsWith
 @ExtendWith(JdbcEnv::class)
 class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test() {
         val a = Meta.address
@@ -35,7 +35,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals(Address(19, "STREET 16", 0), address)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn() {
         val a = Meta.address
@@ -49,7 +49,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals("STREET 16", street)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns() {
         val a = Meta.address
@@ -64,7 +64,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals(0, version)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns() {
         val a = Meta.address
@@ -80,7 +80,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals(19, addressId)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun generatedKeys_autoIncrement() {
         val a = Meta.identityStrategy
@@ -93,7 +93,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals(IdentityStrategy(1, "test"), strategy)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun generatedKeys_sequence() {
         val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
@@ -108,7 +108,7 @@ class JdbcInsertValuesReturningTest(private val db: JdbcDatabase) {
         assertEquals(SequenceStrategy(1, "test"), strategy)
     }
 
-    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException() {
         val a = Meta.address

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSetReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSetReturningTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 @ExtendWith(JdbcEnv::class)
 class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test() {
         val a = Meta.address
@@ -37,7 +37,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(list.single(), address)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn() {
         val a = Meta.address
@@ -57,7 +57,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(list.single(), address.street)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns() {
         val a = Meta.address
@@ -77,7 +77,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(list.single(), address.street to address.version)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns() {
         val a = Meta.address
@@ -97,7 +97,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(list.single(), Triple(address.street, address.version, address.addressId))
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testMultipleUpdate() {
         val a = Meta.address
@@ -118,7 +118,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(list.toSet(), list2.toSet())
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun incrementVersion_auto() {
         val a = Meta.address
@@ -143,7 +143,7 @@ class JdbcUpdateSetReturningTest(private val db: JdbcDatabase) {
         assertEquals(2, address2.version)
     }
 
-    @Run(unless = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(unless = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_updateReturning() {
         val a = Meta.address

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleReturningTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertNull
 @ExtendWith(JdbcEnv::class)
 class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun test() {
         val a = Meta.address
@@ -42,7 +42,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         assertEquals(address2, returningAddress)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn() {
         val a = Meta.address
@@ -62,7 +62,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningPairColumns() {
         val a = Meta.address
@@ -82,7 +82,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningTripleColumns() {
         val a = Meta.address
@@ -102,7 +102,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun suppressOptimisticLockException() {
         val a = Meta.address
@@ -113,7 +113,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         assertNull(returningAddress)
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun uniqueConstraintException() {
         val a = Meta.address
@@ -123,7 +123,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun optimisticLockException() {
         val a = Meta.address
@@ -134,7 +134,7 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(unless = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(unless = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun unsupportedOperationException_updateReturning() {
         val a = Meta.address

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -259,7 +259,9 @@ interface Dialect {
      */
     fun supportsGeneratedKeysReturningWhenInsertingMultipleRows(): Boolean = true
 
-    fun supportsInsertReturning(): Boolean = false
+    fun supportsInsertMultipleReturning(): Boolean = false
+
+    fun supportsInsertSingleReturning(): Boolean = false
 
     /**
      * Returns whether the INTERSECT set operation is supported.
@@ -337,6 +339,10 @@ interface Dialect {
     fun supportsTableHint(): Boolean = false
 
     fun supportsUpdateReturning(): Boolean = false
+
+    fun supportsUpsertMultipleReturning(): Boolean = false
+
+    fun supportsUpsertSingleReturning(): Boolean = false
 }
 
 object DryRunDialect : Dialect {

--- a/komapper-core/src/main/kotlin/org/komapper/core/Statement.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Statement.kt
@@ -28,6 +28,11 @@ data class Statement(val parts: List<StatementPart>) {
     val args: List<Value<*>> = parts.filterIsInstance<StatementPart.Value>().map { it.value }
 
     /**
+     * The return parameters of the SQL statement.
+     */
+    val returnParamTypes: List<KClass<*>> = parts.filterIsInstance<StatementPart.ReturnParameter>().map { it.dataType }
+
+    /**
      * Converts the SQL statement to an SQL string.
      *
      * @param format the format function of the bind values
@@ -40,6 +45,7 @@ data class Statement(val parts: List<StatementPart>) {
                 is StatementPart.Value -> {
                     format(index++, part)
                 }
+                is StatementPart.ReturnParameter -> part
             }
         }
     }
@@ -57,6 +63,7 @@ data class Statement(val parts: List<StatementPart>) {
                     val value = part.value
                     format(value.any, value.klass, value.masking)
                 }
+                is StatementPart.ReturnParameter -> part
             }
         }
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/StatementBuffer.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/StatementBuffer.kt
@@ -18,6 +18,16 @@ class StatementBuffer {
         return this
     }
 
+    fun appendIfNotEmpty(statement: Statement, prefix: CharSequence = " "): StatementBuffer {
+        if (statement.parts.isNotEmpty()) {
+            if (prefix.isNotEmpty()) {
+                append(prefix)
+            }
+            parts.addAll(statement.parts)
+        }
+        return this
+    }
+
     fun bind(value: Value<*>): StatementBuffer {
         parts.add(StatementPart.Value(value))
         return this

--- a/komapper-core/src/main/kotlin/org/komapper/core/StatementBuffer.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/StatementBuffer.kt
@@ -1,5 +1,7 @@
 package org.komapper.core
 
+import kotlin.reflect.KClass
+
 /**
  * The buffer for the SQL statement.
  */
@@ -18,6 +20,11 @@ class StatementBuffer {
 
     fun bind(value: Value<*>): StatementBuffer {
         parts.add(StatementPart.Value(value))
+        return this
+    }
+
+    fun registerReturnParameter(dataType: KClass<*>): StatementBuffer {
+        parts.add(StatementPart.ReturnParameter(dataType))
         return this
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/StatementPart.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/StatementPart.kt
@@ -1,5 +1,7 @@
 package org.komapper.core
 
+import kotlin.reflect.KClass
+
 /**
  * The part of the SQL Statement.
  */
@@ -7,4 +9,5 @@ package org.komapper.core
 sealed class StatementPart : CharSequence {
     data class Text(val text: CharSequence) : StatementPart(), CharSequence by text
     data class Value(val value: org.komapper.core.Value<*>) : StatementPart(), CharSequence by "?"
+    data class ReturnParameter(val dataType: KClass<*>) : StatementPart(), CharSequence by "?"
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityInsertMultipleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityInsertMultipleReturningRunner.kt
@@ -14,7 +14,7 @@ class EntityInsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityM
     private val runner: EntityInsertMultipleRunner<ENTITY, ID, META> = EntityInsertMultipleRunner(context, entities)
 
     override fun check(config: DatabaseConfig) {
-        checkInsertReturning(config)
+        checkInsertMultipleReturning(config)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityInsertSingleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityInsertSingleReturningRunner.kt
@@ -14,7 +14,7 @@ class EntityInsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMet
     private val runner: EntityInsertSingleRunner<ENTITY, ID, META> = EntityInsertSingleRunner(context, entity)
 
     override fun check(config: DatabaseConfig) {
-        checkInsertReturning(config)
+        checkInsertSingleReturning(config)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertMultipleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertMultipleReturningRunner.kt
@@ -14,7 +14,7 @@ class EntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, META : EntityM
     private val runner: EntityUpsertMultipleRunner<ENTITY, ID, META> = EntityUpsertMultipleRunner(context, entities)
 
     override fun check(config: DatabaseConfig) {
-        checkInsertReturning(config)
+        checkUpsertMultipleReturning(config)
         runner.check(config)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertSingleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertSingleReturningRunner.kt
@@ -14,7 +14,7 @@ class EntityUpsertSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMet
     private val runner: EntityUpsertSingleRunner<ENTITY, ID, META> = EntityUpsertSingleRunner(context, entity)
 
     override fun check(config: DatabaseConfig) {
-        checkInsertReturning(config)
+        checkUpsertSingleReturning(config)
         runner.check(config)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationInsertValuesReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationInsertValuesReturningRunner.kt
@@ -16,7 +16,7 @@ class RelationInsertValuesReturningRunner<ENTITY : Any, ID : Any, META : EntityM
     private val runner: RelationInsertValuesRunner<ENTITY, ID, META> = RelationInsertValuesRunner(context)
 
     override fun check(config: DatabaseConfig) {
-        checkInsertReturning(config)
+        checkInsertSingleReturning(config)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
@@ -86,11 +86,21 @@ internal fun checkGeneratedKeysReturningWhenInsertingMultipleRows(
     }
 }
 
-internal fun checkInsertReturning(config: DatabaseConfig) {
+internal fun checkInsertSingleReturning(config: DatabaseConfig) {
     val dialect = config.dialect
-    if (!config.dialect.supportsInsertReturning()) {
+    if (!config.dialect.supportsInsertSingleReturning()) {
         throw UnsupportedOperationException(
-            "The dialect(driver=${dialect.driver}) does not support `INSERT RETURNING`. " +
+            "The dialect(driver=${dialect.driver}) does not support `returning` for inserting single row. " +
+                "Do not use the `returning` function in your query.",
+        )
+    }
+}
+
+internal fun checkInsertMultipleReturning(config: DatabaseConfig) {
+    val dialect = config.dialect
+    if (!config.dialect.supportsInsertMultipleReturning()) {
+        throw UnsupportedOperationException(
+            "The dialect(driver=${dialect.driver}) does not support `returning` for inserting multiple rows. " +
                 "Do not use the `returning` function in your query.",
         )
     }
@@ -125,7 +135,27 @@ internal fun checkUpdateReturning(config: DatabaseConfig) {
     val dialect = config.dialect
     if (!config.dialect.supportsUpdateReturning()) {
         throw UnsupportedOperationException(
-            "The dialect(driver=${dialect.driver}) does not support `UPDATE RETURNING`. " +
+            "The dialect(driver=${dialect.driver}) does not support `returning` for update statements. " +
+                "Do not use the `returning` function in your query.",
+        )
+    }
+}
+
+internal fun checkUpsertSingleReturning(config: DatabaseConfig) {
+    val dialect = config.dialect
+    if (!config.dialect.supportsUpsertSingleReturning()) {
+        throw UnsupportedOperationException(
+            "The dialect(driver=${dialect.driver}) does not support `returning` in combination with `onDuplicateKeyIgnore` or `onDuplicateKeyUpdate` for single row. " +
+                "Do not use the `returning` function in your query.",
+        )
+    }
+}
+
+internal fun checkUpsertMultipleReturning(config: DatabaseConfig) {
+    val dialect = config.dialect
+    if (!config.dialect.supportsUpsertMultipleReturning()) {
+        throw UnsupportedOperationException(
+            "The dialect(driver=${dialect.driver}) does not support `returning` in combination with `onDuplicateKeyIgnore` or `onDuplicateKeyUpdate` for multiple rows. " +
                 "Do not use the `returning` function in your query.",
         )
     }

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
@@ -56,7 +56,13 @@ interface H2Dialect : Dialect {
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false
 
-    override fun supportsInsertReturning(): Boolean = true
+    override fun supportsInsertMultipleReturning(): Boolean = true
+
+    override fun supportsInsertSingleReturning(): Boolean = true
 
     override fun supportsSearchConditionInUpsertStatement(): Boolean = true
+
+    override fun supportsUpsertMultipleReturning(): Boolean = true
+
+    override fun supportsUpsertSingleReturning(): Boolean = true
 }

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
@@ -69,7 +69,9 @@ interface MariaDbDialect : Dialect {
 
     override fun supportsGeneratedKeysReturningWhenInsertingMultipleRows(): Boolean = false
 
-    override fun supportsInsertReturning(): Boolean = true
+    override fun supportsInsertMultipleReturning(): Boolean = true
+
+    override fun supportsInsertSingleReturning(): Boolean = true
 
     override fun supportsLockOptionNowait(): Boolean = true
 
@@ -82,4 +84,8 @@ interface MariaDbDialect : Dialect {
     override fun supportsOptimisticLockOfBatchExecution(): Boolean = false
 
     override fun supportsSearchConditionInUpsertStatement(): Boolean = false
+
+    override fun supportsUpsertMultipleReturning(): Boolean = true
+
+    override fun supportsUpsertSingleReturning(): Boolean = true
 }

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityInsertStatementBuilder.kt
@@ -6,34 +6,21 @@ import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.builder.DefaultEntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
-import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 class MariaDbEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val dialect: BuilderDialect,
-    private val context: EntityInsertContext<ENTITY, ID, META>,
+    dialect: BuilderDialect,
+    context: EntityInsertContext<ENTITY, ID, META>,
     entities: List<ENTITY>,
 ) : EntityInsertStatementBuilder<ENTITY, ID, META> {
 
     private val buf = StatementBuffer()
     private val builder = DefaultEntityInsertStatementBuilder(dialect, context, entities)
+    private val support = MariaDbStatementBuilderSupport(dialect, context)
 
     override fun build(): Statement {
         buf.append(builder.build())
-        val expressions = context.returning.expressions()
-        if (expressions.isNotEmpty()) {
-            buf.append(" returning ")
-            for (e in expressions) {
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
+        buf.appendIfNotEmpty(support.buildReturning())
         return buf.toStatement()
-    }
-
-    private fun column(expression: ColumnExpression<*, *>) {
-        val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
     }
 }

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityUpsertStatementBuilder.kt
@@ -27,6 +27,7 @@ class MariaDbEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityM
     private val aliasManager = EmptyAliasManager
     private val buf = StatementBuffer()
     private val support = BuilderSupport(dialect, aliasManager, buf)
+    private val mariaDbSupport = MariaDbStatementBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         if (context.getAssignments().isNotEmpty()) {
@@ -66,15 +67,7 @@ class MariaDbEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityM
             }
             buf.cutBack(2)
         }
-        val expressions = context.returning.expressions()
-        if (expressions.isNotEmpty()) {
-            buf.append(" returning ")
-            for (e in expressions) {
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
+        buf.appendIfNotEmpty(mariaDbSupport.buildReturning())
         return buf.toStatement()
     }
 

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbRelationInsertValuesStatementBuilder.kt
@@ -5,34 +5,21 @@ import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.context.RelationInsertValuesContext
-import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 
 class MariaDbRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val dialect: BuilderDialect,
-    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+    dialect: BuilderDialect,
+    context: RelationInsertValuesContext<ENTITY, ID, META>,
 ) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
     private val buf = StatementBuffer()
     private val builder = RelationInsertValuesStatementBuilder(dialect, context)
+    private val support = MariaDbStatementBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         buf.append(builder.build(assignments))
-        val expressions = context.returning.expressions()
-        if (expressions.isNotEmpty()) {
-            buf.append(" returning ")
-            for (e in expressions) {
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
+        buf.appendIfNotEmpty(support.buildReturning())
         return buf.toStatement()
-    }
-
-    private fun column(expression: ColumnExpression<*, *>) {
-        val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
     }
 }

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbStatementBuilderSupport.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbStatementBuilderSupport.kt
@@ -1,0 +1,33 @@
+package org.komapper.dialect.mariadb
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.context.ReturningProvider
+import org.komapper.core.dsl.expression.ColumnExpression
+
+class MariaDbStatementBuilderSupport(
+    private val dialect: BuilderDialect,
+    private val returningProvider: ReturningProvider,
+) {
+
+    fun buildReturning(): Statement {
+        return with(StatementBuffer()) {
+            val expressions = returningProvider.returning.expressions()
+            if (expressions.isNotEmpty()) {
+                append(" returning ")
+                for (e in expressions) {
+                    column(e)
+                    append(", ")
+                }
+                cutBack(2)
+            }
+            toStatement()
+        }
+    }
+
+    private fun StatementBuffer.column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        append(name)
+    }
+}

--- a/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDataType.kt
+++ b/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDataType.kt
@@ -1,9 +1,18 @@
 package org.komapper.dialect.oracle.jdbc
 
+import oracle.jdbc.OraclePreparedStatement
 import org.komapper.jdbc.AbstractJdbcDataType
+import org.komapper.jdbc.JdbcDataType
 import java.sql.JDBCType
 import java.sql.PreparedStatement
 import java.sql.ResultSet
+
+class OracleJdbcDataType<T : Any>(private val jdbcDataType: JdbcDataType<T>) : JdbcDataType<T> by jdbcDataType {
+    override fun registerReturnParameter(ps: PreparedStatement, index: Int) {
+        val ops = ps.unwrap(OraclePreparedStatement::class.java)
+        ops.registerReturnParameter(index, jdbcType.vendorTypeNumber)
+    }
+}
 
 object OracleJdbcBooleanType : AbstractJdbcDataType<Boolean>(Boolean::class, JDBCType.INTEGER) {
     override val name: String = "number(1, 0)"
@@ -30,5 +39,14 @@ object OracleJdbcBooleanType : AbstractJdbcDataType<Boolean>(Boolean::class, JDB
 
     private fun toInt(value: Boolean): Int {
         return if (value) 1 else 0
+    }
+}
+
+// TODO
+fun <T : Any> wrap(jdbcDataType: JdbcDataType<T>): OracleJdbcDataType<T> {
+    return if (jdbcDataType is OracleJdbcDataType<T>) {
+        jdbcDataType
+    } else {
+        OracleJdbcDataType(jdbcDataType)
     }
 }

--- a/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDataType.kt
+++ b/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDataType.kt
@@ -42,7 +42,6 @@ object OracleJdbcBooleanType : AbstractJdbcDataType<Boolean>(Boolean::class, JDB
     }
 }
 
-// TODO
 fun <T : Any> wrap(jdbcDataType: JdbcDataType<T>): OracleJdbcDataType<T> {
     return if (jdbcDataType is OracleJdbcDataType<T>) {
         jdbcDataType

--- a/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDataTypeProvider.kt
+++ b/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDataTypeProvider.kt
@@ -51,6 +51,6 @@ class OracleJdbcDataTypeProvider(next: JdbcDataTypeProvider) : AbstractJdbcDataT
             JdbcUIntType("integer"),
             JdbcUShortType("integer"),
             OracleJdbcBooleanType,
-        )
+        ).map { wrap(it) }
     }
 }

--- a/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDialect.kt
+++ b/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDialect.kt
@@ -51,7 +51,11 @@ interface OracleJdbcDialect : OracleDialect, JdbcDialect {
 
     override fun supportsBatchExecutionReturningGeneratedValues(): Boolean = false
 
+    override fun supportsInsertSingleReturning(): Boolean = true
+
     override fun supportsReturnGeneratedKeysFlag(): Boolean = false
+
+    override fun supportsUpdateReturning(): Boolean = true
 }
 
 private object OracleJdbcDialectImpl : OracleJdbcDialect

--- a/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDialect.kt
+++ b/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDialect.kt
@@ -1,10 +1,23 @@
 package org.komapper.dialect.oracle.jdbc
 
+import org.komapper.core.ExecutionOptionsProvider
 import org.komapper.dialect.oracle.OracleDialect
+import org.komapper.jdbc.DefaultJdbcExecutor
+import org.komapper.jdbc.JdbcDatabaseConfig
 import org.komapper.jdbc.JdbcDialect
+import org.komapper.jdbc.JdbcExecutor
 import java.sql.SQLException
 
 interface OracleJdbcDialect : OracleDialect, JdbcDialect {
+
+    override fun createExecutor(
+        config: JdbcDatabaseConfig,
+        executionOptionProvider: ExecutionOptionsProvider,
+        generatedColumn: String?,
+    ): JdbcExecutor {
+        val executor = DefaultJdbcExecutor(config, executionOptionProvider, generatedColumn)
+        return OracleJdbcExecutor(config, executor)
+    }
 
     override fun isSequenceExistsError(exception: SQLException): Boolean {
         return exception.filterIsInstance<SQLException>().any {

--- a/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcExecutor.kt
+++ b/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcExecutor.kt
@@ -1,0 +1,64 @@
+package org.komapper.dialect.oracle.jdbc
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
+import oracle.jdbc.OraclePreparedStatement
+import org.komapper.core.Statement
+import org.komapper.jdbc.DefaultJdbcExecutor
+import org.komapper.jdbc.JdbcDataOperator
+import org.komapper.jdbc.JdbcDatabaseConfig
+import org.komapper.jdbc.JdbcExecutor
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+
+class OracleJdbcExecutor(
+    private val config: JdbcDatabaseConfig,
+    private val executor: DefaultJdbcExecutor,
+) : JdbcExecutor by executor {
+
+    override fun <T, R> executeReturning(
+        statement: Statement,
+        transform: (JdbcDataOperator, ResultSet) -> T,
+        collect: suspend (Flow<T>) -> R,
+    ): R {
+        return executor.withExceptionTranslator {
+            @Suppress("NAME_SHADOWING")
+            val statement = executor.inspect(statement)
+            config.session.useConnection { con ->
+                executor.prepare(con, statement).use { ps ->
+                    executor.setUp(ps)
+                    executor.log(statement)
+                    executor.bind(ps, statement)
+                    register(ps, statement)
+                    val count = ps.executeUpdate()
+                    if (count > 0) {
+                        val ops = ps.unwrap(OraclePreparedStatement::class.java)
+                        ops.returnResultSet.use { rs ->
+                            val sequence = sequence {
+                                while (rs.next()) {
+                                    this.yield(transform(config.dataOperator, rs))
+                                }
+                            }
+                            runBlocking {
+                                collect(sequence.asFlow())
+                            }
+                        }
+                    } else {
+                        runBlocking {
+                            collect(emptyFlow())
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun register(ps: PreparedStatement, statement: Statement) {
+        val base = statement.args.size
+        statement.returnParamTypes.forEachIndexed { index, klass ->
+            config.dataOperator.registerReturnParameter(ps, base + index + 1, klass)
+        }
+    }
+}

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
@@ -94,8 +94,6 @@ interface OracleDialect : Dialect {
 
     override fun supportsGeneratedKeysReturningWhenInsertingMultipleRows(): Boolean = false
 
-    override fun supportsInsertSingleReturning(): Boolean = true
-
     override fun supportsLockOfColumns(): Boolean = true
 
     override fun supportsLockOptionNowait(): Boolean = true
@@ -111,6 +109,4 @@ interface OracleDialect : Dialect {
     override fun supportsSetOperationMinus(): Boolean = true
 
     override fun supportsSearchConditionInUpsertStatement(): Boolean = true
-
-    override fun supportsUpdateReturning(): Boolean = true
 }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
@@ -3,10 +3,16 @@ package org.komapper.dialect.oracle
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
+import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
+import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
+import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
+import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationInsertValuesContext
+import org.komapper.core.dsl.context.RelationUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 interface OracleDialect : Dialect {
@@ -43,10 +49,15 @@ interface OracleDialect : Dialect {
         context: EntityInsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
     ): EntityInsertStatementBuilder<ENTITY, ID, META> {
-        if (entities.size == 1) {
-            return super.getEntityInsertStatementBuilder(dialect, context, entities)
-        }
         return OracleEntityInsertStatementBuilder(dialect, context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpdateStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityUpdateContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): EntityUpdateStatementBuilder<ENTITY, ID, META> {
+        return OracleEntityUpdateStatementBuilder(dialect, context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityUpsertStatementBuilder(
@@ -55,6 +66,20 @@ interface OracleDialect : Dialect {
         entities: List<ENTITY>,
     ): EntityUpsertStatementBuilder<ENTITY> {
         return OracleEntityUpsertStatementBuilder(dialect, context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationInsertValuesContext<ENTITY, ID, META>,
+    ): RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
+        return OracleRelationInsertValuesStatementBuilder(dialect, context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationUpdateStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationUpdateContext<ENTITY, ID, META>,
+    ): RelationUpdateStatementBuilder<ENTITY, ID, META> {
+        return OracleRelationUpdateStatementBuilder(dialect, context)
     }
 
     override fun supportsAsKeywordForTableAlias(): Boolean = false
@@ -68,6 +93,8 @@ interface OracleDialect : Dialect {
     override fun supportsDropIfExists(): Boolean = false
 
     override fun supportsGeneratedKeysReturningWhenInsertingMultipleRows(): Boolean = false
+
+    override fun supportsInsertSingleReturning(): Boolean = true
 
     override fun supportsLockOfColumns(): Boolean = true
 
@@ -84,4 +111,6 @@ interface OracleDialect : Dialect {
     override fun supportsSetOperationMinus(): Boolean = true
 
     override fun supportsSearchConditionInUpsertStatement(): Boolean = true
+
+    override fun supportsUpdateReturning(): Boolean = true
 }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityInsertStatementBuilder.kt
@@ -34,11 +34,7 @@ class OracleEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMe
         val support = OracleStatementBuilderSupport(dialect, context)
         return with(StatementBuffer()) {
             append(builder.build())
-            val returningStatement = support.buildReturning()
-            if (returningStatement.parts.isNotEmpty()) {
-                append(" ")
-                append(returningStatement)
-            }
+            appendIfNotEmpty(support.buildReturning())
             toStatement()
         }
     }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityInsertStatementBuilder.kt
@@ -3,6 +3,7 @@ package org.komapper.dialect.oracle
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.expression.ColumnExpression
@@ -20,40 +21,62 @@ class OracleEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMe
         require(entities.isNotEmpty()) { "entities must not be empty." }
     }
 
-    private val buf = StatementBuffer()
-
     override fun build(): Statement {
+        return if (entities.size == 1) {
+            buildForSingleEntity()
+        } else {
+            buildForMultipleEntities()
+        }
+    }
+
+    private fun buildForSingleEntity(): Statement {
+        val builder = DefaultEntityInsertStatementBuilder(dialect, context, entities)
+        val support = OracleStatementBuilderSupport(dialect, context)
+        return with(StatementBuffer()) {
+            append(builder.build())
+            val returningStatement = support.buildReturning()
+            if (returningStatement.parts.isNotEmpty()) {
+                append(" ")
+                append(returningStatement)
+            }
+            toStatement()
+        }
+    }
+
+    private fun buildForMultipleEntities(): Statement {
         val target = context.target
         val properties = target.getNonAutoIncrementProperties()
-        buf.append("insert all ")
-        for (entity in entities) {
-            buf.append("into ")
-            table(target)
-            buf.append(" (")
-            for (p in properties) {
-                column(p)
-                buf.append(", ")
+        return with(StatementBuffer()) {
+            append("insert all ")
+            for (entity in entities) {
+                append("into ")
+                table(target)
+                append(" (")
+                for (p in properties) {
+                    column(p)
+                    append(", ")
+                }
+                cutBack(2)
+                append(") values (")
+                for (p in properties) {
+                    bind(p.toValue(entity))
+                    append(", ")
+                }
+                cutBack(2)
+                append(") ")
             }
-            buf.cutBack(2)
-            buf.append(") values (")
-            for (p in properties) {
-                buf.bind(p.toValue(entity))
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-            buf.append(") ")
+            append("select 1 from dual")
+            toStatement()
         }
-        buf.append("select 1 from dual")
-        return buf.toStatement()
     }
 
-    private fun table(metamodel: EntityMetamodel<*, *, *>) {
+    private fun StatementBuffer.table(metamodel: EntityMetamodel<*, *, *>) {
         val name = metamodel.getCanonicalTableName(dialect::enquote)
-        buf.append(name)
+        append(name)
     }
 
-    private fun column(expression: ColumnExpression<*, *>) {
+    private fun StatementBuffer.column(expression: ColumnExpression<*, *>) {
         val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
+        append(name)
     }
 }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityUpdateStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityUpdateStatementBuilder.kt
@@ -1,4 +1,4 @@
-package org.komapper.dialect.sqlserver
+package org.komapper.dialect.oracle
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
@@ -8,25 +8,23 @@ import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
-class SqlServerEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    dialect: BuilderDialect,
-    context: EntityUpdateContext<ENTITY, ID, META>,
+class OracleEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: EntityUpdateContext<ENTITY, ID, META>,
     entity: ENTITY,
 ) : EntityUpdateStatementBuilder<ENTITY, ID, META> {
 
+    private val buf = StatementBuffer()
     private val builder = DefaultEntityUpdateStatementBuilder(dialect, context, entity)
-    private val support = SqlServerStatementBuilderSupport(dialect, context)
+    private val support = OracleStatementBuilderSupport(dialect, context)
 
     override fun build(): Statement {
-        val buf = StatementBuffer()
-        buf.append(builder.buildUpdateSet())
-        val outputStatement = support.buildOutput()
-        if (outputStatement.parts.isNotEmpty()) {
+        buf.append(builder.build())
+        val returningStatement = support.buildReturning()
+        if (returningStatement.parts.isNotEmpty()) {
             buf.append(" ")
-            buf.append(outputStatement)
+            buf.append(returningStatement)
         }
-        buf.append(" ")
-        buf.append(builder.buildWhere())
         return buf.toStatement()
     }
 }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityUpdateStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityUpdateStatementBuilder.kt
@@ -20,11 +20,7 @@ class OracleEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMe
 
     override fun build(): Statement {
         buf.append(builder.build())
-        val returningStatement = support.buildReturning()
-        if (returningStatement.parts.isNotEmpty()) {
-            buf.append(" ")
-            buf.append(returningStatement)
-        }
+        buf.appendIfNotEmpty(support.buildReturning())
         return buf.toStatement()
     }
 }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleRelationInsertValuesStatementBuilder.kt
@@ -1,34 +1,29 @@
-package org.komapper.dialect.sqlserver
+package org.komapper.dialect.oracle
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
-import org.komapper.core.dsl.builder.DefaultRelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.context.RelationInsertValuesContext
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 
-class SqlServerRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+class OracleRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     dialect: BuilderDialect,
     context: RelationInsertValuesContext<ENTITY, ID, META>,
 ) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
-
-    private val builder = DefaultRelationInsertValuesStatementBuilder(dialect, context)
-
-    private val support = SqlServerStatementBuilderSupport(dialect, context)
+    private val buf = StatementBuffer()
+    private val builder = RelationInsertValuesStatementBuilder(dialect, context)
+    private val support = OracleStatementBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
-        val buf = StatementBuffer()
-        buf.append(builder.buildInsertInto(assignments))
-        val outputStatement = support.buildOutput()
-        if (outputStatement.parts.isNotEmpty()) {
+        buf.append(builder.build(assignments))
+        val returningStatement = support.buildReturning()
+        if (returningStatement.parts.isNotEmpty()) {
             buf.append(" ")
-            buf.append(outputStatement)
+            buf.append(returningStatement)
         }
-        buf.append(" ")
-        buf.append(builder.buildValues(assignments))
         return buf.toStatement()
     }
 }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleRelationInsertValuesStatementBuilder.kt
@@ -19,11 +19,7 @@ class OracleRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : 
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         buf.append(builder.build(assignments))
-        val returningStatement = support.buildReturning()
-        if (returningStatement.parts.isNotEmpty()) {
-            buf.append(" ")
-            buf.append(returningStatement)
-        }
+        buf.appendIfNotEmpty(support.buildReturning())
         return buf.toStatement()
     }
 }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleRelationUpdateStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleRelationUpdateStatementBuilder.kt
@@ -20,11 +20,7 @@ class OracleRelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : Entity
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         buf.append(builder.build(assignments))
-        val returningStatement = support.buildReturning()
-        if (returningStatement.parts.isNotEmpty()) {
-            buf.append(" ")
-            buf.append(returningStatement)
-        }
+        buf.appendIfNotEmpty(support.buildReturning())
         return buf.toStatement()
     }
 }

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleRelationUpdateStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleRelationUpdateStatementBuilder.kt
@@ -1,0 +1,30 @@
+package org.komapper.dialect.oracle
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
+import org.komapper.core.dsl.context.RelationUpdateContext
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+
+class OracleRelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
+    private val context: RelationUpdateContext<ENTITY, ID, META>,
+) : RelationUpdateStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = RelationUpdateStatementBuilder(dialect, context)
+    private val support = OracleStatementBuilderSupport(dialect, context)
+
+    override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        buf.append(builder.build(assignments))
+        val returningStatement = support.buildReturning()
+        if (returningStatement.parts.isNotEmpty()) {
+            buf.append(" ")
+            buf.append(returningStatement)
+        }
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleStatementBuilderSupport.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleStatementBuilderSupport.kt
@@ -1,4 +1,4 @@
-package org.komapper.dialect.sqlserver
+package org.komapper.dialect.oracle
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
@@ -6,26 +6,30 @@ import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.context.ReturningProvider
 import org.komapper.core.dsl.expression.ColumnExpression
 
-class SqlServerBuilderSupport(
+class OracleStatementBuilderSupport(
     private val dialect: BuilderDialect,
     private val returningProvider: ReturningProvider,
 ) {
 
-    fun buildOutput(): Statement {
-        val buf = StatementBuffer()
-        with(buf) {
+    fun buildReturning(): Statement {
+        return with(StatementBuffer()) {
             val expressions = returningProvider.returning.expressions()
             if (expressions.isNotEmpty()) {
-                append(" output ")
+                append("returning ")
                 for (e in expressions) {
-                    append("inserted.")
                     column(e)
                     append(", ")
                 }
                 cutBack(2)
+                append(" into ")
+                for (e in expressions) {
+                    registerReturnParameter(e.interiorClass)
+                    append(", ")
+                }
+                cutBack(2)
             }
+            toStatement()
         }
-        return buf.toStatement()
     }
 
     private fun StatementBuffer.column(expression: ColumnExpression<*, *>) {

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
@@ -81,9 +81,15 @@ interface PostgreSqlDialect : Dialect {
 
     override fun supportsLockOptionSkipLocked(): Boolean = true
 
-    override fun supportsInsertReturning(): Boolean = true
+    override fun supportsInsertMultipleReturning(): Boolean = true
+
+    override fun supportsInsertSingleReturning(): Boolean = true
 
     override fun supportsSearchConditionInUpsertStatement(): Boolean = true
 
     override fun supportsUpdateReturning(): Boolean = true
+
+    override fun supportsUpsertMultipleReturning(): Boolean = true
+
+    override fun supportsUpsertSingleReturning(): Boolean = true
 }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityInsertStatementBuilder.kt
@@ -6,34 +6,21 @@ import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.builder.DefaultEntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.context.EntityInsertContext
-import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 class PostgreSqlEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val dialect: BuilderDialect,
-    private val context: EntityInsertContext<ENTITY, ID, META>,
+    dialect: BuilderDialect,
+    context: EntityInsertContext<ENTITY, ID, META>,
     entities: List<ENTITY>,
 ) : EntityInsertStatementBuilder<ENTITY, ID, META> {
 
     private val buf = StatementBuffer()
     private val builder = DefaultEntityInsertStatementBuilder(dialect, context, entities)
+    private val support = PostgreSqlStatementBuilderSupport(dialect, context)
 
     override fun build(): Statement {
         buf.append(builder.build())
-        val expressions = context.returning.expressions()
-        if (expressions.isNotEmpty()) {
-            buf.append(" returning ")
-            for (e in expressions) {
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
+        buf.appendIfNotEmpty(support.buildReturning())
         return buf.toStatement()
-    }
-
-    private fun column(expression: ColumnExpression<*, *>) {
-        val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
     }
 }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpdateStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpdateStatementBuilder.kt
@@ -6,34 +6,21 @@ import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.builder.DefaultEntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.context.EntityUpdateContext
-import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
 class PostgreSqlEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val dialect: BuilderDialect,
-    private val context: EntityUpdateContext<ENTITY, ID, META>,
+    dialect: BuilderDialect,
+    context: EntityUpdateContext<ENTITY, ID, META>,
     entity: ENTITY,
 ) : EntityUpdateStatementBuilder<ENTITY, ID, META> {
 
     private val buf = StatementBuffer()
     private val builder = DefaultEntityUpdateStatementBuilder(dialect, context, entity)
+    private val support = PostgreSqlStatementBuilderSupport(dialect, context)
 
     override fun build(): Statement {
         buf.append(builder.build())
-        val expressions = context.returning.expressions()
-        if (expressions.isNotEmpty()) {
-            buf.append(" returning ")
-            for (e in expressions) {
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
+        buf.appendIfNotEmpty(support.buildReturning())
         return buf.toStatement()
-    }
-
-    private fun column(expression: ColumnExpression<*, *>) {
-        val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
     }
 }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
@@ -29,6 +29,7 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
     private val aliasManager = UpsertAliasManager(target, excluded)
     private val buf = StatementBuffer()
     private val support = BuilderSupport(dialect, aliasManager, buf, context.insertContext.options.escapeSequence)
+    private val postgreSqlSupport = PostgreSqlStatementBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         val properties = target.getNonAutoIncrementProperties()
@@ -88,15 +89,7 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
                 }
             }
         }
-        val expressions = context.returning.expressions()
-        if (expressions.isNotEmpty()) {
-            buf.append(" returning ")
-            for (e in expressions) {
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
+        buf.appendIfNotEmpty(postgreSqlSupport.buildReturning())
         return buf.toStatement()
     }
 

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationInsertValuesStatementBuilder.kt
@@ -5,34 +5,21 @@ import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.context.RelationInsertValuesContext
-import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 
 class PostgreSqlRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val dialect: BuilderDialect,
-    private val context: RelationInsertValuesContext<ENTITY, ID, META>,
+    dialect: BuilderDialect,
+    context: RelationInsertValuesContext<ENTITY, ID, META>,
 ) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
     private val buf = StatementBuffer()
     private val builder = RelationInsertValuesStatementBuilder(dialect, context)
+    private val support = PostgreSqlStatementBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         buf.append(builder.build(assignments))
-        val expressions = context.returning.expressions()
-        if (expressions.isNotEmpty()) {
-            buf.append(" returning ")
-            for (e in expressions) {
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
+        buf.appendIfNotEmpty(support.buildReturning())
         return buf.toStatement()
-    }
-
-    private fun column(expression: ColumnExpression<*, *>) {
-        val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
     }
 }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationUpdateStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationUpdateStatementBuilder.kt
@@ -5,35 +5,22 @@ import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
 import org.komapper.core.dsl.context.RelationUpdateContext
-import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 
 class PostgreSqlRelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
-    private val dialect: BuilderDialect,
-    private val context: RelationUpdateContext<ENTITY, ID, META>,
+    dialect: BuilderDialect,
+    context: RelationUpdateContext<ENTITY, ID, META>,
 ) : RelationUpdateStatementBuilder<ENTITY, ID, META> {
 
     private val buf = StatementBuffer()
     private val builder = RelationUpdateStatementBuilder(dialect, context)
+    private val support = PostgreSqlStatementBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         buf.append(builder.build(assignments))
-        val expressions = context.returning.expressions()
-        if (expressions.isNotEmpty()) {
-            buf.append(" returning ")
-            for (e in expressions) {
-                column(e)
-                buf.append(", ")
-            }
-            buf.cutBack(2)
-        }
+        buf.appendIfNotEmpty(support.buildReturning())
         return buf.toStatement()
-    }
-
-    private fun column(expression: ColumnExpression<*, *>) {
-        val name = expression.getCanonicalColumnName(dialect::enquote)
-        buf.append(name)
     }
 }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlStatementBuilderSupport.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlStatementBuilderSupport.kt
@@ -1,0 +1,33 @@
+package org.komapper.dialect.postgresql
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.context.ReturningProvider
+import org.komapper.core.dsl.expression.ColumnExpression
+
+class PostgreSqlStatementBuilderSupport(
+    private val dialect: BuilderDialect,
+    private val returningProvider: ReturningProvider,
+) {
+
+    fun buildReturning(): Statement {
+        return with(StatementBuffer()) {
+            val expressions = returningProvider.returning.expressions()
+            if (expressions.isNotEmpty()) {
+                append(" returning ")
+                for (e in expressions) {
+                    column(e)
+                    append(", ")
+                }
+                cutBack(2)
+            }
+            toStatement()
+        }
+    }
+
+    private fun StatementBuffer.column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        append(name)
+    }
+}

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
@@ -107,7 +107,9 @@ interface SqlServerDialect : Dialect {
 
     override fun supportsForUpdateClause(): Boolean = false
 
-    override fun supportsInsertReturning(): Boolean = true
+    override fun supportsInsertMultipleReturning(): Boolean = true
+
+    override fun supportsInsertSingleReturning(): Boolean = true
 
     override fun supportsMultipleColumnsInInPredicate(): Boolean = false
 
@@ -118,4 +120,8 @@ interface SqlServerDialect : Dialect {
     override fun supportsLockOptionNowait(): Boolean = true
 
     override fun supportsSearchConditionInUpsertStatement(): Boolean = true
+
+    override fun supportsUpsertMultipleReturning(): Boolean = true
+
+    override fun supportsUpsertSingleReturning(): Boolean = true
 }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityInsertStatementBuilder.kt
@@ -16,7 +16,7 @@ class SqlServerEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : Entit
 
     private val builder = DefaultEntityInsertStatementBuilder(dialect, context, entities)
 
-    private val support = SqlServerBuilderSupport(dialect, context)
+    private val support = SqlServerStatementBuilderSupport(dialect, context)
 
     override fun build(): Statement {
         val buf = StatementBuffer()

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityInsertStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityInsertStatementBuilder.kt
@@ -15,17 +15,12 @@ class SqlServerEntityInsertStatementBuilder<ENTITY : Any, ID : Any, META : Entit
 ) : EntityInsertStatementBuilder<ENTITY, ID, META> {
 
     private val builder = DefaultEntityInsertStatementBuilder(dialect, context, entities)
-
     private val support = SqlServerStatementBuilderSupport(dialect, context)
 
     override fun build(): Statement {
         val buf = StatementBuffer()
         buf.append(builder.buildInsertInto())
-        val outputStatement = support.buildOutput()
-        if (outputStatement.parts.isNotEmpty()) {
-            buf.append(" ")
-            buf.append(outputStatement)
-        }
+        buf.appendIfNotEmpty(support.buildOutput())
         buf.append(" ")
         buf.append(builder.buildValues())
         return buf.toStatement()

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpdateStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpdateStatementBuilder.kt
@@ -20,11 +20,7 @@ class SqlServerEntityUpdateStatementBuilder<ENTITY : Any, ID : Any, META : Entit
     override fun build(): Statement {
         val buf = StatementBuffer()
         buf.append(builder.buildUpdateSet())
-        val outputStatement = support.buildOutput()
-        if (outputStatement.parts.isNotEmpty()) {
-            buf.append(" ")
-            buf.append(outputStatement)
-        }
+        buf.appendIfNotEmpty(support.buildOutput())
         buf.append(" ")
         buf.append(builder.buildWhere())
         return buf.toStatement()

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpsertStatementBuilder.kt
@@ -29,7 +29,7 @@ internal class SqlServerEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, MET
     private val aliasManager = UpsertAliasManager(target, excluded)
     private val buf = StatementBuffer()
     private val support = BuilderSupport(dialect, aliasManager, buf, context.insertContext.options.escapeSequence)
-    private val sqlServerSupport = SqlServerBuilderSupport(dialect, context)
+    private val sqlServerSupport = SqlServerStatementBuilderSupport(dialect, context)
     private val sourceStatementBuilder = SourceStatementBuilder(dialect, context, entities)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpsertStatementBuilder.kt
@@ -86,11 +86,7 @@ internal class SqlServerEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, MET
         }
         buf.cutBack(2)
         buf.append(")")
-        val outputStatement = sqlServerSupport.buildOutput()
-        if (outputStatement.parts.isNotEmpty()) {
-            buf.append(" ")
-            buf.append(outputStatement)
-        }
+        buf.appendIfNotEmpty(sqlServerSupport.buildOutput())
         buf.append(";")
         return buf.toStatement()
     }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationInsertValuesStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationInsertValuesStatementBuilder.kt
@@ -16,17 +16,12 @@ class SqlServerRelationInsertValuesStatementBuilder<ENTITY : Any, ID : Any, META
 ) : RelationInsertValuesStatementBuilder<ENTITY, ID, META> {
 
     private val builder = DefaultRelationInsertValuesStatementBuilder(dialect, context)
-
     private val support = SqlServerStatementBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         val buf = StatementBuffer()
         buf.append(builder.buildInsertInto(assignments))
-        val outputStatement = support.buildOutput()
-        if (outputStatement.parts.isNotEmpty()) {
-            buf.append(" ")
-            buf.append(outputStatement)
-        }
+        buf.appendIfNotEmpty(support.buildOutput())
         buf.append(" ")
         buf.append(builder.buildValues(assignments))
         return buf.toStatement()

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationUpdateStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationUpdateStatementBuilder.kt
@@ -17,7 +17,7 @@ class SqlServerRelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : Ent
 
     private val builder = DefaultRelationUpdateStatementBuilder(dialect, context)
 
-    private val support = SqlServerBuilderSupport(dialect, context)
+    private val support = SqlServerStatementBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         val buf = StatementBuffer()

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationUpdateStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationUpdateStatementBuilder.kt
@@ -16,17 +16,12 @@ class SqlServerRelationUpdateStatementBuilder<ENTITY : Any, ID : Any, META : Ent
 ) : RelationUpdateStatementBuilder<ENTITY, ID, META> {
 
     private val builder = DefaultRelationUpdateStatementBuilder(dialect, context)
-
     private val support = SqlServerStatementBuilderSupport(dialect, context)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
         val buf = StatementBuffer()
         buf.append(builder.buildUpdateSet(assignments))
-        val outputStatement = support.buildOutput()
-        if (outputStatement.parts.isNotEmpty()) {
-            buf.append(" ")
-            buf.append(outputStatement)
-        }
+        buf.appendIfNotEmpty(support.buildOutput())
         buf.append(" ")
         buf.append(builder.buildWhere())
         return buf.toStatement()

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerStatementBuilderSupport.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerStatementBuilderSupport.kt
@@ -1,0 +1,35 @@
+package org.komapper.dialect.sqlserver
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.context.ReturningProvider
+import org.komapper.core.dsl.expression.ColumnExpression
+
+class SqlServerStatementBuilderSupport(
+    private val dialect: BuilderDialect,
+    private val returningProvider: ReturningProvider,
+) {
+
+    fun buildOutput(): Statement {
+        val buf = StatementBuffer()
+        with(buf) {
+            val expressions = returningProvider.returning.expressions()
+            if (expressions.isNotEmpty()) {
+                append(" output ")
+                for (e in expressions) {
+                    append("inserted.")
+                    column(e)
+                    append(", ")
+                }
+                cutBack(2)
+            }
+        }
+        return buf.toStatement()
+    }
+
+    private fun StatementBuffer.column(expression: ColumnExpression<*, *>) {
+        val name = expression.getCanonicalColumnName(dialect::enquote)
+        append(name)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataOperator.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataOperator.kt
@@ -37,6 +37,15 @@ interface JdbcDataOperator : DataOperator {
     fun <T : Any> setValue(ps: PreparedStatement, index: Int, value: T?, valueClass: KClass<out T>)
 
     /**
+     * Registers the return parameter.
+     *
+     * @param ps the prepared statement
+     * @param index the column index
+     * @param parameterClass the parameter class
+     */
+    fun <T : Any> registerReturnParameter(ps: PreparedStatement, index: Int, parameterClass: KClass<out T>)
+
+    /**
      * Returns the data type.
      *
      * @param klass the value class
@@ -68,6 +77,11 @@ class DefaultJdbcDataOperator(private val dialect: JdbcDialect, private val data
     override fun <T : Any> setValue(ps: PreparedStatement, index: Int, value: T?, valueClass: KClass<out T>) {
         val dataType = getDataType(valueClass)
         dataType.setValue(ps, index, value)
+    }
+
+    override fun <T : Any> registerReturnParameter(ps: PreparedStatement, index: Int, valueClass: KClass<out T>) {
+        val dataType = getDataType(valueClass)
+        dataType.registerReturnParameter(ps, index)
     }
 
     override fun <T : Any> formatValue(value: T?, valueClass: KClass<out T>, masking: Boolean): String {

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataType.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataType.kt
@@ -68,6 +68,16 @@ interface JdbcDataType<T : Any> {
     fun setValue(ps: PreparedStatement, index: Int, value: T?)
 
     /**
+     * Registers the return parameter.
+     *
+     * @param ps the prepared statement
+     * @param index the index
+     */
+    fun registerReturnParameter(ps: PreparedStatement, index: Int) {
+        throw UnsupportedOperationException()
+    }
+
+    /**
      * Returns the string presentation of the value.
      *
      * @param value the value

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDialect.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDialect.kt
@@ -1,12 +1,21 @@
 package org.komapper.jdbc
 
 import org.komapper.core.Dialect
+import org.komapper.core.ExecutionOptionsProvider
 import java.sql.SQLException
 
 /**
  * Represents a dialect for JDBC access.
  */
 interface JdbcDialect : Dialect {
+
+    fun createExecutor(
+        config: JdbcDatabaseConfig,
+        executionOptionProvider: ExecutionOptionsProvider,
+        generatedColumn: String? = null,
+    ): JdbcExecutor {
+        return DefaultJdbcExecutor(config, executionOptionProvider, generatedColumn)
+    }
 
     /**
      * Returns whether the exception indicates that the sequence already exists.

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityDeleteRunnerSupport.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityDeleteRunnerSupport.kt
@@ -10,7 +10,7 @@ internal class JdbcEntityDeleteRunnerSupport<ENTITY : Any, ID : Any, META : Enti
 ) {
 
     fun <T> delete(config: JdbcDatabaseConfig, execute: (JdbcExecutor) -> T): T {
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         return execute(executor)
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertMultipleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertMultipleReturningRunner.kt
@@ -40,7 +40,7 @@ internal class JdbcEntityInsertMultipleReturningRunner<ENTITY : Any, ID : Any, M
     private fun insert(config: JdbcDatabaseConfig, entities: List<ENTITY>): List<T> {
         val statement = runner.buildStatement(config, entities)
         return support.insert(config) { executor ->
-            executor.executeQuery(statement, transform) { it.toList() }
+            executor.executeReturning(statement, transform) { it.toList() }
         }
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertReturningRunnerSupport.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertReturningRunnerSupport.kt
@@ -26,7 +26,7 @@ internal class JdbcEntityInsertReturningRunnerSupport<ENTITY : Any, ID : Any, ME
     }
 
     fun <T> insert(config: JdbcDatabaseConfig, execute: (JdbcExecutor) -> T): T {
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         return execute(executor)
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertRunnerSupport.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertRunnerSupport.kt
@@ -32,7 +32,7 @@ internal class JdbcEntityInsertRunnerSupport<ENTITY : Any, ID : Any, META : Enti
         } else {
             null
         }
-        val executor = JdbcExecutor(config, context.options, generatedColumn)
+        val executor = config.dialect.createExecutor(config, context.options, generatedColumn)
         return execute(executor)
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityInsertSingleReturningRunner.kt
@@ -38,7 +38,7 @@ internal class JdbcEntityInsertSingleReturningRunner<ENTITY : Any, ID : Any, MET
     private fun insert(config: JdbcDatabaseConfig, entity: ENTITY): T {
         val statement = runner.buildStatement(config, entity)
         return support.insert(config) { executor ->
-            executor.executeQuery(statement, transform) { it.first() }
+            executor.executeReturning(statement, transform) { it.first() }
         }
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityStoreRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityStoreRunner.kt
@@ -8,7 +8,6 @@ import org.komapper.core.dsl.query.EntityStore
 import org.komapper.core.dsl.runner.EntityStoreFactory
 import org.komapper.core.dsl.runner.SelectRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal class JdbcEntityStoreRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: SelectContext<ENTITY, ID, META>,
@@ -24,7 +23,7 @@ internal class JdbcEntityStoreRunner<ENTITY : Any, ID : Any, META : EntityMetamo
     override fun run(config: JdbcDatabaseConfig): EntityStore {
         val metamodels = context.getProjection().metamodels()
         val statement = runner.buildStatement(config)
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         val rows = executor.executeQuery(statement) { rs ->
             val rows = mutableListOf<Map<EntityMetamodel<*, *, *>, Any>>()
             while (rs.next()) {

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateReturningRunnerSupport.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateReturningRunnerSupport.kt
@@ -10,7 +10,7 @@ internal class JdbcEntityUpdateReturningRunnerSupport<ENTITY : Any, ID : Any, ME
 ) {
 
     fun <T> update(config: JdbcDatabaseConfig, execute: (JdbcExecutor) -> T): T {
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         return execute(executor)
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateRunnerSupport.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateRunnerSupport.kt
@@ -10,7 +10,7 @@ internal class JdbcEntityUpdateRunnerSupport<ENTITY : Any, ID : Any, META : Enti
 ) {
 
     fun <T> update(config: JdbcDatabaseConfig, execute: (JdbcExecutor) -> T): T {
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         return execute(executor)
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateSingleReturningRunner.kt
@@ -40,7 +40,7 @@ internal class JdbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, MET
     private fun update(config: JdbcDatabaseConfig, entity: ENTITY): T? {
         val statement = runner.buildStatement(config, entity)
         return support.update(config) { executor ->
-            executor.executeQuery(statement, transform) { it.singleOrNull() }
+            executor.executeReturning(statement, transform) { it.singleOrNull() }
         }
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertMultipleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertMultipleReturningRunner.kt
@@ -39,7 +39,7 @@ internal class JdbcEntityUpsertMultipleReturningRunner<ENTITY : Any, ID : Any, M
     private fun upsert(config: JdbcDatabaseConfig, entities: List<ENTITY>): List<T> {
         val statement = runner.buildStatement(config, entities)
         return support.upsert(config) { executor ->
-            executor.executeQuery(statement, transform) { it.toList() }
+            executor.executeReturning(statement, transform) { it.toList() }
         }
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpsertSingleReturningRunner.kt
@@ -39,7 +39,7 @@ internal class JdbcEntityUpsertSingleReturningRunner<ENTITY : Any, ID : Any, MET
     private fun upsert(config: JdbcDatabaseConfig, entity: ENTITY): R {
         val statement = runner.buildStatement(config, entity)
         return support.upsert(config) { executor ->
-            executor.executeQuery(statement, transform, collect)
+            executor.executeReturning(statement, transform, collect)
         }
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationDeleteRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationDeleteRunner.kt
@@ -6,7 +6,6 @@ import org.komapper.core.dsl.context.RelationDeleteContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.runner.RelationDeleteRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal class JdbcRelationDeleteRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: RelationDeleteContext<ENTITY, ID, META>,
@@ -20,7 +19,7 @@ internal class JdbcRelationDeleteRunner<ENTITY : Any, ID : Any, META : EntityMet
 
     override fun run(config: JdbcDatabaseConfig): Long {
         val statement = runner.buildStatement(config)
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         val (count) = executor.executeUpdate(statement)
         return count
     }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertSelectRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertSelectRunner.kt
@@ -7,7 +7,6 @@ import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.getAutoIncrementProperty
 import org.komapper.core.dsl.runner.RelationInsertSelectRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal class JdbcRelationInsertSelectRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: RelationInsertSelectContext<ENTITY, ID, META>,
@@ -26,7 +25,7 @@ internal class JdbcRelationInsertSelectRunner<ENTITY : Any, ID : Any, META : Ent
         } else {
             null
         }
-        val executor = JdbcExecutor(config, context.options, generatedColumn)
+        val executor = config.dialect.createExecutor(config, context.options, generatedColumn)
         val (count, keys) = executor.executeUpdate(statement)
         val ids = keys.mapNotNull { context.target.convertToId(it) }
         return count to ids

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertValuesReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertValuesReturningRunner.kt
@@ -11,7 +11,6 @@ import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.runner.RelationInsertValuesReturningRunner
 import org.komapper.jdbc.JdbcDataOperator
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 import java.sql.ResultSet
 
 internal class JdbcRelationInsertValuesReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
@@ -52,8 +51,8 @@ internal class JdbcRelationInsertValuesReturningRunner<ENTITY : Any, ID : Any, M
         idAssignment: Pair<PropertyMetamodel<ENTITY, ID, *>, Operand>? = null,
     ): T {
         val statement = runner.buildStatement(config, idAssignment)
-        val executor = JdbcExecutor(config, context.options)
-        return executor.executeQuery(statement, transform) { it.single() }
+        val executor = config.dialect.createExecutor(config, context.options)
+        return executor.executeReturning(statement, transform) { it.single() }
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertValuesRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationInsertValuesRunner.kt
@@ -9,7 +9,6 @@ import org.komapper.core.dsl.metamodel.IdGenerator
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.runner.RelationInsertValuesRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal class JdbcRelationInsertValuesRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: RelationInsertValuesContext<ENTITY, ID, META>,
@@ -53,7 +52,7 @@ internal class JdbcRelationInsertValuesRunner<ENTITY : Any, ID : Any, META : Ent
         generatedColumn: String? = null,
     ): Pair<Long, List<Long>> {
         val statement = runner.buildStatement(config, idAssignment)
-        val executor = JdbcExecutor(config, context.options, generatedColumn)
+        val executor = config.dialect.createExecutor(config, context.options, generatedColumn)
         return executor.executeUpdate(statement)
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationUpdateReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationUpdateReturningRunner.kt
@@ -8,7 +8,6 @@ import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.runner.RelationUpdateReturningRunner
 import org.komapper.jdbc.JdbcDataOperator
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 import java.sql.ResultSet
 
 internal class JdbcRelationUpdateReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
@@ -28,8 +27,8 @@ internal class JdbcRelationUpdateReturningRunner<ENTITY : Any, ID : Any, META : 
         val result = runner.buildStatement(config, updatedAtAssignment)
         val statement = result.getOrNull()
         return if (statement != null) {
-            val executor = JdbcExecutor(config, context.options)
-            executor.executeQuery(statement, transform) { it.toList() }
+            val executor = config.dialect.createExecutor(config, context.options)
+            executor.executeReturning(statement, transform) { it.toList() }
         } else {
             emptyList()
         }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationUpdateRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationUpdateRunner.kt
@@ -6,7 +6,6 @@ import org.komapper.core.dsl.context.RelationUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.runner.RelationUpdateRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal class JdbcRelationUpdateRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: RelationUpdateContext<ENTITY, ID, META>,
@@ -24,7 +23,7 @@ internal class JdbcRelationUpdateRunner<ENTITY : Any, ID : Any, META : EntityMet
         val result = runner.buildStatement(config, updatedAtAssignment)
         val statement = result.getOrNull()
         return if (statement != null) {
-            val executor = JdbcExecutor(config, context.options)
+            val executor = config.dialect.createExecutor(config, context.options)
             val (count) = executor.executeUpdate(statement)
             count
         } else {

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRunnerUtility.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRunnerUtility.kt
@@ -5,7 +5,6 @@ import org.komapper.core.Statement
 import org.komapper.core.dsl.metamodel.IdGenerator
 import org.komapper.core.dsl.options.QueryOptions
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal fun <ENTITY : Any, ID : Any> IdGenerator.Sequence<ENTITY, ID>.execute(
     config: JdbcDatabaseConfig,
@@ -14,7 +13,7 @@ internal fun <ENTITY : Any, ID : Any> IdGenerator.Sequence<ENTITY, ID>.execute(
     generate(config.id, config.dialect::enquote) { sequenceName ->
         val sql = config.dialect.getSequenceSql(sequenceName)
         val statement = Statement(sql)
-        val executor = JdbcExecutor(config, options)
+        val executor = config.dialect.createExecutor(config, options)
         executor.executeQuery(statement) { rs ->
             if (rs.next()) rs.getLong(1) else error("No result: ${statement.toSql()}")
         }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcSchemaCreateRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcSchemaCreateRunner.kt
@@ -5,7 +5,6 @@ import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.SchemaContext
 import org.komapper.core.dsl.runner.SchemaCreateRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal class JdbcSchemaCreateRunner(
     private val context: SchemaContext,
@@ -19,7 +18,7 @@ internal class JdbcSchemaCreateRunner(
 
     override fun run(config: JdbcDatabaseConfig) {
         val statements = runner.buildStatements(config)
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         executor.execute(statements) {
             if (!config.dialect.isTableExistsError(it) &&
                 !config.dialect.isSequenceExistsError(it)

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcSchemaDropRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcSchemaDropRunner.kt
@@ -5,7 +5,6 @@ import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.SchemaContext
 import org.komapper.core.dsl.runner.SchemaDropRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal class JdbcSchemaDropRunner(
     private val context: SchemaContext,
@@ -19,7 +18,7 @@ internal class JdbcSchemaDropRunner(
 
     override fun run(config: JdbcDatabaseConfig) {
         val statements = runner.buildStatements(config)
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         executor.execute(statements) {
             if (!config.dialect.isTableNotExistsError(it) &&
                 !config.dialect.isSequenceNotExistsError(it)

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcScriptExecuteRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcScriptExecuteRunner.kt
@@ -5,7 +5,6 @@ import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.ScriptContext
 import org.komapper.core.dsl.runner.ScriptExecuteRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal class JdbcScriptExecuteRunner(
     private val context: ScriptContext,
@@ -20,7 +19,7 @@ internal class JdbcScriptExecuteRunner(
 
     override fun run(config: JdbcDatabaseConfig) {
         val statements = runner.buildStatements()
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         return executor.execute(statements)
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcSelectRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcSelectRunner.kt
@@ -7,7 +7,6 @@ import org.komapper.core.dsl.context.SelectContext
 import org.komapper.core.dsl.runner.SelectRunner
 import org.komapper.jdbc.JdbcDataOperator
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 import java.sql.ResultSet
 
 internal class JdbcSelectRunner<T, R>(
@@ -25,7 +24,7 @@ internal class JdbcSelectRunner<T, R>(
 
     override fun run(config: JdbcDatabaseConfig): R {
         val statement = runner.buildStatement(config)
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         return executor.executeQuery(statement, transform, collect)
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcSetOperationRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcSetOperationRunner.kt
@@ -7,7 +7,6 @@ import org.komapper.core.dsl.context.SetOperationContext
 import org.komapper.core.dsl.runner.SetOperationRunner
 import org.komapper.jdbc.JdbcDataOperator
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 import java.sql.ResultSet
 
 internal class JdbcSetOperationRunner<T : Any?, R>(
@@ -24,7 +23,7 @@ internal class JdbcSetOperationRunner<T : Any?, R>(
 
     override fun run(config: JdbcDatabaseConfig): R {
         val statement = runner.buildStatement(config)
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         return executor.executeQuery(statement, transform, collect)
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcTemplateExecuteRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcTemplateExecuteRunner.kt
@@ -5,7 +5,6 @@ import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.TemplateExecuteContext
 import org.komapper.core.dsl.runner.TemplateExecuteRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal class JdbcTemplateExecuteRunner(
     private val context: TemplateExecuteContext,
@@ -19,7 +18,7 @@ internal class JdbcTemplateExecuteRunner(
 
     override fun run(config: JdbcDatabaseConfig): Long {
         val statement = runner.buildStatement(config)
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         val (count) = executor.executeUpdate(statement)
         return count
     }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcTemplateSelectRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcTemplateSelectRunner.kt
@@ -7,7 +7,6 @@ import org.komapper.core.dsl.context.TemplateSelectContext
 import org.komapper.core.dsl.query.Row
 import org.komapper.core.dsl.runner.TemplateSelectRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
-import org.komapper.jdbc.JdbcExecutor
 
 internal class JdbcTemplateSelectRunner<T, R>(
     private val context: TemplateSelectContext,
@@ -23,7 +22,7 @@ internal class JdbcTemplateSelectRunner<T, R>(
 
     override fun run(config: JdbcDatabaseConfig): R {
         val statement = runner.buildStatement(config)
-        val executor = JdbcExecutor(config, context.options)
+        val executor = config.dialect.createExecutor(config, context.options)
         return executor.executeQuery(
             statement,
             { dataOperator, rs ->


### PR DESCRIPTION
This PR allows RETURNING INTO Clause to be used with Oracle JDBC.
As for R2DBC, the driver doesn't seem to support it yet (oracle/oracle-r2dbc#115).

Other dialect implementations are supported in #962.
