### PR TITLE
Fix the bug that generates invalid SQL when performing logical operations in extension blocks

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWhereTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWhereTest.kt
@@ -652,6 +652,42 @@ class JdbcSelectWhereTest(private val db: JdbcDatabase) {
 
     @Test
     @Run(onlyIf = [Dbms.POSTGRESQL])
+    fun userDefinedComparison_and() {
+        val e = Meta.employee
+        val list = db.runQuery {
+            QueryDsl.from(e).where {
+                e.salary greaterEq BigDecimal(1000)
+                extension(::MyExtension) {
+                    e.employeeName `~` "S"
+                    and {
+                        e.employeeName `!~` "T"
+                    }
+                }
+            }.orderBy(e.employeeName)
+        }
+        assertEquals(listOf("ADAMS", "JONES"), list.map { it.employeeName })
+    }
+
+    @Test
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    fun userDefinedComparison_or() {
+        val e = Meta.employee
+        val list = db.runQuery {
+            QueryDsl.from(e).where {
+                e.salary greaterEq BigDecimal(1000)
+                extension(::MyExtension) {
+                    e.employeeName `~` "S"
+                    or {
+                        e.employeeName `~` "T"
+                    }
+                }
+            }.orderBy(e.employeeName)
+        }
+        assertEquals(listOf("ADAMS", "JONES", "MARTIN", "SCOTT", "SMITH", "TURNER"), list.map { it.employeeName })
+    }
+
+    @Test
+    @Run(onlyIf = [Dbms.POSTGRESQL])
     fun userDefinedComparison_use_builtin_operator_in_extension_block() {
         val e = Meta.employee
         val list = db.runQuery {

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWhereTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWhereTest.kt
@@ -688,6 +688,27 @@ class JdbcSelectWhereTest(private val db: JdbcDatabase) {
 
     @Test
     @Run(onlyIf = [Dbms.POSTGRESQL])
+    fun userDefinedComparison_or_and() {
+        val e = Meta.employee
+        val list = db.runQuery {
+            QueryDsl.from(e).where {
+                e.salary greaterEq BigDecimal(1000)
+                extension(::MyExtension) {
+                    e.employeeName `~` "S"
+                    or {
+                        e.employeeName `~` "T"
+                        and {
+                            e.employeeName `~` "S"
+                        }
+                    }
+                }
+            }.orderBy(e.employeeName)
+        }
+        assertEquals(listOf("ADAMS", "JONES", "SCOTT", "SMITH"), list.map { it.employeeName })
+    }
+
+    @Test
+    @Run(onlyIf = [Dbms.POSTGRESQL])
     fun userDefinedComparison_use_builtin_operator_in_extension_block() {
         val e = Meta.employee
         val list = db.runQuery {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderUtility.kt
@@ -18,19 +18,19 @@ import org.komapper.core.dsl.scope.WhereScope
 
 fun WhereProvider.getWhereCriteria(): List<Criterion> {
     val where = getCompositeWhere()
-    val support = FilterScopeSupport()
+    val support = FilterScopeSupport(::WhereScope)
     WhereScope(support).apply(where)
     return support.toList()
 }
 
 internal fun Join<*, *, *>.getOnCriteria(): List<Criterion> {
-    val support = FilterScopeSupport()
+    val support = FilterScopeSupport(::OnScope)
     OnScope(support).apply(on)
     return support.toList()
 }
 
 internal fun SelectContext<*, *, *>.getHavingCriteria(): List<Criterion> {
-    val support = FilterScopeSupport()
+    val support = FilterScopeSupport(::HavingScope)
     HavingScope(support).apply(having)
     return support.toList()
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ConditionalExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ConditionalExpression.kt
@@ -23,7 +23,7 @@ internal sealed interface ConditionalExpression<T : Any, S : Any> : ColumnExpres
 class When<S : Any, T : Any>(val declaration: WhenDeclaration, internal val then: ColumnExpression<S, T>) {
     val criteria: List<Criterion>
         get() {
-            val support = FilterScopeSupport()
+            val support = FilterScopeSupport(::WhenScope)
             WhenScope(support).apply(declaration)
             return support.toList()
         }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/CriteriaContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/CriteriaContext.kt
@@ -1,6 +1,5 @@
 package org.komapper.core.dsl.operator
 
-import org.komapper.core.dsl.expression.EscapeExpression
 import org.komapper.core.dsl.expression.SqlBuilderScope
 
 /**
@@ -14,14 +13,4 @@ interface CriteriaContext {
      * @param build the SQL builder
      */
     fun add(build: SqlBuilderScope.() -> Unit)
-
-    /**
-     * Does not escape the given string.
-     */
-    fun <S : CharSequence> text(value: S): EscapeExpression
-
-    /**
-     * Escapes the given string.
-     */
-    fun <S : CharSequence> escape(value: S): EscapeExpression
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/CriteriaContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/CriteriaContext.kt
@@ -1,32 +1,27 @@
 package org.komapper.core.dsl.operator
 
-import org.komapper.core.dsl.expression.Criterion
+import org.komapper.core.dsl.expression.EscapeExpression
 import org.komapper.core.dsl.expression.SqlBuilderScope
-import org.komapper.core.dsl.scope.FilterScope
 
 /**
  * The context for criteria.
  */
 interface CriteriaContext {
-    /**
-     * The parent scope.
-     */
-    val scope: FilterScope
-
+    
     /**
      * Adds a SQL builder.
      *
      * @param build the SQL builder
      */
     fun add(build: SqlBuilderScope.() -> Unit)
-}
 
-internal class CriteriaContextImpl(
-    override val scope: FilterScope,
-    private val criteria: MutableList<Criterion>,
-) : CriteriaContext {
-    override fun add(build: SqlBuilderScope.() -> Unit) {
-        val criterion = Criterion.UserDefined(build)
-        criteria.add(criterion)
-    }
+    /**
+     * Does not escape the given string.
+     */
+    fun <S : CharSequence> text(value: S): EscapeExpression
+
+    /**
+     * Escapes the given string.
+     */
+    fun <S : CharSequence> escape(value: S): EscapeExpression
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/CriteriaContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/CriteriaContext.kt
@@ -7,7 +7,7 @@ import org.komapper.core.dsl.expression.SqlBuilderScope
  * The context for criteria.
  */
 interface CriteriaContext {
-    
+
     /**
      * Adds a SQL builder.
      *

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/EscapeExpressions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/EscapeExpressions.kt
@@ -1,0 +1,40 @@
+package org.komapper.core.dsl.operator
+
+import org.komapper.core.dsl.expression.EscapeExpression
+
+/**
+ * Does not escape the given string.
+ */
+fun <S : CharSequence> text(value: S): EscapeExpression {
+    if (value is EscapeExpression) return value
+    return EscapeExpression.Text(value.toString())
+}
+
+/**
+ * Escapes the given string.
+ */
+fun <S : CharSequence> escape(value: S): EscapeExpression {
+    if (value is EscapeExpression) return value
+    return EscapeExpression.Escape(value.toString())
+}
+
+/**
+ * Escapes the given string and appends a wildcard character at the end.
+ */
+fun CharSequence.asPrefix(): EscapeExpression {
+    return escape(this) + text("%")
+}
+
+/**
+ * Escapes the given string and encloses it with wildcard characters.
+ */
+fun CharSequence.asInfix(): EscapeExpression {
+    return text("%") + escape(this) + text("%")
+}
+
+/**
+ * Escapes the given string and appends a wildcard character at the beginning.
+ */
+fun CharSequence.asSuffix(): EscapeExpression {
+    return text("%") + escape(this)
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
@@ -9,7 +9,7 @@ import org.komapper.core.dsl.operator.CriteriaContext
 /**
  * Provides operators and predicates for HAVING, ON, WHEN, and WHERE clauses.
  */
-interface FilterScope {
+interface FilterScope<F : FilterScope<F>> {
     /**
      * Applies the `=` operator.
      */
@@ -257,6 +257,21 @@ interface FilterScope {
     fun notExists(block: () -> SubqueryExpression<*>)
 
     /**
+     * Applies the `AND` operator.
+     */
+    fun and(declaration: F.() -> Unit)
+
+    /**
+     * Applies the `OR` operator.
+     */
+    fun or(declaration: F.() -> Unit)
+
+    /**
+     * Applies the `NOT` operator.
+     */
+    fun not(declaration: F.() -> Unit)
+
+    /**
      * Does not escape the given string.
      */
     fun <S : CharSequence> text(value: S): EscapeExpression {
@@ -294,11 +309,11 @@ interface FilterScope {
     }
 
     /**
-     * Adds an extension scope constructor.
+     * Adds an extension.
      *
-     * @param SCOPE the type of extension scope
-     * @param construct the extension scope constructor
+     * @param EXTENSION the type of extension
+     * @param construct the extension constructor
      * @param declaration the filter declaration
      */
-    fun <SCOPE> extension(construct: (context: CriteriaContext) -> SCOPE, declaration: SCOPE.() -> Unit)
+    fun <EXTENSION> extension(construct: (context: CriteriaContext) -> EXTENSION, declaration: EXTENSION.() -> Unit)
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
@@ -5,6 +5,9 @@ import org.komapper.core.dsl.expression.CompositeColumnExpression
 import org.komapper.core.dsl.expression.EscapeExpression
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.operator.CriteriaContext
+import org.komapper.core.dsl.operator.asInfix as asInfixFunction
+import org.komapper.core.dsl.operator.asPrefix as asPrefixFunction
+import org.komapper.core.dsl.operator.asSuffix as asSuffixFunction
 
 /**
  * Provides operators and predicates for HAVING, ON, WHEN, and WHERE clauses.
@@ -274,39 +277,27 @@ interface FilterScope<F : FilterScope<F>> {
     /**
      * Does not escape the given string.
      */
-    fun <S : CharSequence> text(value: S): EscapeExpression {
-        if (value is EscapeExpression) return value
-        return EscapeExpression.Text(value.toString())
-    }
+    fun <S : CharSequence> text(value: S): EscapeExpression = org.komapper.core.dsl.operator.text(value)
 
     /**
      * Escapes the given string.
      */
-    fun <S : CharSequence> escape(value: S): EscapeExpression {
-        if (value is EscapeExpression) return value
-        return EscapeExpression.Escape(value.toString())
-    }
+    fun <S : CharSequence> escape(value: S): EscapeExpression = org.komapper.core.dsl.operator.escape(value)
 
     /**
      * Escapes the given string and appends a wildcard character at the end.
      */
-    fun CharSequence.asPrefix(): EscapeExpression {
-        return escape(this) + text("%")
-    }
+    fun CharSequence.asPrefix(): EscapeExpression = this.asPrefixFunction()
 
     /**
      * Escapes the given string and encloses it with wildcard characters.
      */
-    fun CharSequence.asInfix(): EscapeExpression {
-        return text("%") + escape(this) + text("%")
-    }
+    fun CharSequence.asInfix(): EscapeExpression = this.asInfixFunction()
 
     /**
      * Escapes the given string and appends a wildcard character at the beginning.
      */
-    fun CharSequence.asSuffix(): EscapeExpression {
-        return text("%") + escape(this)
-    }
+    fun CharSequence.asSuffix(): EscapeExpression = this.asSuffixFunction()
 
     /**
      * Adds an extension.

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
@@ -5,13 +5,18 @@ import org.komapper.core.dsl.expression.CompositeColumnExpression
 import org.komapper.core.dsl.expression.Criterion
 import org.komapper.core.dsl.expression.EscapeExpression
 import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.expression.SqlBuilderScope
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.operator.CriteriaContext
-import org.komapper.core.dsl.operator.CriteriaContextImpl
+import java.util.Deque
+import java.util.LinkedList
 
-class FilterScopeSupport(
+class FilterScopeSupport<F : FilterScope<F>>(
+    private val constructFilterScope: (FilterScopeSupport<F>) -> F,
     private val criteria: MutableList<Criterion> = mutableListOf(),
-) : FilterScope {
+) : FilterScope<F> {
+
+    private val deque: Deque<MutableList<Criterion>> = LinkedList()
 
     fun toList(): List<Criterion> {
         return criteria.toList()
@@ -317,8 +322,40 @@ class FilterScopeSupport(
         add(Criterion.NotExists(operand))
     }
 
-    override fun <SCOPE> extension(construct: (context: CriteriaContext) -> SCOPE, declaration: SCOPE.() -> Unit) {
-        val context = CriteriaContextImpl(this, criteria)
+    override fun and(declaration: F.() -> Unit) {
+        addCriteria(declaration, Criterion::And)
+    }
+
+    override fun or(declaration: F.() -> Unit) {
+        addCriteria(declaration, Criterion::Or)
+    }
+
+    override fun not(declaration: F.() -> Unit) {
+        addCriteria(declaration, Criterion::Not)
+    }
+
+    private fun addCriteria(declaration: F.() -> Unit, operator: (List<Criterion>) -> Criterion) {
+        val newCriteria = mutableListOf<Criterion>()
+        val newSupport = FilterScopeSupport(constructFilterScope, newCriteria)
+
+        deque.push(newCriteria)
+        constructFilterScope(newSupport).apply(declaration)
+        deque.pop()
+
+        val criterion = operator(newCriteria.toList())
+        add(criterion)
+    }
+
+    override fun <EXTENSION> extension(construct: (context: CriteriaContext) -> EXTENSION, declaration: EXTENSION.() -> Unit) {
+        val context = object : CriteriaContext {
+            override fun add(build: SqlBuilderScope.() -> Unit) {
+                val criterion = Criterion.UserDefined(build)
+                val target = deque.peek() ?: criteria
+                target.add(criterion)
+            }
+            override fun <S : CharSequence> text(value: S): EscapeExpression = this@FilterScopeSupport.text(value)
+            override fun <S : CharSequence> escape(value: S): EscapeExpression = this@FilterScopeSupport.escape(value)
+        }
         val scope = construct(context)
         scope.declaration()
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
@@ -13,10 +13,9 @@ import java.util.LinkedList
 
 class FilterScopeSupport<F : FilterScope<F>>(
     private val constructFilterScope: (FilterScopeSupport<F>) -> F,
+    private val deque: Deque<MutableList<Criterion>> = LinkedList(),
     private val criteria: MutableList<Criterion> = mutableListOf(),
 ) : FilterScope<F> {
-
-    private val deque: Deque<MutableList<Criterion>> = LinkedList()
 
     fun toList(): List<Criterion> {
         return criteria.toList()
@@ -336,7 +335,7 @@ class FilterScopeSupport<F : FilterScope<F>>(
 
     private fun addCriteria(declaration: F.() -> Unit, operator: (List<Criterion>) -> Criterion) {
         val newCriteria = mutableListOf<Criterion>()
-        val newSupport = FilterScopeSupport(constructFilterScope, newCriteria)
+        val newSupport = FilterScopeSupport(constructFilterScope, deque, newCriteria)
 
         deque.push(newCriteria)
         constructFilterScope(newSupport).apply(declaration)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
@@ -353,8 +353,6 @@ class FilterScopeSupport<F : FilterScope<F>>(
                 val target = deque.peek() ?: criteria
                 target.add(criterion)
             }
-            override fun <S : CharSequence> text(value: S): EscapeExpression = this@FilterScopeSupport.text(value)
-            override fun <S : CharSequence> escape(value: S): EscapeExpression = this@FilterScopeSupport.escape(value)
         }
         val scope = construct(context)
         scope.declaration()

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/HavingScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/HavingScope.kt
@@ -1,33 +1,11 @@
 package org.komapper.core.dsl.scope
 
 import org.komapper.core.Scope
-import org.komapper.core.dsl.expression.Criterion
-import org.komapper.core.dsl.expression.HavingDeclaration
 
 /**
  * Provides operators for the HAVING clause.
  */
 @Scope
 class HavingScope(
-    private val support: FilterScopeSupport,
-) : FilterScope by support {
-
-    fun and(declaration: HavingDeclaration) {
-        addCriteria(declaration, Criterion::And)
-    }
-
-    fun or(declaration: HavingDeclaration) {
-        addCriteria(declaration, Criterion::Or)
-    }
-
-    fun not(declaration: HavingDeclaration) {
-        addCriteria(declaration, Criterion::Not)
-    }
-
-    private fun addCriteria(declaration: HavingDeclaration, operator: (List<Criterion>) -> Criterion) {
-        val newSupport = FilterScopeSupport()
-        HavingScope(newSupport).apply(declaration)
-        val criterion = operator(newSupport.toList())
-        support.add(criterion)
-    }
-}
+    private val support: FilterScopeSupport<HavingScope>,
+) : FilterScope<HavingScope> by support

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/OnScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/OnScope.kt
@@ -1,33 +1,11 @@
 package org.komapper.core.dsl.scope
 
 import org.komapper.core.Scope
-import org.komapper.core.dsl.expression.Criterion
-import org.komapper.core.dsl.expression.OnDeclaration
 
 /**
  * Provides operators for the ON clause.
  */
 @Scope
 class OnScope(
-    private val support: FilterScopeSupport,
-) : FilterScope by support {
-
-    fun and(declaration: OnDeclaration) {
-        addCriteria(declaration, Criterion::And)
-    }
-
-    fun or(declaration: OnDeclaration) {
-        addCriteria(declaration, Criterion::Or)
-    }
-
-    fun not(declaration: OnDeclaration) {
-        addCriteria(declaration, Criterion::Not)
-    }
-
-    private fun addCriteria(declaration: OnDeclaration, operator: (List<Criterion>) -> Criterion) {
-        val newSupport = FilterScopeSupport()
-        OnScope(newSupport).apply(declaration)
-        val criterion = operator(newSupport.toList())
-        support.add(criterion)
-    }
-}
+    private val support: FilterScopeSupport<OnScope>,
+) : FilterScope<OnScope> by support

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/WhenScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/WhenScope.kt
@@ -1,33 +1,11 @@
 package org.komapper.core.dsl.scope
 
 import org.komapper.core.Scope
-import org.komapper.core.dsl.expression.Criterion
-import org.komapper.core.dsl.expression.WhenDeclaration
 
 /**
  * Provides operators for the WHEN clause.
  */
 @Scope
 class WhenScope(
-    private val support: FilterScopeSupport,
-) : FilterScope by support {
-
-    fun and(declaration: WhenDeclaration) {
-        addCriteria(declaration, Criterion::And)
-    }
-
-    fun or(declaration: WhenDeclaration) {
-        addCriteria(declaration, Criterion::Or)
-    }
-
-    fun not(declaration: WhenDeclaration) {
-        addCriteria(declaration, Criterion::Not)
-    }
-
-    private fun addCriteria(declaration: WhenDeclaration, operator: (List<Criterion>) -> Criterion) {
-        val newSupport = FilterScopeSupport()
-        WhenScope(newSupport).apply(declaration)
-        val criterion = operator(newSupport.toList())
-        support.add(criterion)
-    }
-}
+    private val support: FilterScopeSupport<WhenScope>,
+) : FilterScope<WhenScope> by support

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/WhereScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/WhereScope.kt
@@ -1,33 +1,11 @@
 package org.komapper.core.dsl.scope
 
 import org.komapper.core.Scope
-import org.komapper.core.dsl.expression.Criterion
-import org.komapper.core.dsl.expression.WhereDeclaration
 
 /**
  * Provides operators for the WHERE clause.
  */
 @Scope
 class WhereScope(
-    private val support: FilterScopeSupport,
-) : FilterScope by support {
-
-    fun and(declaration: WhereDeclaration) {
-        addCriteria(declaration, Criterion::And)
-    }
-
-    fun or(declaration: WhereDeclaration) {
-        addCriteria(declaration, Criterion::Or)
-    }
-
-    fun not(declaration: WhereDeclaration) {
-        addCriteria(declaration, Criterion::Not)
-    }
-
-    private fun addCriteria(declaration: WhereDeclaration, operator: (List<Criterion>) -> Criterion) {
-        val newSupport = FilterScopeSupport()
-        WhereScope(newSupport).apply(declaration)
-        val criterion = operator(newSupport.toList())
-        support.add(criterion)
-    }
-}
+    private val support: FilterScopeSupport<WhereScope>,
+) : FilterScope<WhereScope> by support


### PR DESCRIPTION

With this fix, the following query will work correctly.

```kotlin
QueryDsl.from(e).where {
    e.salary greaterEq BigDecimal(1000)
    extension(::MyExtension) {
        e.employeeName `~` "S"
        or {
            e.employeeName `~` "T"
        }
    }
}.orderBy(e.employeeName)
```

```kotlin
class MyExtension(private val context: CriteriaContext) {

    infix fun <T : Any> ColumnExpression<T, String>.`~`(pattern: T?) {
        if (pattern == null) return
        val o1 = Operand.Column(this)
        val o2 = Operand.Argument(this, pattern)
        context.add {
            visit(o1)
            append(" ~ ")
            visit(o2)
        }
    }

    infix fun <T : Any> ColumnExpression<T, String>.`!~`(pattern: T?) {
        if (pattern == null) return
        val o1 = Operand.Column(this)
        val o2 = Operand.Argument(this, pattern)
        context.add {
            visit(o1)
            append(" !~ ")
            visit(o2)
        }
    }
}
```