### PR TITLE
Fix CodeGeneratorTest failure on Windows

### DIFF
--- a/komapper-codegen/src/test/kotlin/org/komapper/codegen/CodeGeneratorTest.kt
+++ b/komapper-codegen/src/test/kotlin/org/komapper/codegen/CodeGeneratorTest.kt
@@ -55,7 +55,7 @@ class CodeGeneratorTest {
                 val `val`: String,
             )
             
-        """.trimIndent()
+        """.trimIndent().normalizeLineSeparator()
         assertEquals(expected, file.readText())
     }
 
@@ -99,7 +99,7 @@ class CodeGeneratorTest {
                 val `val`: String?,
             )
             
-        """.trimIndent()
+        """.trimIndent().normalizeLineSeparator()
         assertEquals(expected, file.readText())
     }
 
@@ -149,7 +149,7 @@ class CodeGeneratorTest {
                 @KomapperColumn("VAL") val `val`: Nothing,
             )
             
-        """.trimIndent()
+        """.trimIndent().normalizeLineSeparator()
         assertEquals(expected, file.readText())
     }
 
@@ -224,4 +224,7 @@ class CodeGeneratorTest {
             }
         )
     }
+
+    private fun String.normalizeLineSeparator(): String =
+        replace(Regex("\r?\n"), System.lineSeparator())
 }


### PR DESCRIPTION
`.trimIndent()` always changes the line separator to `LF`. Therefore, the code generation test fails on Windows.
I have fixed the test because fixing the line separator of code generation to `LF` affects users.