### PR TITLE
Download Spring releases from Maven Central.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven(url = "https://repo.spring.io/milestone")
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,8 +5,6 @@ pluginManagement {
     val springBootVersion: String by settings
     repositories {
         mavenLocal()
-        maven { url = uri("https://repo.spring.io/release") }
-        maven { url = uri("https://repo.spring.io/milestone") }
         gradlePluginPortal()
         mavenCentral()
     }


### PR DESCRIPTION
See https://spring.io/blog/2022/12/14/notice-of-permissions-changes-to-repo-spring-io-january-2023