### PR TITLE
Emulate the excluded column using the VALUES clause in MariaDB

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
@@ -356,7 +356,6 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB])
     fun onDuplicateKeyUpdate_update_set() {
         val d = Meta.department
         val department = Department(1, 50, "PLANNING", "TOKYO", 10)
@@ -373,7 +372,6 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB])
     fun onDuplicateKeyUpdateWithKey_update_set() {
         val d = Meta.department
         val department = Department(5, 10, "PLANNING", "TOKYO", 10)

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcInsertSingleTest.kt
@@ -317,7 +317,6 @@ class R2dbcInsertSingleTest(private val db: R2dbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB])
     fun onDuplicateKeyUpdate_update_set(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
         val department = Department(1, 50, "PLANNING", "TOKYO", 10)
@@ -334,7 +333,6 @@ class R2dbcInsertSingleTest(private val db: R2dbcDatabase) {
     }
 
     @Test
-    @Run(unless = [Dbms.MARIADB])
     fun onDuplicateKeyUpdateWithKey_update_set(info: TestInfo) = inTransaction(db, info) {
         val d = Meta.department
         val department = Department(5, 10, "PLANNING", "TOKYO", 10)

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
@@ -88,6 +88,8 @@ interface MariaDbDialect : Dialect {
 
     override fun supportsDeleteReturning(): Boolean = true
 
+    override fun supportsExcludedTable(): Boolean = false
+
     override fun supportsGeneratedKeysReturningWhenInsertingMultipleRows(): Boolean = false
 
     override fun supportsInsertMultipleReturning(): Boolean = true

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbEntityUpsertStatementBuilder.kt
@@ -97,5 +97,4 @@ class MariaDbEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : EntityM
             return aliasMap[expression]
         }
     }
-
 }


### PR DESCRIPTION

We will support the execution of queries like the following in MariaDB:

```kotlin
val d = Meta.department
val department = Department(1, 50, "PLANNING", "TOKYO", 10)
val query = QueryDsl.insert(d).onDuplicateKeyUpdate().set { excluded ->
    d.departmentName eq "PLANNING2"
    d.location eq concat(d.location, concat("_", excluded.location))
}.single(department)
```

The above query will be converted to the following SQL:

```sql
insert into department 
    (department_id, department_no, department_name, location, version) 
values 
    (1, 50, 'PLANNING', 'TOKYO', 10)
on duplicate key update 
    department_name = 'PLANNING2', 
    location = (concat(department.location, (concat('_', values(location)))))
```