### PR TITLE
Support adding user-defined comparison operators

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
@@ -20,6 +20,7 @@ import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.PropertyExpression
 import org.komapper.core.dsl.expression.ScalarExpression
 import org.komapper.core.dsl.expression.ScalarQueryExpression
+import org.komapper.core.dsl.expression.SqlBuilderScope
 import org.komapper.core.dsl.expression.SqlBuilderScopeImpl
 import org.komapper.core.dsl.expression.StringFunction
 import org.komapper.core.dsl.expression.SubqueryExpression
@@ -420,6 +421,7 @@ class BuilderSupport(
             is Criterion.And -> operation.logicalBinary("and", c.criteria, index)
             is Criterion.Or -> operation.logicalBinary("or", c.criteria, index)
             is Criterion.Not -> operation.not(c.criteria)
+            is Criterion.UserDefined -> operation.userDefined(c.build)
         }
     }
 
@@ -627,6 +629,11 @@ class BuilderSupport(
                 buf.cutBack(5)
                 buf.append(")")
             }
+        }
+
+        fun userDefined(build: SqlBuilderScope.() -> Unit) {
+            val scope = SqlBuilderScopeImpl(dialect, buf, ::visitOperand)
+            scope.build()
         }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/Criterion.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/Criterion.kt
@@ -30,4 +30,6 @@ sealed class Criterion {
     data class And(val criteria: List<Criterion>) : Criterion()
     data class Or(val criteria: List<Criterion>) : Criterion()
     data class Not(val criteria: List<Criterion>) : Criterion()
+
+    data class UserDefined(val build: SqlBuilderScope.() -> Unit) : Criterion()
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/CriteriaContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/CriteriaContext.kt
@@ -1,0 +1,32 @@
+package org.komapper.core.dsl.operator
+
+import org.komapper.core.dsl.expression.Criterion
+import org.komapper.core.dsl.expression.SqlBuilderScope
+import org.komapper.core.dsl.scope.FilterScope
+
+/**
+ * The context for criteria.
+ */
+interface CriteriaContext {
+    /**
+     * The parent scope.
+     */
+    val scope: FilterScope
+
+    /**
+     * Adds a SQL builder
+     * @param build the SQL builder
+     */
+    fun add(build: SqlBuilderScope.() -> Unit)
+}
+
+class CriteriaContextImpl(
+    override val scope: FilterScope,
+    val
+    criteria: MutableList<Criterion>,
+) : CriteriaContext {
+    override fun add(build: SqlBuilderScope.() -> Unit) {
+        val criterion = Criterion.UserDefined(build)
+        criteria.add(criterion)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
@@ -4,6 +4,7 @@ import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.CompositeColumnExpression
 import org.komapper.core.dsl.expression.EscapeExpression
 import org.komapper.core.dsl.expression.SubqueryExpression
+import org.komapper.core.dsl.operator.CriteriaContext
 
 /**
  * Provides operators and predicates for HAVING, ON, WHEN, and WHERE clauses.
@@ -291,4 +292,13 @@ interface FilterScope {
     fun CharSequence.asSuffix(): EscapeExpression {
         return text("%") + escape(this)
     }
+
+    /**
+     * Adds an extension scope constructor.
+     *
+     * @param SCOPE the type of extension scope
+     * @param construct the extension scope constructor
+     * @param declaration the filter declaration
+     */
+    fun <SCOPE> extension(construct: (context: CriteriaContext) -> SCOPE, declaration: SCOPE.() -> Unit)
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
@@ -6,6 +6,8 @@ import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.EscapeExpression
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.SubqueryExpression
+import org.komapper.core.dsl.operator.CriteriaContext
+import org.komapper.core.dsl.operator.CriteriaContextImpl
 
 class FilterScopeSupport(
     private val criteria: MutableList<Criterion> = mutableListOf(),
@@ -307,5 +309,11 @@ class FilterScopeSupport(
     override fun notExists(block: () -> SubqueryExpression<*>) {
         val expression = block()
         add(Criterion.NotExists(expression))
+    }
+
+    override fun <SCOPE> extension(construct: (context: CriteriaContext) -> SCOPE, declaration: SCOPE.() -> Unit) {
+        val context = CriteriaContextImpl(this, criteria)
+        val scope = construct(context)
+        scope.declaration()
     }
 }


### PR DESCRIPTION
For example, Komapper does not provide a `~` and `!~` operators, but users can define and use them in their queries.

Define the operators:

```kotlin
class MyExtension(private val context: CriteriaContext) {

    infix fun <T : Any> ColumnExpression<T, String>.`~`(pattern: T?) {
        if (pattern == null) return
        val o1 = Operand.Column(this)
        val o2 = Operand.Argument(this, pattern)
        context.add {
            visit(o1)
            append(" ~ ")
            visit(o2)
        }
    }

    infix fun <T : Any> ColumnExpression<T, String>.`!~`(pattern: T?) {
        if (pattern == null) return
        val o1 = Operand.Column(this)
        val o2 = Operand.Argument(this, pattern)
        context.add {
            visit(o1)
            append(" !~ ")
            visit(o2)
        }
    }
}
```

Use them in your query:

```kotlin
val e = Meta.employee

QueryDsl.from(e).where {
    e.salary greaterEq BigDecimal(1000)
    extension(::MyExtension) {
        e.employeeName `~` "S"
        e.employeeName `!~` "T"
    }
}.orderBy(e.employeeName)
```

The above query is converted to the following SQL:

```sql
select 
    t0_.employee_id, 
    t0_.employee_no, 
    t0_.employee_name, 
    t0_.manager_id, 
    t0_.hiredate, 
    t0_.salary, 
    t0_.department_id, 
    t0_.address_id, 
    t0_.version 
from 
    employee as t0_ 
where 
    t0_.salary >= 1000 
    and 
    t0_.employee_name ~ 'S' 
    and 
    t0_.employee_name !~ 'T' 
order by 
    t0_.employee_name asc
```