### PR TITLE
Support adding user-defined column expressions

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
@@ -20,9 +20,11 @@ import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.PropertyExpression
 import org.komapper.core.dsl.expression.ScalarExpression
 import org.komapper.core.dsl.expression.ScalarQueryExpression
+import org.komapper.core.dsl.expression.SqlBuilderScopeImpl
 import org.komapper.core.dsl.expression.StringFunction
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.expression.TableExpression
+import org.komapper.core.dsl.expression.UserDefinedExpression
 
 class BuilderSupport(
     private val dialect: BuilderDialect,
@@ -78,6 +80,11 @@ class BuilderSupport(
             is StringFunction -> {
                 visitStringFunction(expression)
             }
+
+            is UserDefinedExpression -> {
+                visitUserDefinedExpression(expression)
+            }
+
             is PropertyExpression<*, *> -> {
                 val name = expression.getCanonicalColumnName(dialect::enquote)
                 val owner = expression.owner
@@ -365,6 +372,13 @@ class BuilderSupport(
                 buf.append(")")
             }
         }
+        buf.append(")")
+    }
+
+    private fun visitUserDefinedExpression(expression: UserDefinedExpression<*, *>) {
+        buf.append("(")
+        val scope = SqlBuilderScopeImpl(dialect, buf, ::visitOperand)
+        expression.build(scope)
         buf.append(")")
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ColumnExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ColumnExpression.kt
@@ -2,6 +2,12 @@ package org.komapper.core.dsl.expression
 
 import kotlin.reflect.KClass
 
+/**
+ * The column expression.
+ *
+ * @param EXTERIOR the exterior type of expression evaluation
+ * @param INTERIOR the interior type of expression evaluation
+ */
 sealed interface ColumnExpression<EXTERIOR : Any, INTERIOR : Any> : SortExpression {
     val owner: TableExpression<*>
     val exteriorClass: KClass<EXTERIOR>

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/LiteralExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/LiteralExpression.kt
@@ -2,7 +2,7 @@ package org.komapper.core.dsl.expression
 
 import kotlin.reflect.KClass
 
-internal class LiteralExpression<T : Any>(val value: T, klass: KClass<T>) :
+internal data class LiteralExpression<T : Any>(val value: T, private val klass: KClass<T>) :
     ColumnExpression<T, T> {
     override val owner: TableExpression<*>
         get() = throw UnsupportedOperationException()

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/UserDefinedExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/UserDefinedExpression.kt
@@ -1,0 +1,77 @@
+package org.komapper.core.dsl.expression
+
+import org.komapper.core.Dialect
+import org.komapper.core.StatementBuffer
+import org.komapper.core.Value
+import kotlin.reflect.KClass
+
+internal class UserDefinedExpression<EXTERIOR : Any, INTERIOR : Any>(
+    override val exteriorClass: KClass<EXTERIOR>,
+    override val interiorClass: KClass<INTERIOR>,
+    override val wrap: (INTERIOR) -> EXTERIOR,
+    private val operands: List<Operand>,
+    private val builder: SqlBuilderScope.() -> Unit,
+) : ColumnExpression<EXTERIOR, INTERIOR> {
+    override val unwrap: (EXTERIOR) -> INTERIOR get() = throw UnsupportedOperationException()
+    override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
+    override val columnName: String get() = throw UnsupportedOperationException()
+    override val alwaysQuote: Boolean get() = throw UnsupportedOperationException()
+    override val masking: Boolean get() = throw UnsupportedOperationException()
+    fun build(scope: SqlBuilderScope) {
+        scope.builder()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as UserDefinedExpression<*, *>
+
+        if (exteriorClass != other.exteriorClass) return false
+        if (interiorClass != other.interiorClass) return false
+        if (operands != other.operands) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = exteriorClass.hashCode()
+        result = 31 * result + interiorClass.hashCode()
+        result = 31 * result + operands.hashCode()
+        return result
+    }
+}
+
+interface SqlBuilderScope {
+    val dialect: Dialect
+    fun append(text: CharSequence)
+    fun cutBack(length: Int)
+    fun bind(value: Value<*>)
+    fun visit(operand: Operand)
+}
+
+internal class SqlBuilderScopeImpl(
+    override val dialect: Dialect,
+    val buf: StatementBuffer,
+    val visitOperand: (Operand) -> Unit,
+) : SqlBuilderScope {
+    override fun append(text: CharSequence) {
+        buf.append(text)
+    }
+
+    override fun cutBack(length: Int) {
+        buf.cutBack(length)
+    }
+
+    override fun bind(value: Value<*>) {
+        buf.bind(value)
+    }
+
+    override fun visit(operand: Operand) {
+        visitOperand(operand)
+    }
+
+    override fun toString(): String {
+        return buf.toString()
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/UserDefinedExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/UserDefinedExpression.kt
@@ -2,7 +2,6 @@ package org.komapper.core.dsl.expression
 
 import org.komapper.core.Dialect
 import org.komapper.core.StatementBuffer
-import org.komapper.core.Value
 import kotlin.reflect.KClass
 
 internal class UserDefinedExpression<EXTERIOR : Any, INTERIOR : Any>(
@@ -46,7 +45,6 @@ interface SqlBuilderScope {
     val dialect: Dialect
     fun append(text: CharSequence)
     fun cutBack(length: Int)
-    fun bind(value: Value<*>)
     fun visit(operand: Operand)
 }
 
@@ -61,10 +59,6 @@ internal class SqlBuilderScopeImpl(
 
     override fun cutBack(length: Int) {
         buf.cutBack(length)
-    }
-
-    override fun bind(value: Value<*>) {
-        buf.bind(value)
     }
 
     override fun visit(operand: Operand) {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/OperatorUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/OperatorUtility.kt
@@ -1,0 +1,50 @@
+package org.komapper.core.dsl.operator
+
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.expression.SqlBuilderScope
+import org.komapper.core.dsl.expression.UserDefinedExpression
+import kotlin.reflect.KClass
+
+/**
+ * Define a new simple column expression.
+ *
+ * The [operands] are used to determine identity of the expression.
+ *
+ * @param T the type of expression evaluation
+ * @param klass the class of [T]
+ * @param operands the operand list used in the expression
+ * @param builder the SQL builder
+ * @return column expression
+ */
+fun <T : Any> columnExpression(
+    klass: KClass<T>,
+    operands: List<Operand>,
+    builder: SqlBuilderScope.() -> Unit,
+): ColumnExpression<T, T> {
+    return columnExpression(klass, klass, { it }, operands, builder)
+}
+
+/**
+ * Define a new complex column expression.
+ *
+ * The [operands] are used to determine identity of the expression.
+ *
+ * @param EXTERIOR the exterior type of expression evaluation
+ * @param INTERIOR the interior type of expression evaluation
+ * @param exteriorClass the class of [EXTERIOR]
+ * @param interiorClass the class of [INTERIOR]
+ * @param wrap the function to convert an interior value to an exterior value
+ * @param operands the operand list used in the expression
+ * @param builder the SQL builder
+ * @return column expression
+ */
+fun <EXTERIOR : Any, INTERIOR : Any> columnExpression(
+    exteriorClass: KClass<EXTERIOR>,
+    interiorClass: KClass<INTERIOR>,
+    wrap: (INTERIOR) -> EXTERIOR,
+    operands: List<Operand>,
+    builder: SqlBuilderScope.() -> Unit,
+): ColumnExpression<EXTERIOR, INTERIOR> {
+    return UserDefinedExpression(exteriorClass, interiorClass, wrap, operands, builder)
+}

--- a/komapper-core/src/test/kotlin/org/komapper/core/dsl/operator/LiteralExpressionsTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/dsl/operator/LiteralExpressionsTest.kt
@@ -1,0 +1,12 @@
+package org.komapper.core.dsl.operator
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LiteralExpressionsTest {
+
+    @Test
+    fun literal_int() {
+        assertEquals(literal(123), literal(123))
+    }
+}

--- a/komapper-core/src/test/kotlin/org/komapper/core/dsl/operator/OperatorUtilityTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/dsl/operator/OperatorUtilityTest.kt
@@ -1,0 +1,32 @@
+package org.komapper.core.dsl.operator
+
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OperatorUtilityTest {
+
+    @Test
+    fun columnExpression() {
+        val value = "world"
+        val left = myConcat(literal("hello"), value)
+        val right = myConcat(literal("hello"), value)
+        assertEquals(left, right)
+    }
+
+    private fun myConcat(
+        left: ColumnExpression<String, String>,
+        @Suppress("SameParameterValue") right: String,
+    ): ColumnExpression<String, String> {
+        val o1 = Operand.Column(left)
+        val o2 = Operand.Argument(left, right)
+        return columnExpression(String::class, listOf(o1, o2)) {
+            append("concat(")
+            visit(o1)
+            append(", ")
+            visit(o2)
+            append(")")
+        }
+    }
+}


### PR DESCRIPTION
For example, Komapper does not provide a regexp operator, but users can define and use it in their queries.

Define the regexp expression:

```kotlin
fun regexp(
    left: ColumnExpression<String, String>,
    right: String,
): ColumnExpression<Int, Int> {
    val o1 = Operand.Column(left)
    val o2 = Operand.Argument(left, right)
    return columnExpression(Int::class, listOf(o1, o2)) {
        visit(o1)
        append(" regexp ")
        visit(o2)
    }
}
```

Use it in your query:

```kotlin
QueryDsl.from(a).select(regexp(literal("hello"), ".*")).first()
```

The above query is converted to the following SQL:

```sql
select ('hello' regexp '.*') from address as t0_
```