### PR TITLE
Support `@KomapperVersion`, `@KomapperCreatedAt` and `@KomapperUpdatedAt` in code generator

### DIFF
--- a/gradle-plugin/src/main/java/org/komapper/gradle/codegen/GenerateTask.java
+++ b/gradle-plugin/src/main/java/org/komapper/gradle/codegen/GenerateTask.java
@@ -69,14 +69,22 @@ public class GenerateTask extends DefaultTask {
           settings.getUseSelfMapping().get(),
           settings.getUseCatalog().get(),
           settings.getUseSchema().get(),
-          settings.getPropertyTypeResolver().get());
+          settings.getPropertyTypeResolver().get(),
+          settings.getVersionPropertyName().get(),
+          settings.getCreatedAtPropertyName().get(),
+          settings.getUpdatedAtPropertyName().get());
     }
     if (!settings.getUseSelfMapping().get()) {
       try (var writer =
           generator.createNewFile(
               destinationDir, "entityDefinitions.kt", settings.getOverwriteDefinitions().get())) {
         generator.generateDefinitions(
-            writer, settings.getUseCatalog().get(), settings.getUseSchema().get());
+            writer,
+            settings.getUseCatalog().get(),
+            settings.getUseSchema().get(),
+            settings.getVersionPropertyName().get(),
+            settings.getCreatedAtPropertyName().get(),
+            settings.getUpdatedAtPropertyName().get());
       }
     }
   }

--- a/gradle-plugin/src/main/java/org/komapper/gradle/codegen/Generator.java
+++ b/gradle-plugin/src/main/java/org/komapper/gradle/codegen/Generator.java
@@ -36,6 +36,9 @@ public class Generator {
 
   private final Property<ClassNameResolver> classNameResolver;
   private final Property<PropertyNameResolver> propertyNameResolver;
+  private final Property<String> versionPropertyName;
+  private final Property<String> createdAtPropertyName;
+  private final Property<String> updatedAtPropertyName;
 
   @Inject
   public Generator(String name, Project project) {
@@ -69,6 +72,9 @@ public class Generator {
     classNameResolver.set(prefix.zip(suffix, ClassNameResolver::of));
     this.propertyNameResolver =
         objects.property(PropertyNameResolver.class).value(PropertyNameResolver.of());
+    this.versionPropertyName = objects.property(String.class).value("");
+    this.createdAtPropertyName = objects.property(String.class).value("");
+    this.updatedAtPropertyName = objects.property(String.class).value("");
   }
 
   public String getName() {
@@ -149,6 +155,18 @@ public class Generator {
 
   public Property<PropertyNameResolver> getPropertyNameResolver() {
     return propertyNameResolver;
+  }
+
+  public Property<String> getVersionPropertyName() {
+    return versionPropertyName;
+  }
+
+  public Property<String> getCreatedAtPropertyName() {
+    return createdAtPropertyName;
+  }
+
+  public Property<String> getUpdatedAtPropertyName() {
+    return updatedAtPropertyName;
   }
 
   public void jdbc(Action<Jdbc> action) {

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcMetadataReaderTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcMetadataReaderTest.kt
@@ -31,7 +31,7 @@ class JdbcMetadataReaderTest(val db: JdbcDatabase) {
         val tables = getTables()
         val generator = CodeGenerator(null, tables, ClassNameResolver.of("", ""), PropertyNameResolver.of())
         val writer = StringWriter()
-        generator.generateEntities(writer, false, false, false, false, PropertyTypeResolver.of())
+        generator.generateEntities(writer, false, false, false, false, PropertyTypeResolver.of(), "", "", "")
         println(writer)
     }
 
@@ -41,7 +41,7 @@ class JdbcMetadataReaderTest(val db: JdbcDatabase) {
         val tables = getTables("PUBLIC")
         val generator = CodeGenerator(null, tables, ClassNameResolver.of("", ""), PropertyNameResolver.of())
         val writer = StringWriter()
-        generator.generateEntities(writer, false, false, false, false, PropertyTypeResolver.of())
+        generator.generateEntities(writer, false, false, false, false, PropertyTypeResolver.of(), "", "", "")
         println(writer)
     }
 

--- a/komapper-codegen/src/test/kotlin/org/komapper/codegen/CodeGeneratorTest.kt
+++ b/komapper-codegen/src/test/kotlin/org/komapper/codegen/CodeGeneratorTest.kt
@@ -52,7 +52,6 @@ class CodeGeneratorTest {
             )
             
         """.trimIndent().normalizeLineSeparator()
-        println(file.readText())
         assertEquals(expected, file.readText())
     }
 
@@ -93,7 +92,6 @@ class CodeGeneratorTest {
             )
             
         """.trimIndent().normalizeLineSeparator()
-        println(file.readText())
         assertEquals(expected, file.readText())
     }
 
@@ -146,7 +144,6 @@ class CodeGeneratorTest {
             )
             
         """.trimIndent().normalizeLineSeparator()
-        println(file.readText())
         assertEquals(expected, file.readText())
     }
 
@@ -199,7 +196,6 @@ class CodeGeneratorTest {
             )
             
         """.trimIndent().normalizeLineSeparator()
-        println(file.readText())
         assertEquals(expected, file.readText())
     }
 
@@ -255,7 +251,6 @@ class CodeGeneratorTest {
             )
             
         """.trimIndent().normalizeLineSeparator()
-        println(file.readText())
         assertEquals(expected, file.readText())
     }
 


### PR DESCRIPTION
Hello.

Well, I would like to automatically generate `@KomapperVersion`, `@KomapperCreatedAt` and `@KomapperUpdatedAt` annotations, and I have implemented this.
Please merge this if you like.