### PR TITLE
Support MySQL 5.7

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/Dbms.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Dbms.kt
@@ -1,5 +1,5 @@
 package integration.core
 
 enum class Dbms {
-    H2, MARIADB, MYSQL, ORACLE, POSTGRESQL, SQLSERVER
+    H2, MARIADB, MYSQL_5, MYSQL, ORACLE, POSTGRESQL, SQLSERVER
 }

--- a/integration-test-core/src/main/kotlin/integration/core/MySql5Setting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/MySql5Setting.kt
@@ -1,0 +1,118 @@
+package integration.core
+
+import org.komapper.core.Database
+
+interface MySql5Setting<DATABASE : Database> : Setting<DATABASE> {
+    override val dbms: Dbms get() = Dbms.MYSQL_5
+    override val createSql: String
+        get() = """
+        create table if not exists department_archive(department_id integer not null primary key, department_no integer not null unique,department_name varchar(20),location varchar(20) default 'tokyo', version integer);
+        create table if not exists department(department_id integer not null primary key, department_no integer not null unique,department_name varchar(20),location varchar(20) default 'tokyo', version integer);
+        create table if not exists address(address_id integer not null primary key, street varchar(20) unique, version integer);
+        create table if not exists address_archive(address_id integer not null primary key, street varchar(20) unique, version integer);
+        create table if not exists employee(employee_id integer not null primary key, employee_no integer not null ,employee_name varchar(20),manager_id integer,hiredate date,salary numeric(7,2),department_id integer,address_id integer, version integer, constraint fk_department_id foreign key(department_id) references department(department_id),constraint fk_address_id foreign key(address_id) references address(address_id));
+        create table if not exists human(human_id integer not null primary key, name varchar(20), created_at timestamp NULL DEFAULT NULL, updated_at timestamp NULL DEFAULT NULL, version integer);
+        create table if not exists person(person_id integer not null primary key, name varchar(20), created_at datetime(6), updated_at datetime(6), version integer);
+        create table if not exists `order`(`order_id` integer not null primary key, `value` varchar(20));
+
+        create table if not exists comp_key_department(department_id1 integer not null, department_id2 integer not null, department_no integer not null unique,department_name varchar(20),location varchar(20) default 'tokyo', version integer, constraint pk_comp_key_department primary key(department_id1, department_id2));
+        create table if not exists comp_key_address(address_id1 integer not null, address_id2 integer not null, street varchar(20), version integer, constraint pk_comp_key_address primary key(address_id1, address_id2));
+        create table if not exists comp_key_employee(employee_id1 integer not null, employee_id2 integer not null, employee_no integer not null ,employee_name varchar(20),manager_id1 integer,manager_id2 integer,hiredate date,salary numeric(7,2),department_id1 integer,department_id2 integer,address_id1 integer,address_id2 integer,version integer, constraint pk_comp_key_employee primary key(employee_id1, employee_id2), constraint fk_comp_key_department_id foreign key(department_id1, department_id2) references comp_key_department(department_id1, department_id2), constraint fk_comp_key_address_id foreign key(address_id1, address_id2) references comp_key_address(address_id1, address_id2));
+
+        create table if not exists identity_strategy(id integer auto_increment primary key, value varchar(10));
+        create table if not exists sequence_strategy(id integer not null primary key, value varchar(10));
+
+        create table if not exists big_decimal_data(id integer not null primary key, value decimal);
+        create table if not exists big_integer_data(id integer not null primary key, value decimal);
+        create table if not exists blob_data(id integer not null primary key, value blob);
+        create table if not exists boolean_data(id integer not null primary key, value boolean);
+        create table if not exists byte_data(id integer not null primary key, value int2);
+        create table if not exists byte_array_data(id integer not null primary key, value varbinary(100));
+        create table if not exists clob_data(id integer not null primary key, value text);
+        create table if not exists double_data(id integer not null primary key, value double);
+        create table if not exists enum_data(id integer not null primary key, value varchar(20));
+        create table if not exists enum_ordinal_data(id integer not null primary key, value integer);
+        create table if not exists enum_property_data(id integer not null primary key, value integer);
+        create table if not exists float_data(id integer not null primary key, value float);
+        create table if not exists instant_data(id integer not null primary key, value timestamp);
+        create table if not exists int_data(id integer not null primary key, value integer);
+        create table if not exists local_date_time_data(id integer not null primary key, value datetime);
+        create table if not exists local_date_data(id integer not null primary key, value date);
+        create table if not exists local_time_data(id integer not null primary key, value time);
+        create table if not exists long_data(id integer not null primary key, value bigint);
+        create table if not exists offset_date_time_data(id integer not null primary key, value timestamp);
+        create table if not exists short_data(id integer not null primary key, value smallint);
+        create table if not exists string_data(id integer not null primary key, value varchar(20));
+
+        insert into department values(1,10,'ACCOUNTING','NEW YORK',1);
+        insert into department values(2,20,'RESEARCH','DALLAS',1);
+        insert into department values(3,30,'SALES','CHICAGO',1);
+        insert into department values(4,40,'OPERATIONS','BOSTON',1);
+        insert into address values(1,'STREET 1',1);
+        insert into address values(2,'STREET 2',1);
+        insert into address values(3,'STREET 3',1);
+        insert into address values(4,'STREET 4',1);
+        insert into address values(5,'STREET 5',1);
+        insert into address values(6,'STREET 6',1);
+        insert into address values(7,'STREET 7',1);
+        insert into address values(8,'STREET 8',1);
+        insert into address values(9,'STREET 9',1);
+        insert into address values(10,'STREET 10',1);
+        insert into address values(11,'STREET 11',1);
+        insert into address values(12,'STREET 12',1);
+        insert into address values(13,'STREET 13',1);
+        insert into address values(14,'STREET 14',1);
+        insert into address values(15,'STREET 15',1);
+        insert into employee values(1,7369,'SMITH',13,'1980-12-17',800,2,1,1);
+        insert into employee values(2,7499,'ALLEN',6,'1981-02-20',1600,3,2,1);
+        insert into employee values(3,7521,'WARD',6,'1981-02-22',1250,3,3,1);
+        insert into employee values(4,7566,'JONES',9,'1981-04-02',2975,2,4,1);
+        insert into employee values(5,7654,'MARTIN',6,'1981-09-28',1250,3,5,1);
+        insert into employee values(6,7698,'BLAKE',9,'1981-05-01',2850,3,6,1);
+        insert into employee values(7,7782,'CLARK',9,'1981-06-09',2450,1,7,1);
+        insert into employee values(8,7788,'SCOTT',4,'1982-12-09',3000.0,2,8,1);
+        insert into employee values(9,7839,'KING',NULL,'1981-11-17',5000,1,9,1);
+        insert into employee values(10,7844,'TURNER',6,'1981-09-08',1500,3,10,1);
+        insert into employee values(11,7876,'ADAMS',8,'1983-01-12',1100,2,11,1);
+        insert into employee values(12,7900,'JAMES',6,'1981-12-03',950,3,12,1);
+        insert into employee values(13,7902,'FORD',4,'1981-12-03',3000,2,13,1);
+        insert into employee values(14,7934,'MILLER',7,'1982-01-23',1300,1,14,1);
+
+        insert into comp_key_department VALUES(1,1,10,'ACCOUNTING','NEW YORK',1);
+        insert into comp_key_department VALUES(2,2,20,'RESEARCH','DALLAS',1);
+        insert into comp_key_department VALUES(3,3,30,'SALES','CHICAGO',1);
+        insert into comp_key_department VALUES(4,4,40,'OPERATIONS','BOSTON',1);
+        insert into comp_key_address values(1,1,'STREET 1',1);
+        insert into comp_key_address values(2,2,'STREET 2',1);
+        insert into comp_key_address values(3,3,'STREET 3',1);
+        insert into comp_key_address values(4,4,'STREET 4',1);
+        insert into comp_key_address values(5,5,'STREET 5',1);
+        insert into comp_key_address values(6,6,'STREET 6',1);
+        insert into comp_key_address values(7,7,'STREET 7',1);
+        insert into comp_key_address values(8,8,'STREET 8',1);
+        insert into comp_key_address values(9,9,'STREET 9',1);
+        insert into comp_key_address values(10,10,'STREET 10',1);
+        insert into comp_key_address values(11,11,'STREET 11',1);
+        insert into comp_key_address values(12,12,'STREET 12',1);
+        insert into comp_key_address values(13,13,'STREET 13',1);
+        insert into comp_key_address values(14,14,'STREET 14',1);
+        insert into comp_key_employee values(1,1,7369,'SMITH',13,13,'1980-12-17',800,2,2,1,1,1);
+        insert into comp_key_employee values(2,2,7499,'ALLEN',6,6,'1981-02-20',1600,3,3,2,2,1);
+        insert into comp_key_employee values(3,3,7521,'WARD',6,6,'1981-02-22',1250,3,3,3,3,1);
+        insert into comp_key_employee values(4,4,7566,'JONES',9,9,'1981-04-02',2975,2,2,4,4,1);
+        insert into comp_key_employee values(5,5,7654,'MARTIN',6,6,'1981-09-28',1250,3,3,5,5,1);
+        insert into comp_key_employee values(6,6,7698,'BLAKE',9,9,'1981-05-01',2850,3,3,6,6,1);
+        insert into comp_key_employee values(7,7,7782,'CLARK',9,9,'1981-06-09',2450,1,1,7,7,1);
+        insert into comp_key_employee values(8,8,7788,'SCOTT',4,4,'1982-12-09',3000.0,2,2,8,8,1);
+        insert into comp_key_employee values(9,9,7839,'KING',NULL,NULL,'1981-11-17',5000,1,1,9,9,1);
+        insert into comp_key_employee values(10,10,7844,'TURNER',6,6,'1981-09-08',1500,3,3,10,10,1);
+        insert into comp_key_employee values(11,11,7876,'ADAMS',8,8,'1983-01-12',1100,2,2,11,11,1);
+        insert into comp_key_employee values(12,12,7900,'JAMES',6,6,'1981-12-03',950,3,3,12,12,1);
+        insert into comp_key_employee values(13,13,7902,'FORD',4,4,'1981-12-03',3000,2,2,13,13,1);
+        insert into comp_key_employee values(14,14,7934,'MILLER',7,7,'1982-01-23',1300,1,1,14,14,1);
+        """.trimIndent()
+    override val resetSql: String
+        get() = """
+        alter table identity_strategy auto_increment = 1
+        """.trimIndent()
+}

--- a/integration-test-jdbc/build.gradle.kts
+++ b/integration-test-jdbc/build.gradle.kts
@@ -74,6 +74,15 @@ testing {
             }
         }
 
+        register("mysql5", JvmTestSuite::class) {
+            setup(name)
+            dependencies {
+                implementation(project())
+                runtimeOnly("org.testcontainers:mysql")
+                implementation(project(":komapper-dialect-mysql-jdbc"))
+            }
+        }
+
         register("oracle", JvmTestSuite::class) {
             setup(name)
             dependencies {

--- a/integration-test-jdbc/build.gradle.kts
+++ b/integration-test-jdbc/build.gradle.kts
@@ -112,10 +112,10 @@ testing {
     }
 }
 
-fun JvmTestSuite.setup(driver: String) {
+fun JvmTestSuite.setup(identifier: String) {
     sources {
         java {
-            setSrcDirs(listOf("src/test/kotlin", "build/generated/ksp/$driver/kotlin"))
+            setSrcDirs(listOf("src/test/kotlin", "build/generated/ksp/$identifier/kotlin"))
         }
         resources {
             setSrcDirs(listOf("src/test/resources"))
@@ -124,9 +124,9 @@ fun JvmTestSuite.setup(driver: String) {
     targets {
         all {
             testTask.configure {
-                val urlKey = "$driver.url"
+                val urlKey = "$identifier.url"
                 val url = project.property(urlKey) ?: throw GradleException("The $urlKey property is not found.")
-                systemProperty("driver", driver)
+                systemProperty("identifier", identifier)
                 systemProperty("url", url)
             }
         }

--- a/integration-test-jdbc/gradle.properties
+++ b/integration-test-jdbc/gradle.properties
@@ -3,6 +3,7 @@ description=Komapper Integration Test for R2DBC
 h2.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
 mariadb.url=jdbc:tc:mariadb:10.6.3:///test?TC_DAEMON=true
 mysql.url=jdbc:tc:mysql:8.0.25:///test?TC_DAEMON=true
+mysql5.url=jdbc:tc:mysql:5.7.44:///test?TC_DAEMON=true
 oracle.url=jdbc:tc:oracle:thin:@test?TC_DAEMON=true
 postgresql.url=jdbc:tc:postgresql:12.9:///test?TC_DAEMON=true
 sqlserver.url=jdbc:tc:sqlserver:2019-CU12-ubuntu-20.04:///test?TC_DAEMON=true

--- a/integration-test-jdbc/src/h2/kotlin/integration/jdbc/h2/JdbcH2Setting.kt
+++ b/integration-test-jdbc/src/h2/kotlin/integration/jdbc/h2/JdbcH2Setting.kt
@@ -5,7 +5,7 @@ import org.komapper.core.ExecutionOptions
 import org.komapper.jdbc.JdbcDatabase
 
 @Suppress("unused")
-class JdbcH2Setting(private val driver: String, url: String) : H2Setting<JdbcDatabase> {
+class JdbcH2Setting(url: String) : H2Setting<JdbcDatabase> {
     override val database: JdbcDatabase = JdbcDatabase(
         url,
         executionOptions = ExecutionOptions(batchSize = 2),

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/JdbcSettingProvider.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/JdbcSettingProvider.kt
@@ -6,9 +6,9 @@ import org.komapper.jdbc.JdbcDatabase
 object JdbcSettingProvider {
 
     fun get(): Setting<JdbcDatabase> {
-        val driver = System.getProperty("driver") ?: error("The driver property is not found.")
+        val identifier = System.getProperty("identifier") ?: error("The identifier property is not found.")
         val url = System.getProperty("url") ?: error("The url property is not found.")
-        val className = when (driver) {
+        val className = when (identifier) {
             "h2" -> "integration.jdbc.h2.JdbcH2Setting"
             "mariadb" -> "integration.jdbc.mariadb.JdbcMariaDbSetting"
             "mysql" -> "integration.jdbc.mysql.JdbcMySqlSetting"
@@ -16,11 +16,11 @@ object JdbcSettingProvider {
             "oracle" -> "integration.jdbc.oracle.JdbcOracleSetting"
             "postgresql" -> "integration.jdbc.postgresql.JdbcPostgreSqlSetting"
             "sqlserver" -> "integration.jdbc.sqlserver.JdbcSqlServerSetting"
-            else -> error("Unsupported driver: $driver")
+            else -> error("Unsupported database: $identifier")
         }
         val clazz = Class.forName(className) ?: error("Invalid className: $className")
-        val constructor = clazz.getDeclaredConstructor(String::class.java, String::class.java)
+        val constructor = clazz.getDeclaredConstructor(String::class.java)
         @Suppress("UNCHECKED_CAST")
-        return constructor.newInstance(driver, url) as Setting<JdbcDatabase>
+        return constructor.newInstance(url) as Setting<JdbcDatabase>
     }
 }

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/JdbcSettingProvider.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/JdbcSettingProvider.kt
@@ -12,6 +12,7 @@ object JdbcSettingProvider {
             "h2" -> "integration.jdbc.h2.JdbcH2Setting"
             "mariadb" -> "integration.jdbc.mariadb.JdbcMariaDbSetting"
             "mysql" -> "integration.jdbc.mysql.JdbcMySqlSetting"
+            "mysql5" -> "integration.jdbc.mysql5.JdbcMySql5Setting"
             "oracle" -> "integration.jdbc.oracle.JdbcOracleSetting"
             "postgresql" -> "integration.jdbc.postgresql.JdbcPostgreSqlSetting"
             "sqlserver" -> "integration.jdbc.sqlserver.JdbcSqlServerSetting"

--- a/integration-test-jdbc/src/mariadb/kotlin/integration/jdbc/mariadb/JdbcMariaDbSetting.kt
+++ b/integration-test-jdbc/src/mariadb/kotlin/integration/jdbc/mariadb/JdbcMariaDbSetting.kt
@@ -5,7 +5,7 @@ import org.komapper.core.ExecutionOptions
 import org.komapper.jdbc.JdbcDatabase
 
 @Suppress("unused")
-class JdbcMariaDbSetting(private val driver: String, url: String) : MariaDbSetting<JdbcDatabase> {
+class JdbcMariaDbSetting(url: String) : MariaDbSetting<JdbcDatabase> {
     override val database: JdbcDatabase = JdbcDatabase(
         url,
         "test",

--- a/integration-test-jdbc/src/mysql/kotlin/integration/jdbc/mysql/JdbcMySqlSetting.kt
+++ b/integration-test-jdbc/src/mysql/kotlin/integration/jdbc/mysql/JdbcMySqlSetting.kt
@@ -5,7 +5,7 @@ import org.komapper.core.ExecutionOptions
 import org.komapper.jdbc.JdbcDatabase
 
 @Suppress("unused")
-class JdbcMySqlSetting(private val driver: String, url: String) : MySqlSetting<JdbcDatabase> {
+class JdbcMySqlSetting(url: String) : MySqlSetting<JdbcDatabase> {
     override val database: JdbcDatabase = JdbcDatabase(
         url,
         "test",

--- a/integration-test-jdbc/src/mysql5/kotlin/integration/jdbc/mysql5/JdbcMySql5Mapping.kt
+++ b/integration-test-jdbc/src/mysql5/kotlin/integration/jdbc/mysql5/JdbcMySql5Mapping.kt
@@ -1,0 +1,43 @@
+package integration.jdbc.mysql5
+
+import org.komapper.annotation.KomapperColumn
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperId
+import org.komapper.annotation.KomapperTable
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.sql.Blob
+import java.sql.Clob
+import java.sql.NClob
+import java.sql.SQLXML
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@KomapperEntity
+@KomapperTable
+data class JdbcMySql5Mapping(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val bigDecimal: BigDecimal,
+    @KomapperColumn(alwaysQuote = true) val bigInteger: BigInteger,
+    @KomapperColumn(alwaysQuote = true) val blob: Blob,
+    @KomapperColumn(alwaysQuote = true) val boolean: Boolean,
+    @KomapperColumn(alwaysQuote = true) val byte: Byte,
+    @KomapperColumn(alwaysQuote = true) val double: Double,
+    @KomapperColumn(alwaysQuote = true) val clob: Clob,
+    @KomapperColumn(alwaysQuote = true) val float: Float,
+    @KomapperColumn(alwaysQuote = true) val instant: Instant,
+    @KomapperColumn(alwaysQuote = true) val localDateTime: LocalDateTime,
+    @KomapperColumn(alwaysQuote = true) val localDate: LocalDate,
+    @KomapperColumn(alwaysQuote = true) val localTime: LocalTime,
+    @KomapperColumn(alwaysQuote = true) val long: Long,
+    @KomapperColumn(alwaysQuote = true) val nClob: NClob,
+//  @KomapperColumn(alwaysQuote = true) val offsetDateTime: OffsetDateTime,
+    @KomapperColumn(alwaysQuote = true) val short: Short,
+    @KomapperColumn(alwaysQuote = true) val string: String,
+    @KomapperColumn(alwaysQuote = true) val sqlxml: SQLXML,
+    @KomapperColumn(alwaysQuote = true) val uByte: UByte,
+    @KomapperColumn(alwaysQuote = true) val uInt: UInt,
+    @KomapperColumn(alwaysQuote = true) val uShort: UShort,
+)

--- a/integration-test-jdbc/src/mysql5/kotlin/integration/jdbc/mysql5/JdbcMySql5MappingTest.kt
+++ b/integration-test-jdbc/src/mysql5/kotlin/integration/jdbc/mysql5/JdbcMySql5MappingTest.kt
@@ -1,0 +1,25 @@
+package integration.jdbc.mysql5
+
+import integration.jdbc.JdbcEnv
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.jdbc.JdbcDatabase
+
+@ExtendWith(JdbcEnv::class)
+class JdbcMySql5MappingTest(private val db: JdbcDatabase) {
+
+    @Test
+    fun test() {
+        db.runQuery {
+            QueryDsl.create(Meta.jdbcMySql5Mapping)
+        }
+        db.runQuery {
+            QueryDsl.from(Meta.jdbcMySql5Mapping)
+        }
+        db.runQuery {
+            QueryDsl.drop(Meta.jdbcMySql5Mapping)
+        }
+    }
+}

--- a/integration-test-jdbc/src/mysql5/kotlin/integration/jdbc/mysql5/JdbcMySql5Setting.kt
+++ b/integration-test-jdbc/src/mysql5/kotlin/integration/jdbc/mysql5/JdbcMySql5Setting.kt
@@ -7,7 +7,7 @@ import org.komapper.dialect.mysql.jdbc.MySqlJdbcDialect
 import org.komapper.jdbc.JdbcDatabase
 
 @Suppress("unused")
-class JdbcMySql5Setting(private val driver: String, url: String) : MySql5Setting<JdbcDatabase> {
+class JdbcMySql5Setting(url: String) : MySql5Setting<JdbcDatabase> {
     override val database: JdbcDatabase = JdbcDatabase(
         url,
         "test",

--- a/integration-test-jdbc/src/mysql5/kotlin/integration/jdbc/mysql5/JdbcMySql5Setting.kt
+++ b/integration-test-jdbc/src/mysql5/kotlin/integration/jdbc/mysql5/JdbcMySql5Setting.kt
@@ -1,0 +1,18 @@
+package integration.jdbc.mysql5
+
+import integration.core.MySql5Setting
+import org.komapper.core.ExecutionOptions
+import org.komapper.dialect.mysql.MySqlVersion
+import org.komapper.dialect.mysql.jdbc.MySqlJdbcDialect
+import org.komapper.jdbc.JdbcDatabase
+
+@Suppress("unused")
+class JdbcMySql5Setting(private val driver: String, url: String) : MySql5Setting<JdbcDatabase> {
+    override val database: JdbcDatabase = JdbcDatabase(
+        url,
+        "test",
+        "test",
+        dialect = MySqlJdbcDialect(MySqlVersion.V5),
+        executionOptions = ExecutionOptions(batchSize = 2),
+    )
+}

--- a/integration-test-jdbc/src/oracle/kotlin/integration/jdbc/oracle/JdbcOracleSetting.kt
+++ b/integration-test-jdbc/src/oracle/kotlin/integration/jdbc/oracle/JdbcOracleSetting.kt
@@ -5,7 +5,7 @@ import org.komapper.core.ExecutionOptions
 import org.komapper.jdbc.JdbcDatabase
 
 @Suppress("unused")
-class JdbcOracleSetting(private val driver: String, url: String) : OracleSetting<JdbcDatabase> {
+class JdbcOracleSetting(url: String) : OracleSetting<JdbcDatabase> {
     override val database: JdbcDatabase = JdbcDatabase(
         url,
         "test",

--- a/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/JdbcPostgreSqlSetting.kt
+++ b/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/JdbcPostgreSqlSetting.kt
@@ -6,7 +6,7 @@ import org.komapper.jdbc.JdbcDataTypeProvider
 import org.komapper.jdbc.JdbcDatabase
 
 @Suppress("unused")
-class JdbcPostgreSqlSetting(private val driver: String, url: String) : PostgreSqlSetting<JdbcDatabase> {
+class JdbcPostgreSqlSetting(url: String) : PostgreSqlSetting<JdbcDatabase> {
 
     override val database: JdbcDatabase by lazy {
         val dataTypeProvider = JdbcDataTypeProvider(PostgreSqlJsonType())

--- a/integration-test-jdbc/src/sqlserver/kotlin/integration/jdbc/sqlserver/JdbcSqlServerSetting.kt
+++ b/integration-test-jdbc/src/sqlserver/kotlin/integration/jdbc/sqlserver/JdbcSqlServerSetting.kt
@@ -5,7 +5,7 @@ import org.komapper.core.ExecutionOptions
 import org.komapper.jdbc.JdbcDatabase
 
 @Suppress("unused")
-class JdbcSqlServerSetting(private val driver: String, url: String) : SqlServerSetting<JdbcDatabase> {
+class JdbcSqlServerSetting(url: String) : SqlServerSetting<JdbcDatabase> {
     override val database: JdbcDatabase = JdbcDatabase(
         url,
         "test",

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDataTypeTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDataTypeTest.kt
@@ -661,7 +661,7 @@ class JdbcDataTypeTest(val db: JdbcDatabase) {
         assertEquals(data, data3)
     }
 
-    @Run(unless = [Dbms.MARIADB])
+    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
     @Test
     fun instant_null() {
         val m = Meta.instantData
@@ -846,7 +846,7 @@ class JdbcDataTypeTest(val db: JdbcDatabase) {
         assertEquals(data, data3)
     }
 
-    @Run(onlyIf = [Dbms.MYSQL])
+    @Run(onlyIf = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun offsetDateTime_mysql() {
         val m = Meta.offsetDateTimeData
@@ -879,7 +879,7 @@ class JdbcDataTypeTest(val db: JdbcDatabase) {
         assertEquals(value.toInstant(), data2.value!!.toInstant())
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MYSQL, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
     @Test
     fun offsetDateTime_null() {
         val m = Meta.offsetDateTimeData
@@ -1070,7 +1070,7 @@ class JdbcDataTypeTest(val db: JdbcDatabase) {
         assertNotNull(data2)
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun unsigned_sequence() {
         val m = Meta.unsignedSequenceStrategy

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
@@ -281,7 +281,7 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun sequenceGenerator() {
         val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
@@ -295,7 +295,7 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun sequenceGenerator_disableSequenceAssignment() {
         val m = Meta.sequenceStrategy
@@ -356,7 +356,7 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB])
+    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
     fun onDuplicateKeyUpdate_update_set() {
         val d = Meta.department
         val department = Department(1, 50, "PLANNING", "TOKYO", 10)
@@ -373,7 +373,7 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB])
+    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
     fun onDuplicateKeyUpdateWithKey_update_set() {
         val d = Meta.department
         val department = Department(5, 10, "PLANNING", "TOKYO", 10)
@@ -434,7 +434,7 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
     }
 
     @Test
-    @Run(onlyIf = [Dbms.MARIADB, Dbms.MYSQL])
+    @Run(onlyIf = [Dbms.MARIADB, Dbms.MYSQL, Dbms.MYSQL_5])
     fun onDuplicateKeyUpdateWithKey_update_set_where_unsupported() {
         val d = Meta.department
         val department = Department(5, 10, "PLANNING", "TOKYO", 10)

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
@@ -356,7 +356,7 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
+    @Run(unless = [Dbms.MARIADB])
     fun onDuplicateKeyUpdate_update_set() {
         val d = Meta.department
         val department = Department(1, 50, "PLANNING", "TOKYO", 10)
@@ -373,7 +373,7 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
+    @Run(unless = [Dbms.MARIADB])
     fun onDuplicateKeyUpdateWithKey_update_set() {
         val d = Meta.department
         val department = Department(5, 10, "PLANNING", "TOKYO", 10)

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertValuesTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertValuesTest.kt
@@ -80,7 +80,7 @@ class JdbcInsertValuesTest(private val db: JdbcDatabase) {
         assertIs<Int>(id)
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun generatedKeys_sequence() {
         val a = Meta.sequenceStrategy

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcScriptTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcScriptTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
 @ExtendWith(JdbcEnv::class)
 internal class JdbcScriptTest(private val db: JdbcDatabase) {
 
-    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL])
+    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun test_double_quote() {
         db.runQuery {
@@ -40,7 +40,7 @@ internal class JdbcScriptTest(private val db: JdbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.MARIADB, Dbms.MYSQL])
+    @Run(onlyIf = [Dbms.MARIADB, Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun test_back_quote() {
         db.runQuery {

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSetOperationTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSetOperationTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertNull
 @ExtendWith(JdbcEnv::class)
 class JdbcSetOperationTest(private val db: JdbcDatabase) {
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun except_entity() {
         val e = Meta.employee
@@ -41,7 +41,7 @@ class JdbcSetOperationTest(private val db: JdbcDatabase) {
         assertEquals(5, e3.employeeId)
     }
 
-    @Run(onlyIf = [Dbms.MYSQL])
+    @Run(onlyIf = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun except_entity_unsupportedOperationException() {
         val e = Meta.employee
@@ -55,7 +55,7 @@ class JdbcSetOperationTest(private val db: JdbcDatabase) {
         println(ex)
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun intersect_entity() {
         val e = Meta.employee
@@ -70,7 +70,7 @@ class JdbcSetOperationTest(private val db: JdbcDatabase) {
         assertEquals(4, e2.employeeId)
     }
 
-    @Run(onlyIf = [Dbms.MYSQL])
+    @Run(onlyIf = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun intersect_entity_unsupportedOperationException() {
         val e = Meta.employee
@@ -100,6 +100,7 @@ class JdbcSetOperationTest(private val db: JdbcDatabase) {
     }
 
     @Test
+    @Run(unless = [Dbms.MYSQL_5])
     fun union_subquery() {
         val e = Meta.employee
         val q1 = QueryDsl.from(e).where { e.employeeId eq 1 }.select(e.employeeId)

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcValueClassTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcValueClassTest.kt
@@ -140,7 +140,7 @@ class JdbcValueClassTest(val db: JdbcDatabase) {
         }
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun sequenceGenerator() {
         for (i in 1..201) {

--- a/integration-test-r2dbc/build.gradle.kts
+++ b/integration-test-r2dbc/build.gradle.kts
@@ -70,6 +70,16 @@ testing {
             }
         }
 
+        register("mysql5", JvmTestSuite::class) {
+            setup(name)
+            dependencies {
+                implementation(project())
+                implementation("org.testcontainers:mysql")
+                implementation(project(":komapper-dialect-mysql-r2dbc"))
+                runtimeOnly("mysql:mysql-connector-java:8.0.33")
+            }
+        }
+
         register("oracle", JvmTestSuite::class) {
             setup(name)
             dependencies {

--- a/integration-test-r2dbc/build.gradle.kts
+++ b/integration-test-r2dbc/build.gradle.kts
@@ -110,12 +110,10 @@ testing {
     }
 }
 
-fun JvmTestSuite.setup(
-    driver: String,
-) {
+fun JvmTestSuite.setup(identifier: String) {
     sources {
         java {
-            setSrcDirs(listOf("src/test/kotlin", "build/generated/ksp/$driver/kotlin"))
+            setSrcDirs(listOf("src/test/kotlin", "build/generated/ksp/$identifier/kotlin"))
         }
         resources {
             setSrcDirs(listOf("src/test/resources"))
@@ -124,9 +122,9 @@ fun JvmTestSuite.setup(
     targets {
         all {
             testTask.configure {
-                val urlKey = "$driver.url"
+                val urlKey = "$identifier.url"
                 val url = project.property(urlKey) ?: throw GradleException("The $urlKey property is not found.")
-                systemProperty("driver", driver)
+                systemProperty("identifier", identifier)
                 systemProperty("url", url)
             }
         }

--- a/integration-test-r2dbc/gradle.properties
+++ b/integration-test-r2dbc/gradle.properties
@@ -3,6 +3,7 @@ description=Komapper Integration Test for R2DBC
 h2.url=r2dbc:h2:mem:///test?DB_CLOSE_DELAY=-1
 mariadb.url=jdbc:tc:mariadb:10.6.3:///test?TC_DAEMON=true
 mysql.url=jdbc:tc:mysql:8.0.25:///test?TC_DAEMON=true
+mysql5.url=jdbc:tc:mysql:5.7.44:///test?TC_DAEMON=true
 oracle.url=jdbc:tc:oracle:thin:@test?TC_DAEMON=true
 postgresql.url=jdbc:tc:postgresql:12.9:///test?TC_DAEMON=true
 sqlserver.url=jdbc:tc:sqlserver:2019-CU12-ubuntu-20.04:///test?TC_DAEMON=true

--- a/integration-test-r2dbc/src/h2/kotlin/integration/r2dbc/h2/R2dbcH2Setting.kt
+++ b/integration-test-r2dbc/src/h2/kotlin/integration/r2dbc/h2/R2dbcH2Setting.kt
@@ -4,7 +4,7 @@ import integration.core.H2Setting
 import org.komapper.core.ExecutionOptions
 import org.komapper.r2dbc.R2dbcDatabase
 
-class R2dbcH2Setting(private val driver: String, url: String) : H2Setting<R2dbcDatabase> {
+class R2dbcH2Setting(url: String) : H2Setting<R2dbcDatabase> {
     override val database: R2dbcDatabase = R2dbcDatabase(
         url = url,
         executionOptions = ExecutionOptions(batchSize = 2),

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/R2dbcSettingProvider.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/R2dbcSettingProvider.kt
@@ -12,6 +12,7 @@ object R2dbcSettingProvider {
             "h2" -> "integration.r2dbc.h2.R2dbcH2Setting"
             "mariadb" -> "integration.r2dbc.mariadb.R2dbcMariaDbSetting"
             "mysql" -> "integration.r2dbc.mysql.R2dbcMySqlSetting"
+            "mysql5" -> "integration.r2dbc.mysql5.R2dbcMySql5Setting"
             "oracle" -> "integration.r2dbc.oracle.R2dbcOracleSetting"
             "postgresql" -> "integration.r2dbc.postgresql.R2dbcPostgreSqlSetting"
             "sqlserver" -> "integration.r2dbc.sqlserver.R2dbcSqlServerSetting"

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/R2dbcSettingProvider.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/R2dbcSettingProvider.kt
@@ -6,9 +6,9 @@ import org.komapper.r2dbc.R2dbcDatabase
 object R2dbcSettingProvider {
 
     fun get(): Setting<R2dbcDatabase> {
-        val driver = System.getProperty("driver") ?: error("The driver property is not found.")
+        val identifier = System.getProperty("identifier") ?: error("The identifier property is not found.")
         val url = System.getProperty("url") ?: error("The url property is not found.")
-        val className = when (driver) {
+        val className = when (identifier) {
             "h2" -> "integration.r2dbc.h2.R2dbcH2Setting"
             "mariadb" -> "integration.r2dbc.mariadb.R2dbcMariaDbSetting"
             "mysql" -> "integration.r2dbc.mysql.R2dbcMySqlSetting"
@@ -16,11 +16,11 @@ object R2dbcSettingProvider {
             "oracle" -> "integration.r2dbc.oracle.R2dbcOracleSetting"
             "postgresql" -> "integration.r2dbc.postgresql.R2dbcPostgreSqlSetting"
             "sqlserver" -> "integration.r2dbc.sqlserver.R2dbcSqlServerSetting"
-            else -> error("Unsupported driver: $driver")
+            else -> error("Unsupported database: $identifier")
         }
         val clazz = Class.forName(className) ?: error("Invalid className: $className")
-        val constructor = clazz.getDeclaredConstructor(String::class.java, String::class.java)
+        val constructor = clazz.getDeclaredConstructor(String::class.java)
         @Suppress("UNCHECKED_CAST")
-        return constructor.newInstance(driver, url) as Setting<R2dbcDatabase>
+        return constructor.newInstance(url) as Setting<R2dbcDatabase>
     }
 }

--- a/integration-test-r2dbc/src/mariadb/kotlin/integration/r2dbc/mariadb/R2dbcMariaDbSetting.kt
+++ b/integration-test-r2dbc/src/mariadb/kotlin/integration/r2dbc/mariadb/R2dbcMariaDbSetting.kt
@@ -11,7 +11,7 @@ import org.testcontainers.containers.MariaDBR2DBCDatabaseContainer
 import org.testcontainers.jdbc.ConnectionUrl
 
 @Suppress("unused")
-class R2dbcMariaDbSetting(private val driver: String, private val url: String) :
+class R2dbcMariaDbSetting(private val url: String) :
     MariaDbSetting<R2dbcDatabase> {
 
     private val options: ConnectionFactoryOptions by lazy {
@@ -22,7 +22,7 @@ class R2dbcMariaDbSetting(private val driver: String, private val url: String) :
         r2dbcContainer.configure(
             ConnectionFactoryOptions.builder()
                 .option(ConnectionFactoryOptions.DRIVER, "pool")
-                .option(ConnectionFactoryOptions.PROTOCOL, driver)
+                .option(ConnectionFactoryOptions.PROTOCOL, "mariadb")
                 .option(Option.valueOf("initialSize"), 2)
                 .build(),
         )

--- a/integration-test-r2dbc/src/mysql/kotlin/integration/r2dbc/mysql/R2dbcMySqlSetting.kt
+++ b/integration-test-r2dbc/src/mysql/kotlin/integration/r2dbc/mysql/R2dbcMySqlSetting.kt
@@ -11,7 +11,7 @@ import org.testcontainers.containers.MySQLR2DBCDatabaseContainer
 import org.testcontainers.jdbc.ConnectionUrl
 
 @Suppress("unused")
-class R2dbcMySqlSetting(private val driver: String, private val url: String) :
+class R2dbcMySqlSetting(private val url: String) :
     MySqlSetting<R2dbcDatabase> {
 
     private val options: ConnectionFactoryOptions by lazy {
@@ -22,7 +22,7 @@ class R2dbcMySqlSetting(private val driver: String, private val url: String) :
         r2dbcContainer.configure(
             ConnectionFactoryOptions.builder()
                 .option(ConnectionFactoryOptions.DRIVER, "pool")
-                .option(ConnectionFactoryOptions.PROTOCOL, driver)
+                .option(ConnectionFactoryOptions.PROTOCOL, "mysql")
                 .option(Option.valueOf("initialSize"), 2)
                 .build(),
         )

--- a/integration-test-r2dbc/src/mysql5/kotlin/integration/r2dbc/mysql5/R2dbcMySql5Mapping.kt
+++ b/integration-test-r2dbc/src/mysql5/kotlin/integration/r2dbc/mysql5/R2dbcMySql5Mapping.kt
@@ -1,0 +1,43 @@
+package integration.r2dbc.mysql5
+
+import io.r2dbc.spi.Blob
+import io.r2dbc.spi.Clob
+import org.komapper.annotation.KomapperColumn
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperId
+import org.komapper.annotation.KomapperTable
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+
+@KomapperEntity
+@KomapperTable
+data class R2dbcMySql5Mapping(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val bigDecimal: BigDecimal,
+    @KomapperColumn(alwaysQuote = true) val bigInteger: BigInteger,
+    @KomapperColumn(alwaysQuote = true) val blob: Blob,
+    @KomapperColumn(alwaysQuote = true) val boolean: Boolean,
+    @KomapperColumn(alwaysQuote = true) val byte: Byte,
+    @Suppress("ArrayInDataClass")
+    @KomapperColumn(alwaysQuote = true) val byteArray: ByteArray,
+    @KomapperColumn(alwaysQuote = true) val clob: Clob,
+    @KomapperColumn(alwaysQuote = true) val double: Double,
+    @KomapperColumn(alwaysQuote = true) val float: Float,
+    @KomapperColumn(alwaysQuote = true) val instant: Instant,
+    @KomapperColumn(alwaysQuote = true) val int: Int,
+    @KomapperColumn(alwaysQuote = true) val localDateTime: LocalDateTime,
+    @KomapperColumn(alwaysQuote = true) val localDate: LocalDate,
+    @KomapperColumn(alwaysQuote = true) val localTime: LocalTime,
+    @KomapperColumn(alwaysQuote = true) val long: Long,
+    // @KomapperColumn(alwaysQuote = true) val offsetDateTime: OffsetDateTime,
+    @KomapperColumn(alwaysQuote = true) val short: Short,
+    @KomapperColumn(alwaysQuote = true) val string: String,
+    @KomapperColumn(alwaysQuote = true) val uByte: UByte,
+    @KomapperColumn(alwaysQuote = true) val uInt: UInt,
+    @KomapperColumn(alwaysQuote = true) val uShort: UShort,
+)

--- a/integration-test-r2dbc/src/mysql5/kotlin/integration/r2dbc/mysql5/R2dbcMySql5Mapping.kt
+++ b/integration-test-r2dbc/src/mysql5/kotlin/integration/r2dbc/mysql5/R2dbcMySql5Mapping.kt
@@ -12,7 +12,6 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.time.OffsetDateTime
 
 @KomapperEntity
 @KomapperTable

--- a/integration-test-r2dbc/src/mysql5/kotlin/integration/r2dbc/mysql5/R2dbcMySql5MappingTest.kt
+++ b/integration-test-r2dbc/src/mysql5/kotlin/integration/r2dbc/mysql5/R2dbcMySql5MappingTest.kt
@@ -1,0 +1,27 @@
+package integration.r2dbc.mysql5
+
+import integration.r2dbc.R2dbcEnv
+import integration.r2dbc.inTransaction
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.r2dbc.R2dbcDatabase
+
+@ExtendWith(R2dbcEnv::class)
+class R2dbcMySql5MappingTest(private val db: R2dbcDatabase) {
+
+    @Test
+    fun test(info: TestInfo) = inTransaction(db, info) {
+        db.runQuery {
+            QueryDsl.create(Meta.r2dbcMySql5Mapping)
+        }
+        db.runQuery {
+            QueryDsl.from(Meta.r2dbcMySql5Mapping)
+        }
+        db.runQuery {
+            QueryDsl.drop(Meta.r2dbcMySql5Mapping)
+        }
+    }
+}

--- a/integration-test-r2dbc/src/mysql5/kotlin/integration/r2dbc/mysql5/R2dbcMySql5Setting.kt
+++ b/integration-test-r2dbc/src/mysql5/kotlin/integration/r2dbc/mysql5/R2dbcMySql5Setting.kt
@@ -1,0 +1,39 @@
+package integration.r2dbc.mysql5
+
+import integration.core.MySql5Setting
+import io.r2dbc.spi.ConnectionFactoryOptions
+import io.r2dbc.spi.Option
+import org.komapper.core.ExecutionOptions
+import org.komapper.dialect.mysql.MySqlVersion
+import org.komapper.dialect.mysql.r2dbc.MySqlR2dbcDialect
+import org.komapper.r2dbc.R2dbcDatabase
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.containers.MySQLContainerProvider
+import org.testcontainers.containers.MySQLR2DBCDatabaseContainer
+import org.testcontainers.jdbc.ConnectionUrl
+
+@Suppress("unused")
+class R2dbcMySql5Setting(private val driver: String, private val url: String) :
+    MySql5Setting<R2dbcDatabase> {
+
+    private val options: ConnectionFactoryOptions by lazy {
+        val connectionUrl = ConnectionUrl.newInstance(url)
+        val container = MySQLContainerProvider().newInstance(connectionUrl) as MySQLContainer<*>
+        val r2dbcContainer = MySQLR2DBCDatabaseContainer(container)
+        r2dbcContainer.start()
+        r2dbcContainer.configure(
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "pool")
+                .option(ConnectionFactoryOptions.PROTOCOL, "mysql")
+                .option(Option.valueOf("initialSize"), 2)
+                .build(),
+        )
+    }
+
+    override val database: R2dbcDatabase
+        get() = R2dbcDatabase(
+            options = options,
+            dialect = MySqlR2dbcDialect(version = MySqlVersion.V5),
+            executionOptions = ExecutionOptions(batchSize = 2),
+        )
+}

--- a/integration-test-r2dbc/src/mysql5/kotlin/integration/r2dbc/mysql5/R2dbcMySql5Setting.kt
+++ b/integration-test-r2dbc/src/mysql5/kotlin/integration/r2dbc/mysql5/R2dbcMySql5Setting.kt
@@ -13,7 +13,7 @@ import org.testcontainers.containers.MySQLR2DBCDatabaseContainer
 import org.testcontainers.jdbc.ConnectionUrl
 
 @Suppress("unused")
-class R2dbcMySql5Setting(private val driver: String, private val url: String) :
+class R2dbcMySql5Setting(private val url: String) :
     MySql5Setting<R2dbcDatabase> {
 
     private val options: ConnectionFactoryOptions by lazy {

--- a/integration-test-r2dbc/src/oracle/kotlin/integration/r2dbc/oracle/R2dbcOracleSetting.kt
+++ b/integration-test-r2dbc/src/oracle/kotlin/integration/r2dbc/oracle/R2dbcOracleSetting.kt
@@ -12,7 +12,7 @@ import org.testcontainers.lifecycle.Startable
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer
 
 @Suppress("unused")
-class R2dbcOracleSetting(private val driver: String, private val url: String) : OracleSetting<R2dbcDatabase> {
+class R2dbcOracleSetting(private val url: String) : OracleSetting<R2dbcDatabase> {
 
     private val options: ConnectionFactoryOptions by lazy {
         val connectionUrl = ConnectionUrl.newInstance(url)
@@ -22,7 +22,7 @@ class R2dbcOracleSetting(private val driver: String, private val url: String) : 
         r2dbcContainer.configure(
             ConnectionFactoryOptions.builder()
                 .option(ConnectionFactoryOptions.DRIVER, "pool")
-                .option(ConnectionFactoryOptions.PROTOCOL, driver)
+                .option(ConnectionFactoryOptions.PROTOCOL, "oracle")
                 .option(Option.valueOf("initialSize"), 2)
                 .build(),
         )

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlSetting.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlSetting.kt
@@ -10,7 +10,7 @@ import org.testcontainers.containers.PostgreSQLR2DBCDatabaseContainer
 import org.testcontainers.jdbc.ConnectionUrl
 
 @Suppress("unused")
-class R2dbcPostgreSqlSetting(private val driver: String, private val url: String) : PostgreSqlSetting<R2dbcDatabase> {
+class R2dbcPostgreSqlSetting(private val url: String) : PostgreSqlSetting<R2dbcDatabase> {
 
     private val options: ConnectionFactoryOptions by lazy {
         val connectionUrl = ConnectionUrl.newInstance(url)
@@ -20,7 +20,7 @@ class R2dbcPostgreSqlSetting(private val driver: String, private val url: String
         r2dbcContainer.configure(
             // We do not use connection pool to use the `mood` enum codec
             ConnectionFactoryOptions.builder()
-                .option(ConnectionFactoryOptions.DRIVER, driver)
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
                 .build(),
         )
     }

--- a/integration-test-r2dbc/src/sqlserver/kotlin/integration/r2dbc/sqlserver/R2dbcSqlServerSetting.kt
+++ b/integration-test-r2dbc/src/sqlserver/kotlin/integration/r2dbc/sqlserver/R2dbcSqlServerSetting.kt
@@ -11,7 +11,7 @@ import org.testcontainers.containers.MSSQLServerContainerProvider
 import org.testcontainers.jdbc.ConnectionUrl
 
 @Suppress("unused")
-class R2dbcSqlServerSetting(private val driver: String, private val url: String) : SqlServerSetting<R2dbcDatabase> {
+class R2dbcSqlServerSetting(private val url: String) : SqlServerSetting<R2dbcDatabase> {
 
     private val options: ConnectionFactoryOptions by lazy {
         val connectionUrl = ConnectionUrl.newInstance(url)
@@ -21,7 +21,7 @@ class R2dbcSqlServerSetting(private val driver: String, private val url: String)
         r2dbcContainer.configure(
             ConnectionFactoryOptions.builder()
                 .option(ConnectionFactoryOptions.DRIVER, "pool")
-                .option(ConnectionFactoryOptions.PROTOCOL, driver)
+                .option(ConnectionFactoryOptions.PROTOCOL, "sqlserver")
                 .option(Option.valueOf("initialSize"), 2)
                 .build(),
         )

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
@@ -224,7 +224,7 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
     }
 
     // jasync-r2dbc-mysql does not support blob type
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun blob(info: TestInfo) = inTransaction(db, info) {
         val m = Meta.blobData
@@ -331,7 +331,7 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
     }
 
     // jasync-r2dbc-mysql does not support blob type
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun clob(info: TestInfo) = inTransaction(db, info) {
         val m = Meta.clobData
@@ -676,7 +676,7 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB])
+    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
     fun instant_null(info: TestInfo) = inTransaction(db, info) {
         val m = Meta.instantData
         val data = InstantData(1, null)
@@ -768,7 +768,7 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
     }
 
     // TODO: jasync-r2dbc-mysql returns a Duration object for the LocalTime type
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun localTime(info: TestInfo) = inTransaction(db, info) {
         val m = Meta.localTimeData
@@ -1021,7 +1021,7 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
         assertNotNull(data2)
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun unsigned_sequence(info: TestInfo) = inTransaction(db, info) {
         val m = Meta.unsignedSequenceStrategy

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertMultipleTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertMultipleTest.kt
@@ -40,7 +40,7 @@ class R2dbcInsertMultipleTest(private val db: R2dbcDatabase) {
         assertEquals(addressList, list)
     }
 
-    @Run(unless = [Dbms.MYSQL, Dbms.MARIADB, Dbms.ORACLE, Dbms.SQLSERVER])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5, Dbms.MARIADB, Dbms.ORACLE, Dbms.SQLSERVER])
     @Test
     fun identity(info: TestInfo) = inTransaction(db, info) {
         val i = Meta.identityStrategy
@@ -55,7 +55,7 @@ class R2dbcInsertMultipleTest(private val db: R2dbcDatabase) {
         assertTrue(results1.all { it.id != null })
     }
 
-    @Run(onlyIf = [Dbms.MYSQL, Dbms.MARIADB, Dbms.ORACLE, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.MYSQL, Dbms.MYSQL_5, Dbms.MARIADB, Dbms.ORACLE, Dbms.SQLSERVER])
     @Test
     fun identity_unsupportedOperationException(info: TestInfo) = inTransaction(db, info) {
         val i = Meta.identityStrategy

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSelectTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSelectTest.kt
@@ -43,7 +43,7 @@ class R2dbcInsertSelectTest(private val db: R2dbcDatabase) {
         assertEquals(emptyList(), ids)
     }
 
-    @Run(unless = [Dbms.MYSQL, Dbms.MARIADB, Dbms.ORACLE, Dbms.SQLSERVER])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5, Dbms.MARIADB, Dbms.ORACLE, Dbms.SQLSERVER])
     @Test
     fun generatedKeys(info: TestInfo) = inTransaction(db, info) {
         val i = Meta.identityStrategy
@@ -65,7 +65,7 @@ class R2dbcInsertSelectTest(private val db: R2dbcDatabase) {
         assertEquals(listOf(3, 4), ids)
     }
 
-    @Run(onlyIf = [Dbms.MYSQL, Dbms.MARIADB, Dbms.ORACLE, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.MYSQL, Dbms.MYSQL_5, Dbms.MARIADB, Dbms.ORACLE, Dbms.SQLSERVER])
     @Test
     fun generatedKeys_unsupportedOperationException(info: TestInfo) = inTransaction(db, info) {
         val i = Meta.identityStrategy

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleTest.kt
@@ -242,7 +242,7 @@ class R2dbcInsertSingleTest(private val db: R2dbcDatabase) {
         }
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun sequenceGenerator(info: TestInfo) = inTransaction(db, info) {
         val generator = Meta.sequenceStrategy.idGenerator() as IdGenerator.Sequence<*, *>
@@ -256,7 +256,7 @@ class R2dbcInsertSingleTest(private val db: R2dbcDatabase) {
         }
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun sequenceGenerator_disableSequenceAssignment(info: TestInfo) = inTransaction(db, info) {
         val m = Meta.sequenceStrategy
@@ -317,7 +317,7 @@ class R2dbcInsertSingleTest(private val db: R2dbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB])
+    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
     fun onDuplicateKeyUpdate_update_set(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
         val department = Department(1, 50, "PLANNING", "TOKYO", 10)
@@ -334,7 +334,7 @@ class R2dbcInsertSingleTest(private val db: R2dbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB])
+    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
     fun onDuplicateKeyUpdateWithKey_update_set(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
         val department = Department(5, 10, "PLANNING", "TOKYO", 10)

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleTest.kt
@@ -317,7 +317,7 @@ class R2dbcInsertSingleTest(private val db: R2dbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
+    @Run(unless = [Dbms.MARIADB])
     fun onDuplicateKeyUpdate_update_set(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
         val department = Department(1, 50, "PLANNING", "TOKYO", 10)
@@ -334,7 +334,7 @@ class R2dbcInsertSingleTest(private val db: R2dbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL_5])
+    @Run(unless = [Dbms.MARIADB])
     fun onDuplicateKeyUpdateWithKey_update_set(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
         val department = Department(5, 10, "PLANNING", "TOKYO", 10)

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertValuesTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertValuesTest.kt
@@ -81,7 +81,7 @@ class R2dbcInsertValuesTest(private val db: R2dbcDatabase) {
         assertIs<Int>(id)
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun generatedKeys_sequence(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.sequenceStrategy

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcScriptTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcScriptTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 @ExtendWith(R2dbcEnv::class)
 internal class R2dbcScriptTest(private val db: R2dbcDatabase) {
 
-    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL])
+    @Run(unless = [Dbms.MARIADB, Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun test_double_quote(info: TestInfo) = inTransaction(db, info) {
         db.runQuery {
@@ -41,7 +41,7 @@ internal class R2dbcScriptTest(private val db: R2dbcDatabase) {
         }
     }
 
-    @Run(onlyIf = [Dbms.MARIADB, Dbms.MYSQL])
+    @Run(onlyIf = [Dbms.MARIADB, Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun test_back_quote(info: TestInfo) = inTransaction(db, info) {
         db.runQuery {

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcSetOperationTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcSetOperationTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertFailsWith
 @ExtendWith(R2dbcEnv::class)
 class R2dbcSetOperationTest(private val db: R2dbcDatabase) {
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun except_entity(info: TestInfo) = inTransaction(db, info) {
         val e = Meta.employee
@@ -36,7 +36,7 @@ class R2dbcSetOperationTest(private val db: R2dbcDatabase) {
         assertEquals(5, e3.employeeId)
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun intersect_entity(info: TestInfo) = inTransaction(db, info) {
         val e = Meta.employee
@@ -66,6 +66,7 @@ class R2dbcSetOperationTest(private val db: R2dbcDatabase) {
         assertEquals(1, e2.employeeId)
     }
 
+    @Run(unless = [Dbms.MYSQL_5])
     @Test
     fun union_subquery(info: TestInfo) = inTransaction(db, info) {
         val e = Meta.employee

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcValueClassTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcValueClassTest.kt
@@ -142,7 +142,7 @@ class R2dbcValueClassTest(val db: R2dbcDatabase) {
         }
     }
 
-    @Run(unless = [Dbms.MYSQL])
+    @Run(unless = [Dbms.MYSQL, Dbms.MYSQL_5])
     @Test
     fun sequenceGenerator(info: TestInfo) = inTransaction(db, info) {
         for (i in 1..201) {

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -283,6 +283,8 @@ interface Dialect {
      */
     fun supportsDropIfExists(): Boolean = true
 
+    fun supportsExcludedTable(): Boolean = true
+
     /**
      * Returns whether the generated keys returning is supported when inserting multiple rows.
      */

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
@@ -94,7 +94,11 @@ class BuilderSupport(
                 if (alias.isBlank()) {
                     buf.append(name)
                 } else {
-                    buf.append("$alias.$name")
+                    if (alias == "excluded" && !dialect.supportsExcludedTable()) {
+                        buf.append("values($name)")
+                    } else {
+                        buf.append("$alias.$name")
+                    }
                 }
             }
         }

--- a/komapper-dialect-mysql-jdbc/src/main/kotlin/org/komapper/dialect/mysql/jdbc/MySqlJdbcDialect.kt
+++ b/komapper-dialect-mysql-jdbc/src/main/kotlin/org/komapper/dialect/mysql/jdbc/MySqlJdbcDialect.kt
@@ -1,6 +1,7 @@
 package org.komapper.dialect.mysql.jdbc
 
 import org.komapper.dialect.mysql.MySqlDialect
+import org.komapper.dialect.mysql.MySqlVersion
 import org.komapper.jdbc.JdbcDialect
 import java.sql.SQLException
 
@@ -13,8 +14,8 @@ interface MySqlJdbcDialect : MySqlDialect, JdbcDialect {
     }
 }
 
-private object MySqlJdbcDialectImpl : MySqlJdbcDialect
+private class MySqlJdbcDialectImpl(override val version: MySqlVersion) : MySqlJdbcDialect
 
-fun MySqlJdbcDialect(): MySqlJdbcDialect {
-    return MySqlJdbcDialectImpl
+fun MySqlJdbcDialect(version: MySqlVersion = MySqlVersion.V8): MySqlJdbcDialect {
+    return MySqlJdbcDialectImpl(version)
 }

--- a/komapper-dialect-mysql-r2dbc/src/main/kotlin/org/komapper/dialect/mysql/r2dbc/MySqlR2dbcDialect.kt
+++ b/komapper-dialect-mysql-r2dbc/src/main/kotlin/org/komapper/dialect/mysql/r2dbc/MySqlR2dbcDialect.kt
@@ -2,6 +2,7 @@ package org.komapper.dialect.mysql.r2dbc
 
 import io.r2dbc.spi.R2dbcException
 import org.komapper.dialect.mysql.MySqlDialect
+import org.komapper.dialect.mysql.MySqlVersion
 import org.komapper.r2dbc.R2dbcDialect
 
 interface MySqlR2dbcDialect : MySqlDialect, R2dbcDialect {
@@ -15,8 +16,8 @@ interface MySqlR2dbcDialect : MySqlDialect, R2dbcDialect {
     override fun supportsGeneratedKeysReturningWhenInsertingMultipleRows(): Boolean = false
 }
 
-private object MySqlR2dbcDialectImpl : MySqlR2dbcDialect
+private class MySqlR2dbcDialectImpl(override val version: MySqlVersion) : MySqlR2dbcDialect
 
-fun MySqlR2dbcDialect(): MySqlR2dbcDialect {
-    return MySqlR2dbcDialectImpl
+fun MySqlR2dbcDialect(version: MySqlVersion = MySqlVersion.V8): MySqlR2dbcDialect {
+    return MySqlR2dbcDialectImpl(version)
 }

--- a/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
+++ b/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
@@ -24,7 +24,11 @@ interface MySqlDialect : Dialect {
     override val openQuote: String get() = "`"
     override val closeQuote: String get() = "`"
 
-    override fun getOffsetLimitStatementBuilder(dialect: BuilderDialect, offset: Int, limit: Int): OffsetLimitStatementBuilder {
+    override fun getOffsetLimitStatementBuilder(
+        dialect: BuilderDialect,
+        offset: Int,
+        limit: Int,
+    ): OffsetLimitStatementBuilder {
         return MySqlOffsetLimitStatementBuilder(dialect, offset, limit)
     }
 
@@ -46,14 +50,17 @@ interface MySqlDialect : Dialect {
         return MySqlEntityUpsertStatementBuilder(dialect, context, entities, version)
     }
 
-    override fun supportsAliasForDeleteStatement(): Boolean {
-        return when (version) {
-            MySqlVersion.V5 -> false
-            MySqlVersion.V8 -> true
-        }
+    override fun supportsAliasForDeleteStatement(): Boolean = when (version) {
+        MySqlVersion.V5 -> false
+        MySqlVersion.V8 -> true
     }
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false
+
+    override fun supportsExcludedTable(): Boolean = when (version) {
+        MySqlVersion.V5 -> false
+        MySqlVersion.V8 -> true
+    }
 
     override fun supportsLockOfTables(): Boolean = when (version) {
         MySqlVersion.V5 -> false

--- a/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
+++ b/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
@@ -18,6 +18,8 @@ interface MySqlDialect : Dialect {
         override val driver: String = DRIVER
     }
 
+    val version: MySqlVersion
+
     override val driver: String get() = DRIVER
     override val openQuote: String get() = "`"
     override val closeQuote: String get() = "`"
@@ -41,16 +43,32 @@ interface MySqlDialect : Dialect {
         context: EntityUpsertContext<ENTITY, ID, META>,
         entities: List<ENTITY>,
     ): EntityUpsertStatementBuilder<ENTITY> {
-        return MySqlEntityUpsertStatementBuilder(dialect, context, entities)
+        return MySqlEntityUpsertStatementBuilder(dialect, context, entities, version)
+    }
+
+    override fun supportsAliasForDeleteStatement(): Boolean {
+        return when (version) {
+            MySqlVersion.V5 -> false
+            MySqlVersion.V8 -> true
+        }
     }
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false
 
-    override fun supportsLockOfTables(): Boolean = true
+    override fun supportsLockOfTables(): Boolean = when (version) {
+        MySqlVersion.V5 -> false
+        MySqlVersion.V8 -> true
+    }
 
-    override fun supportsLockOptionNowait(): Boolean = true
+    override fun supportsLockOptionNowait(): Boolean = when (version) {
+        MySqlVersion.V5 -> false
+        MySqlVersion.V8 -> true
+    }
 
-    override fun supportsLockOptionSkipLocked(): Boolean = true
+    override fun supportsLockOptionSkipLocked(): Boolean = when (version) {
+        MySqlVersion.V5 -> false
+        MySqlVersion.V8 -> true
+    }
 
     override fun supportsNullOrdering(): Boolean = false
 

--- a/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlEntityUpsertStatementBuilder.kt
@@ -5,7 +5,6 @@ import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.builder.AliasManager
 import org.komapper.core.dsl.builder.BuilderSupport
-import org.komapper.core.dsl.builder.EmptyAliasManager
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.TableNameType
 import org.komapper.core.dsl.context.DuplicateKeyType
@@ -26,10 +25,7 @@ class MySqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMet
 
     private val target = context.target
     private val excluded = context.excluded
-    private val aliasManager = when (version) {
-        MySqlVersion.V5 -> EmptyAliasManager
-        MySqlVersion.V8 -> UpsertAliasManager(dialect, target, excluded)
-    }
+    private val aliasManager = UpsertAliasManager(dialect, target, excluded)
     private val buf = StatementBuffer()
     private val support = BuilderSupport(dialect, aliasManager, buf)
 
@@ -72,16 +68,7 @@ class MySqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityMet
             for ((left, right) in assignments) {
                 column(left)
                 buf.append(" = ")
-                when (version) {
-                    MySqlVersion.V5 -> {
-                        buf.append("values(")
-                        operand(right)
-                        buf.append(")")
-                    }
-                    MySqlVersion.V8 -> {
-                        operand(right)
-                    }
-                }
+                operand(right)
                 buf.append(", ")
             }
             buf.cutBack(2)

--- a/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlVersion.kt
+++ b/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlVersion.kt
@@ -1,0 +1,5 @@
+package org.komapper.dialect.mysql
+
+enum class MySqlVersion {
+    V5, V8
+}


### PR DESCRIPTION

To use MySQL 5.7, specify the version when constructing the Database instance as follows:

For JDBC:

```kotlin
val db = JdbcDatabase(dialect = MySqlJdbcDialect(MySqlVersion.V5), ...)
```

For R2DBC:

```kotlin
val db = R2dbcDatabase(dialect = MySqlR2dbcDialect(MySqlVersion.V5), ...)
```