### PR TITLE
Add the `useTableNameAsAlias` option to Gradle plugin

### DIFF
--- a/gradle-plugin/src/main/java/org/komapper/gradle/codegen/GenerateTask.java
+++ b/gradle-plugin/src/main/java/org/komapper/gradle/codegen/GenerateTask.java
@@ -67,7 +67,7 @@ public class GenerateTask extends DefaultTask {
           writer,
           settings.getDeclareAsNullable().get(),
           settings.getUseSelfMapping().get(),
-          settings.getSingularize().get(),
+          settings.getUseTableNameAsAlias().get(),
           settings.getUseCatalog().get(),
           settings.getUseSchema().get(),
           settings.getPropertyTypeResolver().get(),
@@ -81,7 +81,7 @@ public class GenerateTask extends DefaultTask {
               destinationDir, "entityDefinitions.kt", settings.getOverwriteDefinitions().get())) {
         generator.generateDefinitions(
             writer,
-            settings.getSingularize().get(),
+            settings.getUseTableNameAsAlias().get(),
             settings.getUseCatalog().get(),
             settings.getUseSchema().get(),
             settings.getVersionPropertyName().get(),

--- a/gradle-plugin/src/main/java/org/komapper/gradle/codegen/Generator.java
+++ b/gradle-plugin/src/main/java/org/komapper/gradle/codegen/Generator.java
@@ -29,6 +29,7 @@ public class Generator {
   private final Property<Boolean> overwriteEntities;
   private final Property<Boolean> declareAsNullable;
   private final Property<Boolean> useSelfMapping;
+  private final Property<Boolean> useTableNameAsAlias;
   private final Property<Boolean> overwriteDefinitions;
   private final Property<Boolean> useCatalog;
   private final Property<Boolean> useSchema;
@@ -63,6 +64,7 @@ public class Generator {
     this.overwriteEntities = objects.property(Boolean.class).value(false);
     this.declareAsNullable = objects.property(Boolean.class).value(false);
     this.useSelfMapping = objects.property(Boolean.class).value(false);
+    this.useTableNameAsAlias = objects.property(Boolean.class).value(false);
     this.overwriteDefinitions = objects.property(Boolean.class).value(false);
     this.useCatalog = objects.property(Boolean.class).value(false);
     this.useSchema = objects.property(Boolean.class).value(false);
@@ -134,6 +136,10 @@ public class Generator {
 
   public Property<Boolean> getUseSelfMapping() {
     return useSelfMapping;
+  }
+
+  public Property<Boolean> getUseTableNameAsAlias() {
+    return useTableNameAsAlias;
   }
 
   public Property<Boolean> getOverwriteDefinitions() {

--- a/komapper-codegen/src/main/java/org/komapper/codegen/CodeGenerator.java
+++ b/komapper-codegen/src/main/java/org/komapper/codegen/CodeGenerator.java
@@ -48,7 +48,7 @@ public class CodeGenerator {
       @NotNull Writer writer,
       boolean declareAsNullable,
       boolean useSelfMapping,
-      boolean singularize,
+      boolean useTableNameAsAlias,
       boolean useCatalog,
       boolean useSchema,
       @NotNull PropertyTypeResolver resolver,
@@ -71,7 +71,7 @@ public class CodeGenerator {
       var className = classNameResolver.resolve(table);
       if (useSelfMapping) {
         p.print("@KomapperEntity");
-        if (singularize) {
+        if (useTableNameAsAlias) {
           p.print("([\"" + StringUtil.snakeToLowerCamelCase(table.getName()) + "\"])");
         }
         p.println();
@@ -102,7 +102,7 @@ public class CodeGenerator {
 
   public void generateDefinitions(
       @NotNull Writer writer,
-      boolean singularize,
+      boolean useTableNameAsAlias,
       boolean useCatalog,
       boolean useSchema,
       @NotNull String versionPropertyName,
@@ -120,7 +120,7 @@ public class CodeGenerator {
       p.println();
       var className = classNameResolver.resolve(table);
       p.print("@KomapperEntityDef(" + className + "::class");
-      if (singularize) {
+      if (useTableNameAsAlias) {
         p.print(", [\"" + StringUtil.snakeToLowerCamelCase(table.getName()) + "\"]");
       }
       p.println(")");

--- a/komapper-codegen/src/test/kotlin/org/komapper/codegen/CodeGeneratorTest.kt
+++ b/komapper-codegen/src/test/kotlin/org/komapper/codegen/CodeGeneratorTest.kt
@@ -157,7 +157,7 @@ class CodeGeneratorTest {
             PropertyNameResolver.of()
         )
         generator.createNewFile(destinationDir, "entities.kt", false).use { writer ->
-            generator.generateEntities(writer, false, false, true, false, false, DummyPropertyTypeResolver(), "", "", "")
+            generator.generateEntities(writer, false, false, false, false, false, DummyPropertyTypeResolver(), "", "", "")
         }
 
         val file = destinationDir.resolve(Paths.get("entity", "entities.kt"))
@@ -305,6 +305,58 @@ class CodeGeneratorTest {
             PropertyNameResolver.of()
         )
         generator.createNewFile(destinationDir, "entityDefinitions.kt", false).use { writer ->
+            generator.generateDefinitions(writer, false, false, false, "", "", "")
+        }
+        val file = destinationDir.resolve(Paths.get("entity", "entityDefinitions.kt"))
+        val expected = """
+            package entity
+            
+            import org.komapper.annotation.KomapperAutoIncrement
+            import org.komapper.annotation.KomapperColumn
+            import org.komapper.annotation.KomapperEntityDef
+            import org.komapper.annotation.KomapperId
+            import org.komapper.annotation.KomapperTable
+            
+            @KomapperEntityDef(Address::class)
+            @KomapperTable("ADDRESSES")
+            data class AddressDef (
+                @KomapperId @KomapperAutoIncrement @KomapperColumn("ADDRESS_ID") val addressId: Nothing,
+                @KomapperColumn("STREET") val street: Nothing,
+                @KomapperColumn("VERSION") val version: Nothing,
+                @KomapperColumn("CREATED_AT") val createdAt: Nothing,
+                @KomapperColumn("UPDATED_AT") val updatedAt: Nothing,
+            )
+            
+            @KomapperEntityDef(Employee::class)
+            @KomapperTable("EMPLOYEES")
+            data class EmployeeDef (
+                @KomapperId @KomapperColumn("EMPLOYEE_ID") val employeeId: Nothing,
+                @KomapperColumn("NAME") val name: Nothing,
+                @KomapperColumn("VERSION") val version: Nothing,
+            )
+            
+            @KomapperEntityDef(Class::class)
+            @KomapperTable("CLASSES")
+            data class ClassDef (
+                @KomapperId @KomapperAutoIncrement @KomapperColumn("CLASS_ID") val classId: Nothing,
+                @KomapperColumn("SUPER") val `super`: Nothing,
+                @KomapperColumn("VAL") val `val`: Nothing,
+            )
+            
+        """.trimIndent().normalizeLineSeparator()
+        assertEquals(expected, file.readText())
+    }
+
+    @Test
+    fun generateEntityDefinition_useTableNameAsAlias() {
+        val destinationDir = tempDir!!.resolve(Paths.get("src", "kotlin", "main"))
+        val generator = CodeGenerator(
+            "entity",
+            createTables(),
+            ClassNameResolver.of("", "Entity", false),
+            PropertyNameResolver.of()
+        )
+        generator.createNewFile(destinationDir, "entityDefinitions.kt", false).use { writer ->
             generator.generateDefinitions(writer, true, false, false, "", "", "")
         }
         val file = destinationDir.resolve(Paths.get("entity", "entityDefinitions.kt"))
@@ -317,9 +369,9 @@ class CodeGeneratorTest {
             import org.komapper.annotation.KomapperId
             import org.komapper.annotation.KomapperTable
             
-            @KomapperEntityDef(Address::class, ["addresses"])
-            @KomapperTable("ADDRESSES")
-            data class AddressDef (
+            @KomapperEntityDef(AddressEntity::class, ["address"])
+            @KomapperTable("ADDRESS")
+            data class AddressEntityDef (
                 @KomapperId @KomapperAutoIncrement @KomapperColumn("ADDRESS_ID") val addressId: Nothing,
                 @KomapperColumn("STREET") val street: Nothing,
                 @KomapperColumn("VERSION") val version: Nothing,
@@ -327,17 +379,17 @@ class CodeGeneratorTest {
                 @KomapperColumn("UPDATED_AT") val updatedAt: Nothing,
             )
             
-            @KomapperEntityDef(Employee::class, ["employees"])
-            @KomapperTable("EMPLOYEES")
-            data class EmployeeDef (
+            @KomapperEntityDef(EmployeeEntity::class, ["employee"])
+            @KomapperTable("EMPLOYEE")
+            data class EmployeeEntityDef (
                 @KomapperId @KomapperColumn("EMPLOYEE_ID") val employeeId: Nothing,
                 @KomapperColumn("NAME") val name: Nothing,
                 @KomapperColumn("VERSION") val version: Nothing,
             )
             
-            @KomapperEntityDef(Class::class, ["classes"])
-            @KomapperTable("CLASSES")
-            data class ClassDef (
+            @KomapperEntityDef(ClassEntity::class, ["class"])
+            @KomapperTable("CLASS")
+            data class ClassEntityDef (
                 @KomapperId @KomapperAutoIncrement @KomapperColumn("CLASS_ID") val classId: Nothing,
                 @KomapperColumn("SUPER") val `super`: Nothing,
                 @KomapperColumn("VAL") val `val`: Nothing,


### PR DESCRIPTION
Singularizing entity class names and having access to the metamodel with the same name as the table name were originally separate concerns and should have been accomplished with separate options.

The `singularize` option concentrates only on converting to singular entity class names, and the `useTableNameAsAlias` option was added to generate an alias that is the same as the table name.


Close #1015 