### PR TITLE
Enable the `allowMissingWhereClause` option in DELETE ALL queries

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteWhereReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteWhereReturningTest.kt
@@ -91,20 +91,17 @@ class JdbcDeleteWhereReturningTest(private val db: JdbcDatabase) {
 
     @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
-    fun allowMissingWhereClause_default() {
+    fun all() {
         val e = Meta.employee
-        val ex = assertFailsWith<IllegalStateException> {
-            @Suppress("UNUSED_VARIABLE")
-            val count = db.runQuery {
-                QueryDsl.delete(e).all().returning()
-            }
+        val list = db.runQuery {
+            QueryDsl.delete(e).all().returning()
         }
-        println(ex)
+        assertEquals(14, list.size)
     }
 
     @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
-    fun allowMissingWhereClause_default_empty() {
+    fun allowMissingWhereClause_default() {
         val e = Meta.employee
         val ex = assertFailsWith<IllegalStateException> {
             @Suppress("UNUSED_VARIABLE")
@@ -120,7 +117,7 @@ class JdbcDeleteWhereReturningTest(private val db: JdbcDatabase) {
     fun allowMissingWhereClause_true() {
         val e = Meta.employee
         val list = db.runQuery {
-            QueryDsl.delete(e).all().returning().options { it.copy(allowMissingWhereClause = true) }
+            QueryDsl.delete(e).where { }.returning().options { it.copy(allowMissingWhereClause = true) }
         }
         assertEquals(14, list.size)
     }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteWhereTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteWhereTest.kt
@@ -23,19 +23,16 @@ class JdbcDeleteWhereTest(private val db: JdbcDatabase) {
     }
 
     @Test
-    fun allowMissingWhereClause_default() {
+    fun all() {
         val e = Meta.employee
-        val ex = assertFailsWith<IllegalStateException> {
-            @Suppress("UNUSED_VARIABLE")
-            val count = db.runQuery {
-                QueryDsl.delete(e).all()
-            }
+        val count = db.runQuery {
+            QueryDsl.delete(e).all()
         }
-        println(ex)
+        assertEquals(14, count)
     }
 
     @Test
-    fun allowMissingWhereClause_default_empty() {
+    fun allowMissingWhereClause_default() {
         val e = Meta.employee
         val ex = assertFailsWith<IllegalStateException> {
             @Suppress("UNUSED_VARIABLE")
@@ -50,7 +47,7 @@ class JdbcDeleteWhereTest(private val db: JdbcDatabase) {
     fun allowMissingWhereClause_true() {
         val e = Meta.employee
         val count = db.runQuery {
-            QueryDsl.delete(e).all().options { it.copy(allowMissingWhereClause = true) }
+            QueryDsl.delete(e).where { }.options { it.copy(allowMissingWhereClause = true) }
         }
         assertEquals(14, count)
     }

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteWhereReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteWhereReturningTest.kt
@@ -92,20 +92,17 @@ class R2dbcDeleteWhereReturningTest(private val db: R2dbcDatabase) {
 
     @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
-    fun allowMissingWhereClause_default(info: TestInfo) = inTransaction(db, info) {
+    fun all(info: TestInfo) = inTransaction(db, info) {
         val e = Meta.employee
-        val ex = assertFailsWith<IllegalStateException> {
-            @Suppress("UNUSED_VARIABLE")
-            val count = db.runQuery {
-                QueryDsl.delete(e).all().returning()
-            }
+        val list = db.runQuery {
+            QueryDsl.delete(e).all().returning()
         }
-        println(ex)
+        assertEquals(14, list.size)
     }
 
     @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
-    fun allowMissingWhereClause_default_empty(info: TestInfo) = inTransaction(db, info) {
+    fun allowMissingWhereClause_default(info: TestInfo) = inTransaction(db, info) {
         val e = Meta.employee
         val ex = assertFailsWith<IllegalStateException> {
             @Suppress("UNUSED_VARIABLE")
@@ -121,7 +118,7 @@ class R2dbcDeleteWhereReturningTest(private val db: R2dbcDatabase) {
     fun allowMissingWhereClause_true(info: TestInfo) = inTransaction(db, info) {
         val e = Meta.employee
         val list = db.runQuery {
-            QueryDsl.delete(e).all().returning().options { it.copy(allowMissingWhereClause = true) }
+            QueryDsl.delete(e).where { }.returning().options { it.copy(allowMissingWhereClause = true) }
         }
         assertEquals(14, list.size)
     }

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteWhereTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteWhereTest.kt
@@ -24,12 +24,21 @@ class R2dbcDeleteWhereTest(private val db: R2dbcDatabase) {
     }
 
     @Test
+    fun all(info: TestInfo) = inTransaction(db, info) {
+        val e = Meta.employee
+        val count = db.runQuery {
+            QueryDsl.delete(e).all()
+        }
+        assertEquals(14, count)
+    }
+
+    @Test
     fun allowMissingWhereClause_default(info: TestInfo) = inTransaction(db, info) {
         val e = Meta.employee
         val ex = assertFailsWith<IllegalStateException> {
             @Suppress("UNUSED_VARIABLE")
             val count = db.runQuery {
-                QueryDsl.delete(e).all()
+                QueryDsl.delete(e).where { }
             }
         }
         println(ex)
@@ -39,7 +48,7 @@ class R2dbcDeleteWhereTest(private val db: R2dbcDatabase) {
     fun allowMissingWhereClause_true(info: TestInfo) = inTransaction(db, info) {
         val e = Meta.employee
         val count = db.runQuery {
-            QueryDsl.delete(e).all().options { it.copy(allowMissingWhereClause = true) }
+            QueryDsl.delete(e).where { }.options { it.copy(allowMissingWhereClause = true) }
         }
         assertEquals(14, count)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/DeleteQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/DeleteQueryBuilder.kt
@@ -84,7 +84,7 @@ internal data class DeleteQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
     }
 
     override fun all(): RelationDeleteQuery<ENTITY> {
-        return asRelationDeleteQuery()
+        return asRelationDeleteQuery().options { it.copy(allowMissingWhereClause = true) }
     }
 
     private fun asRelationDeleteQuery(): RelationDeleteQuery<ENTITY> {


### PR DESCRIPTION
You can write as follows:
```kotlin
val e = Meta.employee
QueryDsl.delete(e).all()
```

instead of:
```kotlin
val e = Meta.employee
QueryDsl.delete(e).all().options { it.copy(allowMissingWhereClause = true) }
```