### PR TITLE
Support the locate function

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcOperatorTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcOperatorTest.kt
@@ -10,6 +10,7 @@ import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.operator.count
 import org.komapper.core.dsl.operator.div
 import org.komapper.core.dsl.operator.literal
+import org.komapper.core.dsl.operator.locate
 import org.komapper.core.dsl.operator.lower
 import org.komapper.core.dsl.operator.ltrim
 import org.komapper.core.dsl.operator.minus
@@ -190,6 +191,60 @@ class JdbcOperatorTest(private val db: JdbcDatabase) {
                 }.first()
         }
         assertEquals("STREET 10STREET 10STREET 10", result)
+    }
+
+    @Test
+    fun locateFunction_2parameters() {
+        val a = Meta.address
+        val result = db.runQuery {
+            QueryDsl.from(a).select(locate(literal("bar"), literal("foobarbar"))).first()
+        }
+        assertEquals(4, result)
+    }
+
+    @Test
+    fun locateFunction_2parameters_when_1st_parameter_is_value() {
+        val a = Meta.address
+        val result = db.runQuery {
+            QueryDsl.from(a).select(locate("bar", literal("foobarbar"))).first()
+        }
+        assertEquals(4, result)
+    }
+
+    @Test
+    fun locateFunction_2parameters_when_2nd_parameter_is_value() {
+        val a = Meta.address
+        val result = db.runQuery {
+            QueryDsl.from(a).select(locate(literal("bar"), "foobarbar")).first()
+        }
+        assertEquals(4, result)
+    }
+
+    @Test
+    fun locateFunction_3parameters() {
+        val a = Meta.address
+        val result = db.runQuery {
+            QueryDsl.from(a).select(locate(literal("bar"), literal("foobarbar"), 5)).first()
+        }
+        assertEquals(7, result)
+    }
+
+    @Test
+    fun locateFunction_3parameters_when_1st_parameter_is_value() {
+        val a = Meta.address
+        val result = db.runQuery {
+            QueryDsl.from(a).select(locate("bar", literal("foobarbar"), 5)).first()
+        }
+        assertEquals(7, result)
+    }
+
+    @Test
+    fun locateFunction_3parameters_when_2nd_parameter_is_value() {
+        val a = Meta.address
+        val result = db.runQuery {
+            QueryDsl.from(a).select(locate(literal("bar"), "foobarbar", 5)).first()
+        }
+        assertEquals(7, result)
     }
 
     @Test

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -114,6 +114,13 @@ interface Dialect {
     }
 
     /**
+     * Returns the type of LOCATE function.
+     */
+    fun getLocateFunctionType(): LocateFunctionType {
+        return LocateFunctionType.LOCATE
+    }
+
+    /**
      * Returns the statement builder for creating the OFFSET and LIMIT expression.
      *
      * @param dialect the builder dialect
@@ -394,4 +401,14 @@ object DryRunDialect : Dialect {
     override fun supportsLockOptionSkipLocked(): Boolean = true
 
     override fun supportsLockOptionWait(): Boolean = true
+}
+
+/**
+ * Type of LOCATE function.
+ */
+enum class LocateFunctionType(val functionName: String) {
+    LOCATE("locate"),
+    INSTR("instr"),
+    CHARINDEX("charindex"),
+    POSITION("position"),
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/StringFunction.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/StringFunction.kt
@@ -1,30 +1,56 @@
 package org.komapper.core.dsl.expression
 
-internal sealed class StringFunction<T : Any> : ColumnExpression<T, String> {
+import kotlin.reflect.KClass
+
+internal sealed class StringFunction<T : Any, S : Any> : ColumnExpression<T, S> {
     internal data class Concat<T : Any>(
         val expression: ColumnExpression<T, String>,
         val left: Operand,
         val right: Operand,
     ) :
-        ColumnExpression<T, String> by expression, StringFunction<T>()
+        ColumnExpression<T, String> by expression, StringFunction<T, String>()
+
+    internal data class Locate(
+        val expression: ColumnExpression<*, String>,
+        val pattern: Operand,
+        val string: Operand,
+        val startIndex: Operand?,
+    ) : StringFunction<Int, Int>() {
+        override val owner: TableExpression<*>
+            get() = expression.owner
+        override val exteriorClass: KClass<Int>
+            get() = Int::class
+        override val interiorClass: KClass<Int>
+            get() = Int::class
+        override val wrap: (Int) -> Int
+            get() = { it }
+        override val unwrap: (Int) -> Int
+            get() = { it }
+        override val columnName: String
+            get() = expression.columnName
+        override val alwaysQuote: Boolean
+            get() = expression.masking
+        override val masking: Boolean
+            get() = expression.masking
+    }
 
     internal data class Lower<T : Any>(
         val expression: ColumnExpression<T, String>,
         val operand: Operand,
     ) :
-        ColumnExpression<T, String> by expression, StringFunction<T>()
+        ColumnExpression<T, String> by expression, StringFunction<T, String>()
 
     internal data class Ltrim<T : Any>(
         val expression: ColumnExpression<T, String>,
         val operand: Operand,
     ) :
-        ColumnExpression<T, String> by expression, StringFunction<T>()
+        ColumnExpression<T, String> by expression, StringFunction<T, String>()
 
     internal data class Rtrim<T : Any>(
         val expression: ColumnExpression<T, String>,
         val operand: Operand,
     ) :
-        ColumnExpression<T, String> by expression, StringFunction<T>()
+        ColumnExpression<T, String> by expression, StringFunction<T, String>()
 
     internal data class Substring<T : Any>(
         val expression: ColumnExpression<T, String>,
@@ -32,17 +58,17 @@ internal sealed class StringFunction<T : Any> : ColumnExpression<T, String> {
         val startIndex: Operand,
         val length: Operand?,
     ) :
-        ColumnExpression<T, String> by expression, StringFunction<T>()
+        ColumnExpression<T, String> by expression, StringFunction<T, String>()
 
     internal data class Trim<T : Any>(
         val expression: ColumnExpression<T, String>,
         val operand: Operand,
     ) :
-        ColumnExpression<T, String> by expression, StringFunction<T>()
+        ColumnExpression<T, String> by expression, StringFunction<T, String>()
 
     internal data class Upper<T : Any>(
         val expression: ColumnExpression<T, String>,
         val operand: Operand,
     ) :
-        ColumnExpression<T, String> by expression, StringFunction<T>()
+        ColumnExpression<T, String> by expression, StringFunction<T, String>()
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/StringFunctions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/StringFunctions.kt
@@ -38,6 +38,54 @@ fun <T : Any> concat(
 }
 
 /**
+ * Builds a LOCATE function.
+ *
+ * Depending on the Dialect, either the INSTR, CHARINDE, or POSITION function may be created instead of the LOCATE function.
+ */
+fun <T : Any> locate(
+    pattern: ColumnExpression<T, String>,
+    string: T,
+    startIndex: Int? = null,
+): ColumnExpression<Int, Int> {
+    val o1 = Operand.Column(pattern)
+    val o2 = Operand.Argument(pattern, string)
+    val o3 = startIndex?.let { Operand.Argument(literal(it), it) }
+    return StringFunction.Locate(pattern, o1, o2, o3)
+}
+
+/**
+ * Builds a LOCATE function.
+ *
+ * Depending on the Dialect, either the INSTR, CHARINDE, or POSITION function may be created instead of the LOCATE function.
+ */
+fun <T : Any> locate(
+    pattern: T,
+    string: ColumnExpression<T, String>,
+    startIndex: Int? = null,
+): ColumnExpression<Int, Int> {
+    val o1 = Operand.Argument(string, pattern)
+    val o2 = Operand.Column(string)
+    val o3 = startIndex?.let { Operand.Argument(literal(it), it) }
+    return StringFunction.Locate(string, o1, o2, o3)
+}
+
+/**
+ * Builds a LOCATE function.
+ *
+ * Depending on the Dialect, either the INSTR, CHARINDE, or POSITION function may be created instead of the LOCATE function.
+ */
+fun <T : Any> locate(
+    pattern: ColumnExpression<T, String>,
+    string: ColumnExpression<T, String>,
+    startIndex: Int? = null,
+): ColumnExpression<Int, Int> {
+    val o1 = Operand.Column(pattern)
+    val o2 = Operand.Column(string)
+    val o3 = startIndex?.let { Operand.Argument(literal(it), it) }
+    return StringFunction.Locate(pattern, o1, o2, o3)
+}
+
+/**
  * Builds a LOWER function.
  */
 fun <T : Any> lower(

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleDialect.kt
@@ -2,6 +2,7 @@ package org.komapper.dialect.oracle
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.LocateFunctionType
 import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
@@ -33,6 +34,10 @@ interface OracleDialect : Dialect {
     }
 
     override val driver: String get() = DRIVER
+
+    override fun getLocateFunctionType(): LocateFunctionType {
+        return LocateFunctionType.INSTR
+    }
 
     override fun getRandomFunction(): String = "dbms_random.value"
 

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
@@ -2,6 +2,7 @@ package org.komapper.dialect.postgresql
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.LocateFunctionType
 import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
@@ -30,6 +31,10 @@ interface PostgreSqlDialect : Dialect {
     }
 
     override val driver: String get() = DRIVER
+
+    override fun getLocateFunctionType(): LocateFunctionType {
+        return LocateFunctionType.POSITION
+    }
 
     override fun getSequenceSql(sequenceName: String): String {
         return "select nextval('$sequenceName')"

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
@@ -2,6 +2,7 @@ package org.komapper.dialect.sqlserver
 
 import org.komapper.core.BuilderDialect
 import org.komapper.core.Dialect
+import org.komapper.core.LocateFunctionType
 import org.komapper.core.dsl.builder.EntityDeleteStatementBuilder
 import org.komapper.core.dsl.builder.EntityInsertStatementBuilder
 import org.komapper.core.dsl.builder.EntityUpdateStatementBuilder
@@ -36,6 +37,10 @@ interface SqlServerDialect : Dialect {
     override val driver: String get() = DRIVER
     override val openQuote: String get() = OPEN_QUOTE
     override val closeQuote: String get() = CLOSE_QUOTE
+
+    override fun getLocateFunctionType(): LocateFunctionType {
+        return LocateFunctionType.CHARINDEX
+    }
 
     override fun getOffsetLimitStatementBuilder(
         dialect: BuilderDialect,


### PR DESCRIPTION
This PR supports the locate function.

Komapper query:
```kotlin
val a = Meta.address
val result = db.runQuery {
    QueryDsl.from(a).select(locate("bar", literal("foobarbar"), 5)).first()
}
assertEquals(7, result)
```

The above query is converted to the following SQL depending on Dialect:

```sql
-- H2, MySQL, MariaDB
select (locate('bar', 'foobarbar', 5)) from address as t0_

-- Oracle
select (instr('foobarbar', 'bar', 5)) from address as t0_

-- PostgreSQL
select (position('bar' in substring('foobarbar' from 5)) + 5 - 1) from address as t0_

-- SQL Server
select (charindex('bar', 'foobarbar', 5)) from address as t0_

```

### References
- https://www.h2database.com/html/functions.html#locate
- https://mariadb.com/kb/en/locate/
- https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_locate
- https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/INSTR.html
- https://www.postgresql.org/docs/current/functions-string.html
- https://learn.microsoft.com/en-us/sql/t-sql/functions/charindex-transact-sql
