### PR TITLE
Support for `DELETE ... RETURNING`

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteSingleReturningTest.kt
@@ -1,0 +1,97 @@
+package integration.jdbc
+
+import integration.core.Dbms
+import integration.core.Run
+import integration.core.address
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.OptimisticLockException
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.query.first
+import org.komapper.core.dsl.query.firstOrNull
+import org.komapper.jdbc.JdbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+@ExtendWith(JdbcEnv::class)
+class JdbcDeleteSingleReturningTest(private val db: JdbcDatabase) {
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun optimisticLockException() {
+        val a = Meta.address
+        val address = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 15
+            }.first()
+        }
+        db.runQuery { QueryDsl.delete(a).single(address) }
+        assertFailsWith<OptimisticLockException> {
+            db.runQuery { QueryDsl.delete(a).single(address).returning() }
+            Unit
+        }
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun test() {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val address2 = db.runQuery { QueryDsl.delete(a).single(address).returning() }
+        assertEquals(address, address2)
+        val address3 = db.runQuery { query.firstOrNull() }
+        assertNull(address3)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningSingleColumn() {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val street = db.runQuery { QueryDsl.delete(a).single(address).returning(a.street) }
+        assertEquals(address.street, street)
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertNull(address2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningPairColumns() {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val pair = db.runQuery { QueryDsl.delete(a).single(address).returning(a.street, a.version) }
+        assertEquals(address.street to address.version, pair)
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertNull(address2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningTripleColumns() {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val triple = db.runQuery { QueryDsl.delete(a).single(address).returning(a.street, a.version, a.addressId) }
+        assertEquals(Triple(address.street, address.version, address.addressId), triple)
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertNull(address2)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun unsupportedOperationException_deleteReturning() {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.delete(a).single(address).returning() }
+            Unit
+        }
+        println(ex)
+    }
+}

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteWhereReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteWhereReturningTest.kt
@@ -1,0 +1,138 @@
+package integration.jdbc
+
+import integration.core.Address
+import integration.core.Dbms
+import integration.core.Run
+import integration.core.address
+import integration.core.employee
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.jdbc.JdbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+@ExtendWith(JdbcEnv::class)
+class JdbcDeleteWhereReturningTest(private val db: JdbcDatabase) {
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun test() {
+        val a = Meta.address
+        db.runQuery {
+            QueryDsl.insert(a).multiple(Address(16, "STREET 16", 0))
+        }
+        val query = QueryDsl.from(a).where { a.addressId inList listOf(15, 16) }
+        val addressList = db.runQuery { query }
+        assertEquals(2, addressList.size)
+        val addressList2 = db.runQuery {
+            QueryDsl.delete(a).where { a.addressId inList listOf(15, 16) }.returning()
+        }
+        assertEquals(addressList.toSet(), addressList2.toSet())
+        val addressList3 = db.runQuery { query }
+        assertTrue(addressList3.isEmpty())
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningSingleColumn() {
+        val a = Meta.address
+        db.runQuery {
+            QueryDsl.insert(a).multiple(Address(16, "STREET 16", 0))
+        }
+        val query = QueryDsl.from(a).where { a.addressId inList listOf(15, 16) }
+        val addressList = db.runQuery { query }
+        assertEquals(2, addressList.size)
+        val streets = db.runQuery {
+            QueryDsl.delete(a).where { a.addressId inList listOf(15, 16) }.returning(a.street)
+        }
+        assertEquals(addressList.map { it.street }.toSet(), streets.toSet())
+        val addressList2 = db.runQuery { query }
+        assertTrue(addressList2.isEmpty())
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningPairColumns() {
+        val a = Meta.address
+        db.runQuery {
+            QueryDsl.insert(a).multiple(Address(16, "STREET 16", 0))
+        }
+        val query = QueryDsl.from(a).where { a.addressId inList listOf(15, 16) }
+        val addressList = db.runQuery { query }
+        assertEquals(2, addressList.size)
+        val pairs = db.runQuery {
+            QueryDsl.delete(a).where { a.addressId inList listOf(15, 16) }.returning(a.street, a.version)
+        }
+        assertEquals(addressList.map { it.street to it.version }.toSet(), pairs.toSet())
+        val addressList2 = db.runQuery { query }
+        assertTrue(addressList2.isEmpty())
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningTripleColumns() {
+        val a = Meta.address
+        db.runQuery {
+            QueryDsl.insert(a).multiple(Address(16, "STREET 16", 0))
+        }
+        val query = QueryDsl.from(a).where { a.addressId inList listOf(15, 16) }
+        val addressList = db.runQuery { query }
+        assertEquals(2, addressList.size)
+        val triples = db.runQuery {
+            QueryDsl.delete(a).where { a.addressId inList listOf(15, 16) }.returning(a.street, a.version, a.addressId)
+        }
+        assertEquals(addressList.map { Triple(it.street, it.version, it.addressId) }.toSet(), triples.toSet())
+        val addressList2 = db.runQuery { query }
+        assertTrue(addressList2.isEmpty())
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun allowMissingWhereClause_default() {
+        val e = Meta.employee
+        val ex = assertFailsWith<IllegalStateException> {
+            @Suppress("UNUSED_VARIABLE")
+            val count = db.runQuery {
+                QueryDsl.delete(e).all().returning()
+            }
+        }
+        println(ex)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun allowMissingWhereClause_default_empty() {
+        val e = Meta.employee
+        val ex = assertFailsWith<IllegalStateException> {
+            @Suppress("UNUSED_VARIABLE")
+            val count = db.runQuery {
+                QueryDsl.delete(e).where { }.returning()
+            }
+        }
+        println(ex)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun allowMissingWhereClause_true() {
+        val e = Meta.employee
+        val list = db.runQuery {
+            QueryDsl.delete(e).all().returning().options { it.copy(allowMissingWhereClause = true) }
+        }
+        assertEquals(14, list.size)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun unsupportedOperationException_deleteReturning() {
+        val a = Meta.address
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.delete(a).where { a.addressId eq 15 }.returning() }
+            Unit
+        }
+        println(ex)
+    }
+}

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteSingleReturningTest.kt
@@ -1,0 +1,98 @@
+package integration.r2dbc
+
+import integration.core.Dbms
+import integration.core.Run
+import integration.core.address
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.OptimisticLockException
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.query.first
+import org.komapper.core.dsl.query.firstOrNull
+import org.komapper.r2dbc.R2dbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+@ExtendWith(R2dbcEnv::class)
+class R2dbcDeleteSingleReturningTest(private val db: R2dbcDatabase) {
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun optimisticLockException(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val address = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId eq 15
+            }.first()
+        }
+        db.runQuery { QueryDsl.delete(a).single(address) }
+        assertFailsWith<OptimisticLockException> {
+            db.runQuery { QueryDsl.delete(a).single(address).returning() }
+            Unit
+        }
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun test(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val address2 = db.runQuery { QueryDsl.delete(a).single(address).returning() }
+        assertEquals(address, address2)
+        val address3 = db.runQuery { query.firstOrNull() }
+        assertNull(address3)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val street = db.runQuery { QueryDsl.delete(a).single(address).returning(a.street) }
+        assertEquals(address.street, street)
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertNull(address2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val pair = db.runQuery { QueryDsl.delete(a).single(address).returning(a.street, a.version) }
+        assertEquals(address.street to address.version, pair)
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertNull(address2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val triple = db.runQuery { QueryDsl.delete(a).single(address).returning(a.street, a.version, a.addressId) }
+        assertEquals(Triple(address.street, address.version, address.addressId), triple)
+        val address2 = db.runQuery { query.firstOrNull() }
+        assertNull(address2)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun unsupportedOperationException_deleteReturning(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val query = QueryDsl.from(a).where { a.addressId eq 15 }
+        val address = db.runQuery { query.first() }
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.delete(a).single(address).returning() }
+            Unit
+        }
+        println(ex)
+    }
+}

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteWhereReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteWhereReturningTest.kt
@@ -1,0 +1,139 @@
+package integration.r2dbc
+
+import integration.core.Address
+import integration.core.Dbms
+import integration.core.Run
+import integration.core.address
+import integration.core.employee
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.r2dbc.R2dbcDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+@ExtendWith(R2dbcEnv::class)
+class R2dbcDeleteWhereReturningTest(private val db: R2dbcDatabase) {
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun test(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        db.runQuery {
+            QueryDsl.insert(a).multiple(Address(16, "STREET 16", 0))
+        }
+        val query = QueryDsl.from(a).where { a.addressId inList listOf(15, 16) }
+        val addressList = db.runQuery { query }
+        assertEquals(2, addressList.size)
+        val addressList2 = db.runQuery {
+            QueryDsl.delete(a).where { a.addressId inList listOf(15, 16) }.returning()
+        }
+        assertEquals(addressList.toSet(), addressList2.toSet())
+        val addressList3 = db.runQuery { query }
+        assertTrue(addressList3.isEmpty())
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningSingleColumn(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        db.runQuery {
+            QueryDsl.insert(a).multiple(Address(16, "STREET 16", 0))
+        }
+        val query = QueryDsl.from(a).where { a.addressId inList listOf(15, 16) }
+        val addressList = db.runQuery { query }
+        assertEquals(2, addressList.size)
+        val streets = db.runQuery {
+            QueryDsl.delete(a).where { a.addressId inList listOf(15, 16) }.returning(a.street)
+        }
+        assertEquals(addressList.map { it.street }.toSet(), streets.toSet())
+        val addressList2 = db.runQuery { query }
+        assertTrue(addressList2.isEmpty())
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningPairColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        db.runQuery {
+            QueryDsl.insert(a).multiple(Address(16, "STREET 16", 0))
+        }
+        val query = QueryDsl.from(a).where { a.addressId inList listOf(15, 16) }
+        val addressList = db.runQuery { query }
+        assertEquals(2, addressList.size)
+        val pairs = db.runQuery {
+            QueryDsl.delete(a).where { a.addressId inList listOf(15, 16) }.returning(a.street, a.version)
+        }
+        assertEquals(addressList.map { it.street to it.version }.toSet(), pairs.toSet())
+        val addressList2 = db.runQuery { query }
+        assertTrue(addressList2.isEmpty())
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningTripleColumns(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        db.runQuery {
+            QueryDsl.insert(a).multiple(Address(16, "STREET 16", 0))
+        }
+        val query = QueryDsl.from(a).where { a.addressId inList listOf(15, 16) }
+        val addressList = db.runQuery { query }
+        assertEquals(2, addressList.size)
+        val triples = db.runQuery {
+            QueryDsl.delete(a).where { a.addressId inList listOf(15, 16) }.returning(a.street, a.version, a.addressId)
+        }
+        assertEquals(addressList.map { Triple(it.street, it.version, it.addressId) }.toSet(), triples.toSet())
+        val addressList2 = db.runQuery { query }
+        assertTrue(addressList2.isEmpty())
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun allowMissingWhereClause_default(info: TestInfo) = inTransaction(db, info) {
+        val e = Meta.employee
+        val ex = assertFailsWith<IllegalStateException> {
+            @Suppress("UNUSED_VARIABLE")
+            val count = db.runQuery {
+                QueryDsl.delete(e).all().returning()
+            }
+        }
+        println(ex)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun allowMissingWhereClause_default_empty(info: TestInfo) = inTransaction(db, info) {
+        val e = Meta.employee
+        val ex = assertFailsWith<IllegalStateException> {
+            @Suppress("UNUSED_VARIABLE")
+            val count = db.runQuery {
+                QueryDsl.delete(e).where { }.returning()
+            }
+        }
+        println(ex)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun allowMissingWhereClause_true(info: TestInfo) = inTransaction(db, info) {
+        val e = Meta.employee
+        val list = db.runQuery {
+            QueryDsl.delete(e).all().returning().options { it.copy(allowMissingWhereClause = true) }
+        }
+        assertEquals(14, list.size)
+    }
+
+    @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun unsupportedOperationException_deleteReturning(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery { QueryDsl.delete(a).where { a.addressId eq 15 }.returning() }
+            Unit
+        }
+        println(ex)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -1,19 +1,24 @@
 package org.komapper.core
 
+import org.komapper.core.dsl.builder.DefaultEntityDeleteStatementBuilder
 import org.komapper.core.dsl.builder.DefaultEntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.DefaultEntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.DryRunSchemaStatementBuilder
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilderImpl
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
 import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationDeleteContext
 import org.komapper.core.dsl.context.RelationInsertValuesContext
 import org.komapper.core.dsl.context.RelationUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -150,6 +155,14 @@ interface Dialect {
      */
     fun getSchemaStatementBuilder(dialect: BuilderDialect): SchemaStatementBuilder
 
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): EntityDeleteStatementBuilder<ENTITY, ID, META> {
+        return DefaultEntityDeleteStatementBuilder(dialect, context, entity)
+    }
+
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityInsertStatementBuilder(
         dialect: BuilderDialect,
         context: EntityInsertContext<ENTITY, ID, META>,
@@ -182,6 +195,13 @@ interface Dialect {
         context: EntityUpsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
     ): EntityUpsertStatementBuilder<ENTITY>
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationDeleteContext<ENTITY, ID, META>,
+    ): RelationDeleteStatementBuilder<ENTITY, ID, META> {
+        return RelationDeleteStatementBuilder(dialect, context)
+    }
 
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
         dialect: BuilderDialect,
@@ -248,6 +268,8 @@ interface Dialect {
      * Returns whether the "CREATE TABLE/SEQUENCE IF NOT EXISTS" syntax is supported.
      */
     fun supportsCreateIfNotExists(): Boolean = true
+
+    fun supportsDeleteReturning(): Boolean = false
 
     /**
      * Returns whether the "DROP TABLE/SEQUENCE IF EXISTS" syntax is supported.

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/EntityDeleteStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/EntityDeleteStatementBuilder.kt
@@ -9,11 +9,23 @@ import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
-class EntityDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+interface EntityDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> {
+    fun build(): Statement
+}
+
+fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> EntityDeleteStatementBuilder(
     dialect: BuilderDialect,
+    context: EntityDeleteContext<ENTITY, ID, META>,
+    entity: ENTITY,
+): EntityDeleteStatementBuilder<ENTITY, ID, META> {
+    return DefaultEntityDeleteStatementBuilder(dialect, context, entity)
+}
+
+class DefaultEntityDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
     private val context: EntityDeleteContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) {
+) : EntityDeleteStatementBuilder<ENTITY, ID, META> {
 
     private val aliasManager =
         if (dialect.supportsAliasForDeleteStatement()) {
@@ -21,53 +33,70 @@ class EntityDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamode
         } else {
             EmptyAliasManager
         }
-    private val buf = StatementBuffer()
-    private val support = BuilderSupport(dialect, aliasManager, buf)
 
-    fun build(): Statement {
+    override fun build(): Statement {
+        val buf = StatementBuffer()
+        buf.append(buildDeleteFrom())
+        buf.appendIfNotEmpty(buildWhere())
+        return buf.toStatement()
+    }
+
+    fun buildDeleteFrom(): Statement {
+        val buf = StatementBuffer()
+        val support = BuilderSupport(dialect, aliasManager, buf)
+        return with(support) {
+            buf.append("delete from ")
+            table(context.target)
+            buf.toStatement()
+        }
+    }
+
+    fun buildWhere(): Statement {
+        val buf = StatementBuffer()
+        val support = BuilderSupport(dialect, aliasManager, buf)
         val target = context.target
         val identityProperties = target.idProperties()
         val versionProperty = target.versionProperty()
         val versionRequired = versionProperty != null && !context.options.disableOptimisticLock
-        buf.append("delete from ")
-        table(target)
         val criteria = context.getWhereCriteria()
-        if (criteria.isNotEmpty() || identityProperties.isNotEmpty() || versionRequired) {
-            buf.append(" where ")
-            for ((index, criterion) in criteria.withIndex()) {
-                criterion(index, criterion)
-                buf.append(" and ")
-            }
-            if (identityProperties.isNotEmpty()) {
-                for (p in identityProperties) {
-                    column(p)
-                    buf.append(" = ")
-                    buf.bind(p.toValue(entity))
+        return with(support) {
+            if (criteria.isNotEmpty() || identityProperties.isNotEmpty() || versionRequired) {
+                buf.append("where ")
+                for ((index, criterion) in criteria.withIndex()) {
+                    criterion(index, criterion)
                     buf.append(" and ")
                 }
-                if (!versionRequired) {
-                    buf.cutBack(5)
+                if (identityProperties.isNotEmpty()) {
+                    for (p in identityProperties) {
+                        column(p)
+                        buf.append(" = ")
+                        buf.bind(p.toValue(entity))
+                        buf.append(" and ")
+                    }
+                    if (!versionRequired) {
+                        buf.cutBack(5)
+                    }
+                }
+                if (versionRequired) {
+                    checkNotNull(versionProperty)
+                    column(versionProperty)
+                    buf.append(" = ")
+                    buf.bind(versionProperty.toValue(entity))
                 }
             }
-            if (versionRequired) {
-                checkNotNull(versionProperty)
-                column(versionProperty)
-                buf.append(" = ")
-                buf.bind(versionProperty.toValue(entity))
-            }
+            buf.toStatement()
         }
-        return buf.toStatement()
     }
 
-    private fun table(expression: TableExpression<*>) {
-        support.visitTableExpression(expression, TableNameType.NAME_AND_ALIAS)
+    private fun BuilderSupport.table(expression: TableExpression<*>) {
+        visitTableExpression(expression, TableNameType.NAME_AND_ALIAS)
     }
 
-    private fun column(expression: ColumnExpression<*, *>) {
-        support.visitColumnExpression(expression)
+    private fun BuilderSupport.column(expression: ColumnExpression<*, *>) {
+        visitColumnExpression(expression)
     }
 
-    private fun criterion(index: Int, c: Criterion) {
-        support.visitCriterion(index, c)
+    private fun BuilderSupport.criterion(index: Int, c: Criterion) {
+        visitCriterion(index, c)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/RelationDeleteStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/RelationDeleteStatementBuilder.kt
@@ -8,38 +8,66 @@ import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
-class RelationDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+interface RelationDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> {
+    fun build(): Statement
+}
+
+fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> RelationDeleteStatementBuilder(
     dialect: BuilderDialect,
+    context: RelationDeleteContext<ENTITY, ID, META>,
+): RelationDeleteStatementBuilder<ENTITY, ID, META> {
+    return DefaultRelationDeleteStatementBuilder(dialect, context)
+}
+
+class DefaultRelationDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val dialect: BuilderDialect,
     private val context: RelationDeleteContext<ENTITY, ID, META>,
-) {
+) : RelationDeleteStatementBuilder<ENTITY, ID, META> {
     private val aliasManager = if (dialect.supportsAliasForDeleteStatement()) {
         DefaultAliasManager(context)
     } else {
         EmptyAliasManager
     }
-    private val buf = StatementBuffer()
-    private val support = BuilderSupport(dialect, aliasManager, buf, context.options.escapeSequence)
 
-    fun build(): Statement {
-        buf.append("delete from ")
-        table(context.target)
-        val criteria = context.getWhereCriteria()
-        if (criteria.isNotEmpty()) {
-            buf.append(" where ")
-            for ((index, criterion) in criteria.withIndex()) {
-                criterion(index, criterion)
-                buf.append(" and ")
-            }
-            buf.cutBack(5)
-        }
+    override fun build(): Statement {
+        val buf = StatementBuffer()
+        buf.append(buildDeleteFrom())
+        buf.appendIfNotEmpty(buildWhere())
         return buf.toStatement()
     }
 
-    private fun table(expression: TableExpression<*>) {
-        support.visitTableExpression(expression, TableNameType.NAME_AND_ALIAS)
+    fun buildDeleteFrom(): Statement {
+        val buf = StatementBuffer()
+        val support = BuilderSupport(dialect, aliasManager, buf, context.options.escapeSequence)
+        buf.append("delete from ")
+        return with(support) {
+            table(context.target)
+            buf.toStatement()
+        }
     }
 
-    private fun criterion(index: Int, c: Criterion) {
-        return support.visitCriterion(index, c)
+    fun buildWhere(): Statement {
+        val buf = StatementBuffer()
+        val support = BuilderSupport(dialect, aliasManager, buf, context.options.escapeSequence)
+        val criteria = context.getWhereCriteria()
+        return with(support) {
+            if (criteria.isNotEmpty()) {
+                buf.append("where ")
+                for ((index, criterion) in criteria.withIndex()) {
+                    criterion(index, criterion)
+                    buf.append(" and ")
+                }
+                buf.cutBack(5)
+            }
+            buf.toStatement()
+        }
+    }
+
+    private fun BuilderSupport.table(expression: TableExpression<*>) {
+        visitTableExpression(expression, TableNameType.NAME_AND_ALIAS)
+    }
+
+    private fun BuilderSupport.criterion(index: Int, c: Criterion) {
+        visitCriterion(index, c)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityDeleteContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityDeleteContext.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -10,8 +11,9 @@ import org.komapper.core.dsl.options.DeleteOptions
 @ThreadSafe
 data class EntityDeleteContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
+    override val returning: Returning = Returning.Expressions(emptyList()),
     override val options: DeleteOptions = DeleteOptions.DEFAULT,
-) : TablesProvider, WhereProvider {
+) : TablesProvider, WhereProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {
         return setOf(target)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationDeleteContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationDeleteContext.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.TableExpression
 import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -12,8 +13,9 @@ import org.komapper.core.dsl.options.DeleteOptions
 data class RelationDeleteContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
     val where: WhereDeclaration = {},
+    override val returning: Returning = Returning.Expressions(emptyList()),
     override val options: DeleteOptions = DeleteOptions.DEFAULT,
-) : TablesProvider, WhereProvider {
+) : TablesProvider, WhereProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {
         return setOf(target)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/DeleteQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/DeleteQueryBuilder.kt
@@ -19,7 +19,7 @@ interface DeleteQueryBuilder<ENTITY : Any> {
      * @param entity the entity to be deleted
      * @return the query
      */
-    fun single(entity: ENTITY): EntityDeleteQuery
+    fun single(entity: ENTITY): EntityDeleteSingleQuery<ENTITY>
 
     /**
      * Builds a query to delete a list of entities in a batch.
@@ -45,14 +45,14 @@ interface DeleteQueryBuilder<ENTITY : Any> {
      * @param declaration the where declaration
      * @return the query
      */
-    fun where(declaration: WhereDeclaration): RelationDeleteQuery
+    fun where(declaration: WhereDeclaration): RelationDeleteQuery<ENTITY>
 
     /**
      * Builds a query to delete all rows.
      *
      * @return the query
      */
-    fun all(): RelationDeleteQuery
+    fun all(): RelationDeleteQuery<ENTITY>
 }
 
 internal data class DeleteQueryBuilderImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
@@ -60,9 +60,9 @@ internal data class DeleteQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
 ) :
     DeleteQueryBuilder<ENTITY> {
 
-    override fun single(entity: ENTITY): EntityDeleteQuery {
+    override fun single(entity: ENTITY): EntityDeleteSingleQuery<ENTITY> {
         context.target.checkIdValueNotNull(entity)
-        return EntityDeleteSingleQuery(context, entity)
+        return EntityDeleteSingleQueryImpl(context, entity)
     }
 
     override fun batch(entities: List<ENTITY>, batchSize: Int?): EntityDeleteQuery {
@@ -79,15 +79,15 @@ internal data class DeleteQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
         return batch(entities.toList(), batchSize)
     }
 
-    override fun where(declaration: WhereDeclaration): RelationDeleteQuery {
+    override fun where(declaration: WhereDeclaration): RelationDeleteQuery<ENTITY> {
         return asRelationDeleteQuery().where(declaration)
     }
 
-    override fun all(): RelationDeleteQuery {
+    override fun all(): RelationDeleteQuery<ENTITY> {
         return asRelationDeleteQuery()
     }
 
-    private fun asRelationDeleteQuery(): RelationDeleteQuery {
+    private fun asRelationDeleteQuery(): RelationDeleteQuery<ENTITY> {
         return RelationDeleteQueryImpl(context.asRelationDeleteContext())
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityDeleteQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityDeleteQuery.kt
@@ -1,7 +1,9 @@
 package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.options.DeleteOptions
 import org.komapper.core.dsl.visitor.QueryVisitor
 
@@ -19,12 +21,84 @@ interface EntityDeleteQuery : Query<Unit> {
     fun options(configure: (DeleteOptions) -> DeleteOptions): EntityDeleteQuery
 }
 
-internal data class EntityDeleteSingleQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+/**
+ * Represents a query to insert a single entity.
+ *
+ * @param ENTITY the entity type
+ */
+interface EntityDeleteSingleQuery<ENTITY : Any> : EntityDeleteQuery {
+    /**
+     * Indicates to retrieve an entity.
+     *
+     * @return the query
+     */
+    fun returning(): EntityDeleteReturningQuery<ENTITY?>
+
+    /**
+     * Indicates to retrieve a property.
+     *
+     * @param expression the property
+     * @return the query
+     */
+    fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityDeleteReturningQuery<A?>
+
+    /**
+     * Indicates to retrieve a property pair.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @return the query
+     */
+    fun <A : Any, B : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>): EntityDeleteReturningQuery<Pair<A?, B?>?>
+
+    /**
+     * Indicates to retrieve a property triple.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @param expression3 the third property
+     * @return the query
+     */
+    fun <A : Any, B : Any, C : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>, expression3: PropertyMetamodel<ENTITY, C, *>): EntityDeleteReturningQuery<Triple<A?, B?, C?>?>
+
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): EntityDeleteSingleQuery<ENTITY>
+}
+
+internal data class EntityDeleteSingleQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: EntityDeleteContext<ENTITY, ID, META>,
     private val entity: ENTITY,
-) : EntityDeleteQuery {
+) : EntityDeleteSingleQuery<ENTITY> {
 
-    override fun options(configure: (DeleteOptions) -> DeleteOptions): EntityDeleteQuery {
+    override fun returning(): EntityDeleteReturningQuery<ENTITY?> {
+        val newContext = context.copy(returning = Returning.Metamodel(context.target))
+        return EntityDeleteSingleReturningQuery(newContext, entity)
+    }
+
+    override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): EntityDeleteReturningQuery<A?> {
+        val newContext = context.copy(returning = Returning.Expressions(listOf(expression)))
+        return EntityDeleteSingleReturningSingleColumnQuery(newContext, entity, expression)
+    }
+
+    override fun <A : Any, B : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+    ): EntityDeleteReturningQuery<Pair<A?, B?>?> {
+        val expressions = expression1 to expression2
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
+        return EntityDeleteSingleReturningPairColumnsQuery(newContext, entity, expressions)
+    }
+
+    override fun <A : Any, B : Any, C : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+        expression3: PropertyMetamodel<ENTITY, C, *>,
+    ): EntityDeleteReturningQuery<Triple<A?, B?, C?>?> {
+        val expressions = Triple(expression1, expression2, expression3)
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
+        return EntityDeleteSingleReturningTripleColumnsQuery(newContext, entity, expressions)
+    }
+
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): EntityDeleteSingleQuery<ENTITY> {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityDeleteReturningQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityDeleteReturningQuery.kt
@@ -1,0 +1,81 @@
+package org.komapper.core.dsl.query
+
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.options.DeleteOptions
+import org.komapper.core.dsl.visitor.QueryVisitor
+
+/**
+ * Represents a query to delete an entity and retrieve the deleted values.
+ *
+ * @param T the result type
+ */
+interface EntityDeleteReturningQuery<T> : Query<T> {
+    /**
+     * Builds a query with the options applied.
+     *
+     * @param configure the configure function to apply options
+     * @return the query
+     */
+    fun options(configure: (DeleteOptions) -> DeleteOptions): EntityDeleteReturningQuery<T>
+}
+
+internal data class EntityDeleteSingleReturningQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: EntityDeleteContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+) : EntityDeleteReturningQuery<ENTITY?> {
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): EntityDeleteReturningQuery<ENTITY?> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityDeleteSingleReturningQuery(context, entity)
+    }
+}
+
+internal data class EntityDeleteSingleReturningSingleColumnQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>(
+    private val context: EntityDeleteContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expression: ColumnExpression<A, *>,
+) : EntityDeleteReturningQuery<A?> {
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): EntityDeleteReturningQuery<A?> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityDeleteSingleReturningSingleColumnQuery(context, entity, expression)
+    }
+}
+
+internal data class EntityDeleteSingleReturningPairColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>(
+    private val context: EntityDeleteContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+) : EntityDeleteReturningQuery<Pair<A?, B?>?> {
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): EntityDeleteReturningQuery<Pair<A?, B?>?> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityDeleteSingleReturningPairColumnsQuery(context, entity, expressions)
+    }
+}
+
+internal data class EntityDeleteSingleReturningTripleColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>(
+    private val context: EntityDeleteContext<ENTITY, ID, META>,
+    private val entity: ENTITY,
+    private val expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+) : EntityDeleteReturningQuery<Triple<A?, B?, C?>?> {
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): EntityDeleteReturningQuery<Triple<A?, B?, C?>?> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.entityDeleteSingleReturningTripleColumnsQuery(context, entity, expressions)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationDeleteQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationDeleteQuery.kt
@@ -1,8 +1,10 @@
 package org.komapper.core.dsl.query
 
 import org.komapper.core.dsl.context.RelationDeleteContext
+import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.operator.plus
 import org.komapper.core.dsl.options.DeleteOptions
 import org.komapper.core.dsl.visitor.QueryVisitor
@@ -10,15 +12,17 @@ import org.komapper.core.dsl.visitor.QueryVisitor
 /**
  * Represents a query to delete rows.
  * This query returns the number of rows affected.
+ *
+ * @param ENTITY the entity type
  */
-interface RelationDeleteQuery : Query<Long> {
+interface RelationDeleteQuery<ENTITY : Any> : Query<Long> {
     /**
      * Builds a query with a WHERE clause.
      *
      * @param declaration the where declaration
      * @return the query
      */
-    fun where(declaration: WhereDeclaration): RelationDeleteQuery
+    fun where(declaration: WhereDeclaration): RelationDeleteQuery<ENTITY>
 
     /**
      * Builds a query with the options applied.
@@ -26,19 +30,82 @@ interface RelationDeleteQuery : Query<Long> {
      * @param configure the configure function to apply options
      * @return the query
      */
-    fun options(configure: (DeleteOptions) -> DeleteOptions): RelationDeleteQuery
+    fun options(configure: (DeleteOptions) -> DeleteOptions): RelationDeleteQuery<ENTITY>
+
+    /**
+     * Indicates to retrieve an entity.
+     *
+     * @return the query
+     */
+    fun returning(): RelationDeleteReturningQuery<List<ENTITY>>
+
+    /**
+     * Indicates to retrieve a property.
+     *
+     * @param expression the property
+     * @return the query
+     */
+    fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): RelationDeleteReturningQuery<List<A?>>
+
+    /**
+     * Indicates to retrieve a property pair.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @return the query
+     */
+    fun <A : Any, B : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>): RelationDeleteReturningQuery<List<Pair<A?, B?>>>
+
+    /**
+     * Indicates to retrieve a property triple.
+     *
+     * @param expression1 the first property
+     * @param expression2 the second property
+     * @param expression3 the third property
+     * @return the query
+     */
+    fun <A : Any, B : Any, C : Any> returning(expression1: PropertyMetamodel<ENTITY, A, *>, expression2: PropertyMetamodel<ENTITY, B, *>, expression3: PropertyMetamodel<ENTITY, C, *>): RelationDeleteReturningQuery<List<Triple<A?, B?, C?>>>
 }
 
 internal data class RelationDeleteQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     private val context: RelationDeleteContext<ENTITY, ID, META>,
-) : RelationDeleteQuery {
+) : RelationDeleteQuery<ENTITY> {
 
-    override fun where(declaration: WhereDeclaration): RelationDeleteQuery {
+    override fun where(declaration: WhereDeclaration): RelationDeleteQuery<ENTITY> {
         val newContext = context.copy(where = context.where + declaration)
         return copy(context = newContext)
     }
 
-    override fun options(configure: (DeleteOptions) -> DeleteOptions): RelationDeleteQuery {
+    override fun returning(): RelationDeleteReturningQuery<List<ENTITY>> {
+        val newContext = context.copy(returning = Returning.Metamodel(context.target))
+        return RelationDeleteReturningQueryImpl(newContext)
+    }
+
+    override fun <A : Any> returning(expression: PropertyMetamodel<ENTITY, A, *>): RelationDeleteReturningQuery<List<A?>> {
+        val newContext = context.copy(returning = Returning.Expressions(listOf(expression)))
+        return RelationDeleteReturningSingleColumnQuery(newContext, expression)
+    }
+
+    override fun <A : Any, B : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+    ): RelationDeleteReturningQuery<List<Pair<A?, B?>>> {
+        val expressions = expression1 to expression2
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
+        return RelationDeleteReturningPairColumnsQuery(newContext, expressions)
+    }
+
+    override fun <A : Any, B : Any, C : Any> returning(
+        expression1: PropertyMetamodel<ENTITY, A, *>,
+        expression2: PropertyMetamodel<ENTITY, B, *>,
+        expression3: PropertyMetamodel<ENTITY, C, *>,
+    ): RelationDeleteReturningQuery<List<Triple<A?, B?, C?>>> {
+        val expressions = Triple(expression1, expression2, expression3)
+        val newContext = context.copy(returning = Returning.Expressions(expressions.toList()))
+        return RelationDeleteReturningTripleColumnsQuery(newContext, expressions)
+    }
+
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): RelationDeleteQuery<ENTITY> {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationDeleteReturningQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationDeleteReturningQuery.kt
@@ -1,0 +1,83 @@
+package org.komapper.core.dsl.query
+
+import org.komapper.core.dsl.context.RelationDeleteContext
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.operator.plus
+import org.komapper.core.dsl.options.DeleteOptions
+import org.komapper.core.dsl.visitor.QueryVisitor
+
+/**
+ * Represents a query to delete rows and retrieve the deleted values.
+ *
+ * @param T the result type
+ */
+interface RelationDeleteReturningQuery<T> : Query<T> {
+
+    /**
+     * Builds a query with the options applied.
+     *
+     * @param configure the configure function to apply options
+     * @return the query
+     */
+    fun options(configure: (DeleteOptions) -> DeleteOptions): RelationDeleteReturningQuery<T>
+}
+
+internal data class RelationDeleteReturningQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val context: RelationDeleteContext<ENTITY, ID, META>,
+) : RelationDeleteReturningQuery<List<ENTITY>> {
+
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): RelationDeleteReturningQuery<List<ENTITY>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationDeleteReturningQuery(context)
+    }
+}
+
+internal data class RelationDeleteReturningSingleColumnQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>(
+    private val context: RelationDeleteContext<ENTITY, ID, META>,
+    private val expression: ColumnExpression<A, *>,
+) : RelationDeleteReturningQuery<List<A?>> {
+
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): RelationDeleteReturningQuery<List<A?>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationDeleteReturningSingleColumnQuery(context, expression)
+    }
+}
+
+internal data class RelationDeleteReturningPairColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>(
+    private val context: RelationDeleteContext<ENTITY, ID, META>,
+    private val expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+) : RelationDeleteReturningQuery<List<Pair<A?, B?>>> {
+
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): RelationDeleteReturningQuery<List<Pair<A?, B?>>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationDeleteReturningPairColumnsQuery(context, expressions)
+    }
+}
+
+internal data class RelationDeleteReturningTripleColumnsQuery<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>(
+    private val context: RelationDeleteContext<ENTITY, ID, META>,
+    private val expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+) : RelationDeleteReturningQuery<List<Triple<A?, B?, C?>>> {
+
+    override fun options(configure: (DeleteOptions) -> DeleteOptions): RelationDeleteReturningQuery<List<Triple<A?, B?, C?>>> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationDeleteReturningTripleColumnsQuery(context, expressions)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteRunnerSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteRunnerSupport.kt
@@ -3,7 +3,6 @@ package org.komapper.core.dsl.runner
 import org.komapper.core.BuilderDialect
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.Statement
-import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
 import org.komapper.core.dsl.context.EntityDeleteContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
@@ -12,7 +11,7 @@ internal class EntityDeleteRunnerSupport<ENTITY : Any, ID : Any, META : EntityMe
 ) {
 
     fun buildStatement(config: DatabaseConfig, entity: ENTITY): Statement {
-        val builder = EntityDeleteStatementBuilder(BuilderDialect(config), context, entity)
+        val builder = config.dialect.getEntityDeleteStatementBuilder(BuilderDialect(config), context, entity)
         return builder.build()
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteSingleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteSingleReturningRunner.kt
@@ -1,0 +1,32 @@
+package org.komapper.core.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.Statement
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class EntityDeleteSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    context: EntityDeleteContext<ENTITY, ID, META>,
+    entity: ENTITY,
+) : Runner {
+
+    private val runner: EntityDeleteSingleRunner<ENTITY, ID, META> =
+        EntityDeleteSingleRunner(context, entity)
+
+    override fun check(config: DatabaseConfig) {
+        checkDeleteReturning(config)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+
+    fun buildStatement(config: DatabaseConfig): Statement {
+        return runner.buildStatement(config)
+    }
+
+    fun postDelete(count: Long) {
+        runner.postDelete(count)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationDeleteReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationDeleteReturningRunner.kt
@@ -1,0 +1,26 @@
+package org.komapper.core.dsl.runner
+
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.Statement
+import org.komapper.core.dsl.context.RelationDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class RelationDeleteReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    context: RelationDeleteContext<ENTITY, ID, META>,
+) : Runner {
+
+    private val runner: RelationDeleteRunner<ENTITY, ID, META> = RelationDeleteRunner(context)
+
+    override fun check(config: DatabaseConfig) {
+        checkDeleteReturning(config)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+
+    fun buildStatement(config: DatabaseConfig): Statement {
+        return runner.buildStatement(config)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationDeleteRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RelationDeleteRunner.kt
@@ -4,7 +4,6 @@ import org.komapper.core.BuilderDialect
 import org.komapper.core.DatabaseConfig
 import org.komapper.core.DryRunStatement
 import org.komapper.core.Statement
-import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
 import org.komapper.core.dsl.context.RelationDeleteContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
@@ -21,7 +20,7 @@ class RelationDeleteRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY
 
     fun buildStatement(config: DatabaseConfig): Statement {
         checkWhereClause(context)
-        val builder = RelationDeleteStatementBuilder(BuilderDialect(config), context)
+        val builder = config.dialect.getRelationDeleteStatementBuilder(BuilderDialect(config), context)
         return builder.build()
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
@@ -69,6 +69,16 @@ internal fun checkBatchExecutionReturningGeneratedValues(config: DatabaseConfig,
     }
 }
 
+internal fun checkDeleteReturning(config: DatabaseConfig) {
+    val dialect = config.dialect
+    if (!config.dialect.supportsDeleteReturning()) {
+        throw UnsupportedOperationException(
+            "The dialect(driver=${dialect.driver}) does not support `returning` for delete statements. " +
+                "Do not use the `returning` function in your query.",
+        )
+    }
+}
+
 internal fun checkGeneratedKeysReturningWhenInsertingMultipleRows(
     config: DatabaseConfig,
     metamodel: EntityMetamodel<*, *, *>,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
@@ -22,6 +22,7 @@ import org.komapper.core.dsl.query.Query
 import org.komapper.core.dsl.query.Record
 import org.komapper.core.dsl.query.Row
 import org.komapper.core.dsl.runner.EntityDeleteBatchRunner
+import org.komapper.core.dsl.runner.EntityDeleteSingleReturningRunner
 import org.komapper.core.dsl.runner.EntityDeleteSingleRunner
 import org.komapper.core.dsl.runner.EntityInsertBatchRunner
 import org.komapper.core.dsl.runner.EntityInsertMultipleReturningRunner
@@ -36,6 +37,7 @@ import org.komapper.core.dsl.runner.EntityUpsertMultipleReturningRunner
 import org.komapper.core.dsl.runner.EntityUpsertMultipleRunner
 import org.komapper.core.dsl.runner.EntityUpsertSingleReturningRunner
 import org.komapper.core.dsl.runner.EntityUpsertSingleRunner
+import org.komapper.core.dsl.runner.RelationDeleteReturningRunner
 import org.komapper.core.dsl.runner.RelationDeleteRunner
 import org.komapper.core.dsl.runner.RelationInsertSelectRunner
 import org.komapper.core.dsl.runner.RelationInsertValuesReturningRunner
@@ -108,6 +110,37 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         entity: ENTITY,
     ): Runner {
         return EntityDeleteSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityDeleteSingleReturningQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): Runner {
+        return EntityDeleteSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityDeleteSingleReturningSingleColumnQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): Runner {
+        return EntityDeleteSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityDeleteSingleReturningPairColumnsQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): Runner {
+        return EntityDeleteSingleReturningRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityDeleteSingleReturningTripleColumnsQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): Runner {
+        return EntityDeleteSingleReturningRunner(context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertMultipleQuery(
@@ -494,6 +527,31 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         context: RelationDeleteContext<ENTITY, ID, META>,
     ): Runner {
         return RelationDeleteRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationDeleteReturningQuery(context: RelationDeleteContext<ENTITY, ID, META>): Runner {
+        return RelationDeleteReturningRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> relationDeleteReturningSingleColumnQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): Runner {
+        return RelationDeleteReturningRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> relationDeleteReturningPairColumnsQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): Runner {
+        return RelationDeleteReturningRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> relationDeleteReturningTripleColumnsQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): Runner {
+        return RelationDeleteReturningRunner(context)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationInsertValuesQuery(

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
@@ -58,6 +58,33 @@ interface QueryVisitor<VISIT_RESULT> {
     ): VISIT_RESULT
 
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
+    entityDeleteSingleReturningQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>
+    entityDeleteSingleReturningSingleColumnQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>
+    entityDeleteSingleReturningPairColumnsQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>
+    entityDeleteSingleReturningTripleColumnsQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     entityInsertMultipleQuery(
         context: EntityInsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
@@ -380,6 +407,29 @@ interface QueryVisitor<VISIT_RESULT> {
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
     relationDeleteQuery(
         context: RelationDeleteContext<ENTITY, ID, META>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>
+    relationDeleteReturningQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any>
+    relationDeleteReturningSingleColumnQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any>
+    relationDeleteReturningPairColumnsQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): VISIT_RESULT
+
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any>
+    relationDeleteReturningTripleColumnsQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
     ): VISIT_RESULT
 
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2Dialect.kt
@@ -2,12 +2,16 @@ package org.komapper.dialect.h2
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
 import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationDeleteContext
 import org.komapper.core.dsl.context.RelationInsertValuesContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
@@ -31,6 +35,14 @@ interface H2Dialect : Dialect {
         return H2SchemaStatementBuilder(dialect)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): EntityDeleteStatementBuilder<ENTITY, ID, META> {
+        return H2EntityDeleteStatementBuilder(dialect, context, entity)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityInsertStatementBuilder(
         dialect: BuilderDialect,
         context: EntityInsertContext<ENTITY, ID, META>,
@@ -47,6 +59,13 @@ interface H2Dialect : Dialect {
         return H2EntityUpsertStatementBuilder(dialect, context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationDeleteContext<ENTITY, ID, META>,
+    ): RelationDeleteStatementBuilder<ENTITY, ID, META> {
+        return H2RelationDeleteStatementBuilder(dialect, context)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
         dialect: BuilderDialect,
         context: RelationInsertValuesContext<ENTITY, ID, META>,
@@ -55,6 +74,8 @@ interface H2Dialect : Dialect {
     }
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
+    override fun supportsDeleteReturning(): Boolean = true
 
     override fun supportsInsertMultipleReturning(): Boolean = true
 

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityDeleteStatementBuilder.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityDeleteStatementBuilder.kt
@@ -1,0 +1,28 @@
+package org.komapper.dialect.h2
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityDeleteStatementBuilder
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class H2EntityDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    dialect: BuilderDialect,
+    context: EntityDeleteContext<ENTITY, ID, META>,
+    entity: ENTITY,
+) : EntityDeleteStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultEntityDeleteStatementBuilder(dialect, context, entity)
+    private val support = H2StatementBuilderSupport(dialect, context)
+
+    override fun build(): Statement {
+        val tableType = H2StatementBuilderSupport.DeltaTableType.OLD
+        buf.append(support.buildReturningFirstFragment(tableType))
+        buf.append(builder.build())
+        buf.append(support.buildReturningLastFragment())
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2RelationDeleteStatementBuilder.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2RelationDeleteStatementBuilder.kt
@@ -1,0 +1,27 @@
+package org.komapper.dialect.h2
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultRelationDeleteStatementBuilder
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
+import org.komapper.core.dsl.context.RelationDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class H2RelationDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    dialect: BuilderDialect,
+    context: RelationDeleteContext<ENTITY, ID, META>,
+) : RelationDeleteStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultRelationDeleteStatementBuilder(dialect, context)
+    private val support = H2StatementBuilderSupport(dialect, context)
+
+    override fun build(): Statement {
+        val tableType = H2StatementBuilderSupport.DeltaTableType.OLD
+        buf.append(support.buildReturningFirstFragment(tableType))
+        buf.append(builder.build())
+        buf.append(support.buildReturningLastFragment())
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2StatementBuilderSupport.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2StatementBuilderSupport.kt
@@ -11,7 +11,7 @@ class H2StatementBuilderSupport(
     private val returningProvider: ReturningProvider,
 ) {
 
-    fun buildReturningFirstFragment(): Statement {
+    fun buildReturningFirstFragment(tableType: DeltaTableType = DeltaTableType.FINAL): Statement {
         val expressions = returningProvider.returning.expressions()
         return with(StatementBuffer()) {
             if (expressions.isNotEmpty()) {
@@ -21,7 +21,11 @@ class H2StatementBuilderSupport(
                     append(", ")
                 }
                 cutBack(2)
-                append(" from final table (")
+                val tableTypeName = when (tableType) {
+                    DeltaTableType.OLD -> "old"
+                    DeltaTableType.FINAL -> "final"
+                }
+                append(" from $tableTypeName table (")
             }
             toStatement()
         }
@@ -40,5 +44,9 @@ class H2StatementBuilderSupport(
     private fun StatementBuffer.column(expression: ColumnExpression<*, *>) {
         val name = expression.getCanonicalColumnName(dialect::enquote)
         append(name)
+    }
+
+    enum class DeltaTableType {
+        OLD, FINAL
     }
 }

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
@@ -2,13 +2,17 @@ package org.komapper.dialect.mariadb
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
 import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationDeleteContext
 import org.komapper.core.dsl.context.RelationInsertValuesContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 
@@ -40,6 +44,14 @@ interface MariaDbDialect : Dialect {
         return MariaDbSchemaStatementBuilder(dialect)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): EntityDeleteStatementBuilder<ENTITY, ID, META> {
+        return MariaDbEntityDeleteStatementBuilder(dialect, context, entity)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityInsertStatementBuilder(
         dialect: BuilderDialect,
         context: EntityInsertContext<ENTITY, ID, META>,
@@ -56,6 +68,13 @@ interface MariaDbDialect : Dialect {
         return MariaDbEntityUpsertStatementBuilder(dialect, context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationDeleteContext<ENTITY, ID, META>,
+    ): RelationDeleteStatementBuilder<ENTITY, ID, META> {
+        return MariaDbRelationDeleteStatementBuilder(dialect, context)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
         dialect: BuilderDialect,
         context: RelationInsertValuesContext<ENTITY, ID, META>,
@@ -66,6 +85,8 @@ interface MariaDbDialect : Dialect {
     override fun supportsAliasForDeleteStatement() = false
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
+    override fun supportsDeleteReturning(): Boolean = true
 
     override fun supportsGeneratedKeysReturningWhenInsertingMultipleRows(): Boolean = false
 

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityDeleteStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityDeleteStatementBuilder.kt
@@ -1,0 +1,26 @@
+package org.komapper.dialect.mariadb
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityDeleteStatementBuilder
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class MariaDbEntityDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    dialect: BuilderDialect,
+    context: EntityDeleteContext<ENTITY, ID, META>,
+    entity: ENTITY,
+) : EntityDeleteStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultEntityDeleteStatementBuilder(dialect, context, entity)
+    private val support = MariaDbStatementBuilderSupport(dialect, context)
+
+    override fun build(): Statement {
+        buf.append(builder.build())
+        buf.appendIfNotEmpty(support.buildReturning())
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbRelationDeleteStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbRelationDeleteStatementBuilder.kt
@@ -1,0 +1,25 @@
+package org.komapper.dialect.mariadb
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultRelationDeleteStatementBuilder
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
+import org.komapper.core.dsl.context.RelationDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class MariaDbRelationDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    dialect: BuilderDialect,
+    context: RelationDeleteContext<ENTITY, ID, META>,
+) : RelationDeleteStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultRelationDeleteStatementBuilder(dialect, context)
+    private val support = MariaDbStatementBuilderSupport(dialect, context)
+
+    override fun build(): Statement {
+        buf.append(builder.build())
+        buf.appendIfNotEmpty(support.buildReturning())
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbStatementBuilderSupport.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbStatementBuilderSupport.kt
@@ -15,7 +15,7 @@ class MariaDbStatementBuilderSupport(
         return with(StatementBuffer()) {
             val expressions = returningProvider.returning.expressions()
             if (expressions.isNotEmpty()) {
-                append(" returning ")
+                append("returning ")
                 for (e in expressions) {
                     column(e)
                     append(", ")

--- a/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDialect.kt
+++ b/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDialect.kt
@@ -51,6 +51,8 @@ interface OracleJdbcDialect : OracleDialect, JdbcDialect {
 
     override fun supportsBatchExecutionReturningGeneratedValues(): Boolean = false
 
+    override fun supportsDeleteReturning(): Boolean = true
+
     override fun supportsInsertSingleReturning(): Boolean = true
 
     override fun supportsReturnGeneratedKeysFlag(): Boolean = false

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
@@ -2,15 +2,19 @@ package org.komapper.dialect.oracle
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
 import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationDeleteContext
 import org.komapper.core.dsl.context.RelationInsertValuesContext
 import org.komapper.core.dsl.context.RelationUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -44,6 +48,14 @@ interface OracleDialect : Dialect {
         return OracleSchemaStatementBuilder(dialect)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): EntityDeleteStatementBuilder<ENTITY, ID, META> {
+        return OracleEntityDeleteStatementBuilder(dialect, context, entity)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityInsertStatementBuilder(
         dialect: BuilderDialect,
         context: EntityInsertContext<ENTITY, ID, META>,
@@ -66,6 +78,13 @@ interface OracleDialect : Dialect {
         entities: List<ENTITY>,
     ): EntityUpsertStatementBuilder<ENTITY> {
         return OracleEntityUpsertStatementBuilder(dialect, context, entities)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationDeleteContext<ENTITY, ID, META>,
+    ): RelationDeleteStatementBuilder<ENTITY, ID, META> {
+        return OracleRelationDeleteStatementBuilder(dialect, context)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityDeleteStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityDeleteStatementBuilder.kt
@@ -1,0 +1,26 @@
+package org.komapper.dialect.oracle
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityDeleteStatementBuilder
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class OracleEntityDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    dialect: BuilderDialect,
+    context: EntityDeleteContext<ENTITY, ID, META>,
+    entity: ENTITY,
+) : EntityDeleteStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultEntityDeleteStatementBuilder(dialect, context, entity)
+    private val support = OracleStatementBuilderSupport(dialect, context)
+
+    override fun build(): Statement {
+        buf.append(builder.build())
+        buf.appendIfNotEmpty(support.buildReturning())
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleRelationDeleteStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleRelationDeleteStatementBuilder.kt
@@ -1,0 +1,25 @@
+package org.komapper.dialect.oracle
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultRelationDeleteStatementBuilder
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
+import org.komapper.core.dsl.context.RelationDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class OracleRelationDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    dialect: BuilderDialect,
+    context: RelationDeleteContext<ENTITY, ID, META>,
+) : RelationDeleteStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultRelationDeleteStatementBuilder(dialect, context)
+    private val support = OracleStatementBuilderSupport(dialect, context)
+
+    override fun build(): Statement {
+        buf.append(builder.build())
+        buf.appendIfNotEmpty(support.buildReturning())
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
@@ -2,15 +2,19 @@ package org.komapper.dialect.postgresql
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
 import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationDeleteContext
 import org.komapper.core.dsl.context.RelationInsertValuesContext
 import org.komapper.core.dsl.context.RelationUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -33,6 +37,14 @@ interface PostgreSqlDialect : Dialect {
 
     override fun getSchemaStatementBuilder(dialect: BuilderDialect): SchemaStatementBuilder {
         return PostgreSqlSchemaStatementBuilder(dialect)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): EntityDeleteStatementBuilder<ENTITY, ID, META> {
+        return PostgreSqlEntityDeleteStatementBuilder(dialect, context, entity)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityInsertStatementBuilder(
@@ -59,6 +71,13 @@ interface PostgreSqlDialect : Dialect {
         return PostgreSqlEntityUpsertStatementBuilder(dialect, context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationDeleteContext<ENTITY, ID, META>,
+    ): RelationDeleteStatementBuilder<ENTITY, ID, META> {
+        return PostgreSqlRelationDeleteStatementBuilder(dialect, context)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
         dialect: BuilderDialect,
         context: RelationInsertValuesContext<ENTITY, ID, META>,
@@ -74,6 +93,8 @@ interface PostgreSqlDialect : Dialect {
     }
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = true
+
+    override fun supportsDeleteReturning(): Boolean = true
 
     override fun supportsLockOfTables(): Boolean = true
 

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityDeleteStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityDeleteStatementBuilder.kt
@@ -1,0 +1,26 @@
+package org.komapper.dialect.postgresql
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityDeleteStatementBuilder
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class PostgreSqlEntityDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    dialect: BuilderDialect,
+    context: EntityDeleteContext<ENTITY, ID, META>,
+    entity: ENTITY,
+) : EntityDeleteStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultEntityDeleteStatementBuilder(dialect, context, entity)
+    private val support = PostgreSqlStatementBuilderSupport(dialect, context)
+
+    override fun build(): Statement {
+        buf.append(builder.build())
+        buf.appendIfNotEmpty(support.buildReturning())
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationDeleteStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlRelationDeleteStatementBuilder.kt
@@ -1,0 +1,25 @@
+package org.komapper.dialect.postgresql
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultRelationDeleteStatementBuilder
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
+import org.komapper.core.dsl.context.RelationDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class PostgreSqlRelationDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    dialect: BuilderDialect,
+    context: RelationDeleteContext<ENTITY, ID, META>,
+) : RelationDeleteStatementBuilder<ENTITY, ID, META> {
+
+    private val buf = StatementBuffer()
+    private val builder = DefaultRelationDeleteStatementBuilder(dialect, context)
+    private val support = PostgreSqlStatementBuilderSupport(dialect, context)
+
+    override fun build(): Statement {
+        buf.append(builder.build())
+        buf.appendIfNotEmpty(support.buildReturning())
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlStatementBuilderSupport.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlStatementBuilderSupport.kt
@@ -15,7 +15,7 @@ class PostgreSqlStatementBuilderSupport(
         return with(StatementBuffer()) {
             val expressions = returningProvider.returning.expressions()
             if (expressions.isNotEmpty()) {
-                append(" returning ")
+                append("returning ")
                 for (e in expressions) {
                     column(e)
                     append(", ")

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
@@ -2,16 +2,20 @@ package org.komapper.dialect.sqlserver
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
 import org.komapper.core.dsl.builder.RelationInsertValuesStatementBuilder
 import org.komapper.core.dsl.builder.RelationUpdateStatementBuilder
 import org.komapper.core.dsl.builder.SchemaStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.context.EntityUpdateContext
 import org.komapper.core.dsl.context.EntityUpsertContext
+import org.komapper.core.dsl.context.RelationDeleteContext
 import org.komapper.core.dsl.context.RelationInsertValuesContext
 import org.komapper.core.dsl.context.RelationUpdateContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -49,6 +53,14 @@ interface SqlServerDialect : Dialect {
         return SqlServerSchemaStatementBuilder(dialect)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): EntityDeleteStatementBuilder<ENTITY, ID, META> {
+        return SqlServerEntityDeleteStatementBuilder(dialect, context, entity)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getEntityInsertStatementBuilder(
         dialect: BuilderDialect,
         context: EntityInsertContext<ENTITY, ID, META>,
@@ -73,6 +85,13 @@ interface SqlServerDialect : Dialect {
         return SqlServerEntityUpsertStatementBuilder(dialect, context, entities)
     }
 
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationDeleteStatementBuilder(
+        dialect: BuilderDialect,
+        context: RelationDeleteContext<ENTITY, ID, META>,
+    ): RelationDeleteStatementBuilder<ENTITY, ID, META> {
+        return SqlServerRelationDeleteStatementBuilder(dialect, context)
+    }
+
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> getRelationInsertValuesStatementBuilder(
         dialect: BuilderDialect,
         context: RelationInsertValuesContext<ENTITY, ID, META>,
@@ -92,6 +111,8 @@ interface SqlServerDialect : Dialect {
     override fun getRandomFunction(): String = "rand"
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
+    override fun supportsDeleteReturning(): Boolean = true
 
     override fun supportsLimitOffsetWithoutOrderByClause(): Boolean = false
 

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityDeleteStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityDeleteStatementBuilder.kt
@@ -1,0 +1,28 @@
+package org.komapper.dialect.sqlserver
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultEntityDeleteStatementBuilder
+import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class SqlServerEntityDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    dialect: BuilderDialect,
+    context: EntityDeleteContext<ENTITY, ID, META>,
+    entity: ENTITY,
+) : EntityDeleteStatementBuilder<ENTITY, ID, META> {
+
+    private val builder = DefaultEntityDeleteStatementBuilder(dialect, context, entity)
+    private val support = SqlServerStatementBuilderSupport(dialect, context)
+
+    override fun build(): Statement {
+        val buf = StatementBuffer()
+        buf.append(builder.buildDeleteFrom())
+        val tablePrefix = SqlServerStatementBuilderSupport.TablePrefix.DELETED
+        buf.appendIfNotEmpty(support.buildOutput(tablePrefix))
+        buf.appendIfNotEmpty(builder.buildWhere())
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationDeleteStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerRelationDeleteStatementBuilder.kt
@@ -1,0 +1,27 @@
+package org.komapper.dialect.sqlserver
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.builder.DefaultRelationDeleteStatementBuilder
+import org.komapper.core.dsl.builder.RelationDeleteStatementBuilder
+import org.komapper.core.dsl.context.RelationDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class SqlServerRelationDeleteStatementBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    dialect: BuilderDialect,
+    context: RelationDeleteContext<ENTITY, ID, META>,
+) : RelationDeleteStatementBuilder<ENTITY, ID, META> {
+
+    private val builder = DefaultRelationDeleteStatementBuilder(dialect, context)
+    private val support = SqlServerStatementBuilderSupport(dialect, context)
+
+    override fun build(): Statement {
+        val buf = StatementBuffer()
+        buf.append(builder.buildDeleteFrom())
+        val tablePrefix = SqlServerStatementBuilderSupport.TablePrefix.DELETED
+        buf.appendIfNotEmpty(support.buildOutput(tablePrefix))
+        buf.appendIfNotEmpty(builder.buildWhere())
+        return buf.toStatement()
+    }
+}

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerStatementBuilderSupport.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerStatementBuilderSupport.kt
@@ -16,7 +16,7 @@ class SqlServerStatementBuilderSupport(
         with(buf) {
             val expressions = returningProvider.returning.expressions()
             if (expressions.isNotEmpty()) {
-                append(" output ")
+                append("output ")
                 val prefix = when (tablePrefix) {
                     TablePrefix.DELETED -> "deleted"
                     TablePrefix.INSERTED -> "inserted"

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerStatementBuilderSupport.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerStatementBuilderSupport.kt
@@ -11,14 +11,19 @@ class SqlServerStatementBuilderSupport(
     private val returningProvider: ReturningProvider,
 ) {
 
-    fun buildOutput(): Statement {
+    fun buildOutput(tablePrefix: TablePrefix = TablePrefix.INSERTED): Statement {
         val buf = StatementBuffer()
         with(buf) {
             val expressions = returningProvider.returning.expressions()
             if (expressions.isNotEmpty()) {
                 append(" output ")
+                val prefix = when (tablePrefix) {
+                    TablePrefix.DELETED -> "deleted"
+                    TablePrefix.INSERTED -> "inserted"
+                }
                 for (e in expressions) {
-                    append("inserted.")
+                    append(prefix)
+                    append(".")
                     column(e)
                     append(", ")
                 }
@@ -31,5 +36,9 @@ class SqlServerStatementBuilderSupport(
     private fun StatementBuffer.column(expression: ColumnExpression<*, *>) {
         val name = expression.getCanonicalColumnName(dialect::enquote)
         append(name)
+    }
+
+    enum class TablePrefix {
+        DELETED, INSERTED
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityDeleteReturningRunnerSupport.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityDeleteReturningRunnerSupport.kt
@@ -1,0 +1,16 @@
+package org.komapper.jdbc.dsl.runner
+
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.jdbc.JdbcDatabaseConfig
+import org.komapper.jdbc.JdbcExecutor
+
+internal class JdbcEntityDeleteReturningRunnerSupport<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    val context: EntityDeleteContext<ENTITY, ID, META>,
+) {
+
+    fun <T> delete(config: JdbcDatabaseConfig, execute: (JdbcExecutor) -> T): T {
+        val executor = config.dialect.createExecutor(config, context.options)
+        return execute(executor)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityDeleteSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityDeleteSingleReturningRunner.kt
@@ -1,0 +1,50 @@
+package org.komapper.jdbc.dsl.runner
+
+import kotlinx.coroutines.flow.singleOrNull
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityDeleteSingleReturningRunner
+import org.komapper.jdbc.JdbcDataOperator
+import org.komapper.jdbc.JdbcDatabaseConfig
+import java.sql.ResultSet
+
+internal class JdbcEntityDeleteSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    context: EntityDeleteContext<ENTITY, ID, META>,
+    entity: ENTITY,
+    private val transform: (JdbcDataOperator, ResultSet) -> T,
+) : JdbcRunner<T?> {
+
+    private val runner: EntityDeleteSingleReturningRunner<ENTITY, ID, META> =
+        EntityDeleteSingleReturningRunner(context, entity)
+
+    private val support: JdbcEntityDeleteReturningRunnerSupport<ENTITY, ID, META> =
+        JdbcEntityDeleteReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override fun run(config: JdbcDatabaseConfig): T? {
+        val result = delete(config)
+        val count = if (result == null) 0L else 1L
+        postDelete(count)
+        return result
+    }
+
+    private fun delete(config: JdbcDatabaseConfig): T? {
+        val statement = runner.buildStatement(config)
+        return support.delete(config) { executor ->
+            executor.executeReturning(statement, transform) { it.singleOrNull() }
+        }
+    }
+
+    private fun postDelete(count: Long) {
+        runner.postDelete(count)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationDeleteReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcRelationDeleteReturningRunner.kt
@@ -1,0 +1,33 @@
+package org.komapper.jdbc.dsl.runner
+
+import kotlinx.coroutines.flow.toList
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.RelationDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.RelationDeleteReturningRunner
+import org.komapper.jdbc.JdbcDataOperator
+import org.komapper.jdbc.JdbcDatabaseConfig
+import java.sql.ResultSet
+
+internal class JdbcRelationDeleteReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    private val context: RelationDeleteContext<ENTITY, ID, META>,
+    private val transform: (JdbcDataOperator, ResultSet) -> T,
+) : JdbcRunner<List<T>> {
+
+    private val runner: RelationDeleteReturningRunner<ENTITY, ID, META> = RelationDeleteReturningRunner(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override fun run(config: JdbcDatabaseConfig): List<T> {
+        val statement = runner.buildStatement(config)
+        val executor = config.dialect.createExecutor(config, context.options)
+        return executor.executeReturning(statement, transform) { it.toList() }
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
@@ -23,6 +23,7 @@ import org.komapper.core.dsl.query.Record
 import org.komapper.core.dsl.query.Row
 import org.komapper.core.dsl.visitor.QueryVisitor
 import org.komapper.jdbc.dsl.runner.JdbcEntityDeleteBatchRunner
+import org.komapper.jdbc.dsl.runner.JdbcEntityDeleteSingleReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityDeleteSingleRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityInsertBatchRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityInsertMultipleReturningRunner
@@ -40,6 +41,7 @@ import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertSingleIgnoreRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertSingleReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertSingleRunner
 import org.komapper.jdbc.dsl.runner.JdbcEntityUpsertSingleUpdateRunner
+import org.komapper.jdbc.dsl.runner.JdbcRelationDeleteReturningRunner
 import org.komapper.jdbc.dsl.runner.JdbcRelationDeleteRunner
 import org.komapper.jdbc.dsl.runner.JdbcRelationInsertSelectRunner
 import org.komapper.jdbc.dsl.runner.JdbcRelationInsertValuesReturningRunner
@@ -124,6 +126,41 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         entity: ENTITY,
     ): JdbcRunner<Unit> {
         return JdbcEntityDeleteSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityDeleteSingleReturningQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): JdbcRunner<ENTITY?> {
+        val transform = JdbcResultSetTransformers.singleEntity(context.target)
+        return JdbcEntityDeleteSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityDeleteSingleReturningSingleColumnQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): JdbcRunner<A?> {
+        val transform = JdbcResultSetTransformers.singleColumn(expression)
+        return JdbcEntityDeleteSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityDeleteSingleReturningPairColumnsQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): JdbcRunner<Pair<A?, B?>?> {
+        val transform = JdbcResultSetTransformers.pairColumns(expressions)
+        return JdbcEntityDeleteSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityDeleteSingleReturningTripleColumnsQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): JdbcRunner<Triple<A?, B?, C?>?> {
+        val transform = JdbcResultSetTransformers.tripleColumns(expressions)
+        return JdbcEntityDeleteSingleReturningRunner(context, entity, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertMultipleQuery(
@@ -548,6 +585,35 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         context: RelationDeleteContext<ENTITY, ID, META>,
     ): JdbcRunner<Long> {
         return JdbcRelationDeleteRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationDeleteReturningQuery(context: RelationDeleteContext<ENTITY, ID, META>): JdbcRunner<List<ENTITY>> {
+        val transform = JdbcResultSetTransformers.singleEntity(context.target)
+        return JdbcRelationDeleteReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> relationDeleteReturningSingleColumnQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): JdbcRunner<List<A?>> {
+        val transform = JdbcResultSetTransformers.singleColumn(expression)
+        return JdbcRelationDeleteReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> relationDeleteReturningPairColumnsQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): JdbcRunner<List<Pair<A?, B?>>> {
+        val transform = JdbcResultSetTransformers.pairColumns(expressions)
+        return JdbcRelationDeleteReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> relationDeleteReturningTripleColumnsQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): JdbcRunner<List<Triple<A?, B?, C?>>> {
+        val transform = JdbcResultSetTransformers.tripleColumns(expressions)
+        return JdbcRelationDeleteReturningRunner(context, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationInsertValuesQuery(

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityDeleteReturningRunnerSupport.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityDeleteReturningRunnerSupport.kt
@@ -1,0 +1,16 @@
+package org.komapper.r2dbc.dsl.runner
+
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+import org.komapper.r2dbc.R2dbcExecutor
+
+internal class R2dbcEntityDeleteReturningRunnerSupport<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    val context: EntityDeleteContext<ENTITY, ID, META>,
+) {
+
+    suspend fun <T> delete(config: R2dbcDatabaseConfig, execute: suspend (R2dbcExecutor) -> T): T {
+        val executor = R2dbcExecutor(config, context.options)
+        return execute(executor)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityDeleteSingleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityDeleteSingleReturningRunner.kt
@@ -1,0 +1,51 @@
+package org.komapper.r2dbc.dsl.runner
+
+import io.r2dbc.spi.Row
+import kotlinx.coroutines.flow.singleOrNull
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.EntityDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.EntityDeleteSingleReturningRunner
+import org.komapper.r2dbc.R2dbcDataOperator
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+
+internal class R2dbcEntityDeleteSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    context: EntityDeleteContext<ENTITY, ID, META>,
+    entity: ENTITY,
+    private val transform: (R2dbcDataOperator, Row) -> T,
+) : R2dbcRunner<T?> {
+
+    private val runner: EntityDeleteSingleReturningRunner<ENTITY, ID, META> =
+        EntityDeleteSingleReturningRunner(context, entity)
+
+    private val support: R2dbcEntityDeleteReturningRunnerSupport<ENTITY, ID, META> =
+        R2dbcEntityDeleteReturningRunnerSupport(context)
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override suspend fun run(config: R2dbcDatabaseConfig): T? {
+        val result = delete(config)
+        val count = if (result == null) 0L else 1L
+        postDelete(count)
+        return result
+    }
+
+    private suspend fun delete(config: R2dbcDatabaseConfig): T? {
+        val statement = runner.buildStatement(config)
+        return support.delete(config) { executor ->
+            val flow = executor.executeQuery(statement, transform)
+            flow.singleOrNull()
+        }
+    }
+
+    private fun postDelete(count: Long) {
+        runner.postDelete(count)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRelationDeleteReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRelationDeleteReturningRunner.kt
@@ -1,0 +1,35 @@
+package org.komapper.r2dbc.dsl.runner
+
+import io.r2dbc.spi.Row
+import kotlinx.coroutines.flow.toList
+import org.komapper.core.DatabaseConfig
+import org.komapper.core.DryRunStatement
+import org.komapper.core.dsl.context.RelationDeleteContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.runner.RelationDeleteReturningRunner
+import org.komapper.r2dbc.R2dbcDataOperator
+import org.komapper.r2dbc.R2dbcDatabaseConfig
+import org.komapper.r2dbc.R2dbcExecutor
+
+internal class R2dbcRelationDeleteReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
+    private val context: RelationDeleteContext<ENTITY, ID, META>,
+    private val transform: (R2dbcDataOperator, Row) -> T,
+) : R2dbcRunner<List<T>> {
+
+    private val runner: RelationDeleteReturningRunner<ENTITY, ID, META> = RelationDeleteReturningRunner(context)
+
+    override suspend fun run(config: R2dbcDatabaseConfig): List<T> {
+        val statement = runner.buildStatement(config)
+        val executor = R2dbcExecutor(config, context.options)
+        val flow = executor.executeQuery(statement, transform)
+        return flow.toList()
+    }
+
+    override fun check(config: DatabaseConfig) {
+        runner.check(config)
+    }
+
+    override fun dryRun(config: DatabaseConfig): DryRunStatement {
+        return runner.dryRun(config)
+    }
+}

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
@@ -23,6 +23,7 @@ import org.komapper.core.dsl.query.Record
 import org.komapper.core.dsl.query.Row
 import org.komapper.core.dsl.visitor.QueryVisitor
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityDeleteBatchRunner
+import org.komapper.r2dbc.dsl.runner.R2dbcEntityDeleteSingleReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityDeleteSingleRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityInsertBatchRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityInsertMultipleReturningRunner
@@ -40,6 +41,7 @@ import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertSingleIgnoreRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertSingleReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertSingleRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcEntityUpsertSingleUpdateRunner
+import org.komapper.r2dbc.dsl.runner.R2dbcRelationDeleteReturningRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcRelationDeleteRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcRelationInsertSelectRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcRelationInsertValuesReturningRunner
@@ -122,6 +124,41 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         entity: ENTITY,
     ): R2dbcRunner<Unit> {
         return R2dbcEntityDeleteSingleRunner(context, entity)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityDeleteSingleReturningQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+    ): R2dbcRunner<ENTITY?> {
+        val transform = R2dbcRowTransformers.singleEntity(context.target)
+        return R2dbcEntityDeleteSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> entityDeleteSingleReturningSingleColumnQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expression: ColumnExpression<A, *>,
+    ): R2dbcRunner<A?> {
+        val transform = R2dbcRowTransformers.singleColumn(expression)
+        return R2dbcEntityDeleteSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> entityDeleteSingleReturningPairColumnsQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): R2dbcRunner<Pair<A?, B?>?> {
+        val transform = R2dbcRowTransformers.pairColumns(expressions)
+        return R2dbcEntityDeleteSingleReturningRunner(context, entity, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> entityDeleteSingleReturningTripleColumnsQuery(
+        context: EntityDeleteContext<ENTITY, ID, META>,
+        entity: ENTITY,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): R2dbcRunner<Triple<A?, B?, C?>?> {
+        val transform = R2dbcRowTransformers.tripleColumns(expressions)
+        return R2dbcEntityDeleteSingleReturningRunner(context, entity, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> entityInsertMultipleQuery(
@@ -544,6 +581,35 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         context: RelationDeleteContext<ENTITY, ID, META>,
     ): R2dbcRunner<Long> {
         return R2dbcRelationDeleteRunner(context)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationDeleteReturningQuery(context: RelationDeleteContext<ENTITY, ID, META>): R2dbcRunner<List<ENTITY>> {
+        val transform = R2dbcRowTransformers.singleEntity(context.target)
+        return R2dbcRelationDeleteReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any> relationDeleteReturningSingleColumnQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expression: ColumnExpression<A, *>,
+    ): R2dbcRunner<List<A?>> {
+        val transform = R2dbcRowTransformers.singleColumn(expression)
+        return R2dbcRelationDeleteReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any> relationDeleteReturningPairColumnsQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expressions: Pair<ColumnExpression<A, *>, ColumnExpression<B, *>>,
+    ): R2dbcRunner<List<Pair<A?, B?>>> {
+        val transform = R2dbcRowTransformers.pairColumns(expressions)
+        return R2dbcRelationDeleteReturningRunner(context, transform)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, A : Any, B : Any, C : Any> relationDeleteReturningTripleColumnsQuery(
+        context: RelationDeleteContext<ENTITY, ID, META>,
+        expressions: Triple<ColumnExpression<A, *>, ColumnExpression<B, *>, ColumnExpression<C, *>>,
+    ): R2dbcRunner<List<Triple<A?, B?, C?>>> {
+        val transform = R2dbcRowTransformers.tripleColumns(expressions)
+        return R2dbcRelationDeleteReturningRunner(context, transform)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> relationInsertValuesQuery(


### PR DESCRIPTION
We support `DELETE ... RETURNING` for the following databases:

- H2
- MariaDB
- Oracle
- PostgreSQL
- SQL Server

### example

To use `DELETE ... RETURNING`, invoke the returning function:

Kotlin code:
```kotlin
val a = Meta.address
val addressList: Query<List<Address>> = db.runQuery {
    QueryDsl.delete(a).where { a.addressId inList listOf(15, 16) }.returning()
}
```

generated SQL:
```sql
-- PostgreSQL
delete from address as t0_ where t0_.address_id in (15, 16) returning address_id, street, version
```