### PR TITLE
Support geometric types in the Dialect for PostgreSQL R2DBC

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
@@ -52,8 +52,15 @@ interface PostgreSqlSetting<DATABASE : Database> : Setting<DATABASE> {
         create table if not exists string_data(id integer not null primary key, value varchar(20));
         create table if not exists uuid_data(id integer not null primary key, value uuid);
 
+        create table if not exists box_data(id integer not null primary key, value box);
+        create table if not exists circle_data(id integer not null primary key, value circle);
+        create table if not exists line_data(id integer not null primary key, value line);
+        create table if not exists lseg_data(id integer not null primary key, value lseg);
         create table if not exists interval_data(id integer not null primary key, value interval);
         create table if not exists json_data(id integer not null primary key, value jsonb);
+        create table if not exists path_data(id integer not null primary key, value path);
+        create table if not exists point_data(id integer not null primary key, value point);
+        create table if not exists polygon_data(id integer not null primary key, value polygon);
 
         create table if not exists friend(uuid1 uuid, uuid2 uuid, pending boolean, constraint pk_friend primary key(uuid1, uuid2));
         create unique index friend_unique_idx on friend (greatest(uuid1, uuid2), least(uuid1, uuid2));

--- a/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
@@ -54,6 +54,7 @@ interface PostgreSqlSetting<DATABASE : Database> : Setting<DATABASE> {
 
         create table if not exists box_data(id integer not null primary key, value box);
         create table if not exists circle_data(id integer not null primary key, value circle);
+        create table if not exists geometry_data(id integer not null primary key, value geometry);
         create table if not exists line_data(id integer not null primary key, value line);
         create table if not exists lseg_data(id integer not null primary key, value lseg);
         create table if not exists interval_data(id integer not null primary key, value interval);

--- a/integration-test-jdbc/gradle.properties
+++ b/integration-test-jdbc/gradle.properties
@@ -5,5 +5,5 @@ mariadb.url=jdbc:tc:mariadb:10.6.3:///test?TC_DAEMON=true
 mysql.url=jdbc:tc:mysql:8.0.25:///test?TC_DAEMON=true
 mysql5.url=jdbc:tc:mysql:5.7.44:///test?TC_DAEMON=true
 oracle.url=jdbc:tc:oracle:thin:@test?TC_DAEMON=true
-postgresql.url=jdbc:tc:postgresql:12.9:///test?TC_DAEMON=true
+postgresql.url=jdbc:tc:postgis:12-3.4:///test?TC_DAEMON=true
 sqlserver.url=jdbc:tc:sqlserver:2019-CU12-ubuntu-20.04:///test?TC_DAEMON=true

--- a/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/JdbcPostgreSqlSetting.kt
+++ b/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/JdbcPostgreSqlSetting.kt
@@ -4,6 +4,7 @@ import integration.core.PostgreSqlSetting
 import org.komapper.core.ExecutionOptions
 import org.komapper.jdbc.JdbcDataTypeProvider
 import org.komapper.jdbc.JdbcDatabase
+import org.komapper.jdbc.JdbcDialects
 
 @Suppress("unused")
 class JdbcPostgreSqlSetting(url: String) : PostgreSqlSetting<JdbcDatabase> {
@@ -12,6 +13,7 @@ class JdbcPostgreSqlSetting(url: String) : PostgreSqlSetting<JdbcDatabase> {
         val dataTypeProvider = JdbcDataTypeProvider(PostgreSqlJsonType())
         JdbcDatabase(
             url = url,
+            dialect = JdbcDialects.get("postgresql"),
             dataTypeProvider = dataTypeProvider,
             executionOptions = ExecutionOptions(batchSize = 2),
         )

--- a/integration-test-r2dbc/gradle.properties
+++ b/integration-test-r2dbc/gradle.properties
@@ -5,5 +5,5 @@ mariadb.url=jdbc:tc:mariadb:10.6.3:///test?TC_DAEMON=true
 mysql.url=jdbc:tc:mysql:8.0.25:///test?TC_DAEMON=true
 mysql5.url=jdbc:tc:mysql:5.7.44:///test?TC_DAEMON=true
 oracle.url=jdbc:tc:oracle:thin:@test?TC_DAEMON=true
-postgresql.url=jdbc:tc:postgresql:12.9:///test?TC_DAEMON=true
+postgresql.url=jdbc:tc:postgis:12-3.4:///test?TC_DAEMON=true
 sqlserver.url=jdbc:tc:sqlserver:2019-CU12-ubuntu-20.04:///test?TC_DAEMON=true

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/PostgreSqlEntities.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/PostgreSqlEntities.kt
@@ -1,16 +1,51 @@
 package integration.r2dbc.postgresql
 
+import io.r2dbc.postgresql.codec.Box
+import io.r2dbc.postgresql.codec.Circle
 import io.r2dbc.postgresql.codec.Interval
 import io.r2dbc.postgresql.codec.Json
+import io.r2dbc.postgresql.codec.Line
+import io.r2dbc.postgresql.codec.Lseg
+import io.r2dbc.postgresql.codec.Path
+import io.r2dbc.postgresql.codec.Point
+import io.r2dbc.postgresql.codec.Polygon
 import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperId
 import org.komapper.annotation.KomapperTable
 
 @KomapperEntity
-@KomapperTable("json_data")
-data class JsonData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Json?)
+@KomapperTable("box_data")
+data class BoxData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Box?)
+
+@KomapperEntity
+@KomapperTable("circle_data")
+data class CircleData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Circle?)
+
+@KomapperEntity
+@KomapperTable("line_data")
+data class LineData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Line?)
+
+@KomapperEntity
+@KomapperTable("lseg_data")
+data class LsegData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Lseg?)
 
 @KomapperEntity
 @KomapperTable("interval_data")
 data class IntervalData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Interval?)
+
+@KomapperEntity
+@KomapperTable("json_data")
+data class JsonData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Json?)
+
+@KomapperEntity
+@KomapperTable("path_data")
+data class PathData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Path?)
+
+@KomapperEntity
+@KomapperTable("point_data")
+data class PointData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Point?)
+
+@KomapperEntity
+@KomapperTable("polygon_data")
+data class PolygonData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Polygon?)

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/PostgreSqlEntities.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/PostgreSqlEntities.kt
@@ -13,6 +13,7 @@ import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperId
 import org.komapper.annotation.KomapperTable
+import org.locationtech.jts.geom.Geometry
 
 @KomapperEntity
 @KomapperTable("box_data")
@@ -21,6 +22,10 @@ data class BoxData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) 
 @KomapperEntity
 @KomapperTable("circle_data")
 data class CircleData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Circle?)
+
+@KomapperEntity
+@KomapperTable("geometry_data")
+data class GeometryData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Geometry?)
 
 @KomapperEntity
 @KomapperTable("line_data")

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlMapping.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlMapping.kt
@@ -1,5 +1,12 @@
 package integration.r2dbc.postgresql
 
+import io.r2dbc.postgresql.codec.Box
+import io.r2dbc.postgresql.codec.Circle
+import io.r2dbc.postgresql.codec.Line
+import io.r2dbc.postgresql.codec.Lseg
+import io.r2dbc.postgresql.codec.Path
+import io.r2dbc.postgresql.codec.Point
+import io.r2dbc.postgresql.codec.Polygon
 import io.r2dbc.spi.Blob
 import io.r2dbc.spi.Clob
 import org.komapper.annotation.KomapperColumn
@@ -26,18 +33,25 @@ data class R2dbcPostgreSqlMapping(
     @KomapperColumn(alwaysQuote = true) val bigInteger: BigInteger,
     @KomapperColumn(alwaysQuote = true) val blob: Blob,
     @KomapperColumn(alwaysQuote = true) val boolean: Boolean,
+    @KomapperColumn(alwaysQuote = true) val box: Box,
     @KomapperColumn(alwaysQuote = true) val byte: Byte,
     @Suppress("ArrayInDataClass")
     @KomapperColumn(alwaysQuote = true) val byteArray: ByteArray,
     @KomapperColumn(alwaysQuote = true) val double: Double,
+    @KomapperColumn(alwaysQuote = true) val circle: Circle,
     @KomapperColumn(alwaysQuote = true) val clob: Clob,
     @KomapperColumn(alwaysQuote = true) val float: Float,
     @KomapperColumn(alwaysQuote = true) val instant: Instant,
+    @KomapperColumn(alwaysQuote = true) val line: Line,
+    @KomapperColumn(alwaysQuote = true) val lseg: Lseg,
     @KomapperColumn(alwaysQuote = true) val localDateTime: LocalDateTime,
     @KomapperColumn(alwaysQuote = true) val localDate: LocalDate,
     @KomapperColumn(alwaysQuote = true) val localTime: LocalTime,
     @KomapperColumn(alwaysQuote = true) val long: Long,
     @KomapperColumn(alwaysQuote = true) val offsetDateTime: OffsetDateTime,
+    @KomapperColumn(alwaysQuote = true) val path: Path,
+    @KomapperColumn(alwaysQuote = true) val point: Point,
+    @KomapperColumn(alwaysQuote = true) val polygon: Polygon,
     @KomapperColumn(alwaysQuote = true) val short: Short,
     @KomapperColumn(alwaysQuote = true) val string: String,
     @KomapperColumn(alwaysQuote = true) val uByte: UByte,

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlMapping.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlMapping.kt
@@ -13,6 +13,7 @@ import org.komapper.annotation.KomapperColumn
 import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperId
 import org.komapper.annotation.KomapperTable
+import org.locationtech.jts.geom.Geometry
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.Instant
@@ -37,10 +38,11 @@ data class R2dbcPostgreSqlMapping(
     @KomapperColumn(alwaysQuote = true) val byte: Byte,
     @Suppress("ArrayInDataClass")
     @KomapperColumn(alwaysQuote = true) val byteArray: ByteArray,
-    @KomapperColumn(alwaysQuote = true) val double: Double,
     @KomapperColumn(alwaysQuote = true) val circle: Circle,
     @KomapperColumn(alwaysQuote = true) val clob: Clob,
+    @KomapperColumn(alwaysQuote = true) val double: Double,
     @KomapperColumn(alwaysQuote = true) val float: Float,
+    @KomapperColumn(alwaysQuote = true) val geometory: Geometry,
     @KomapperColumn(alwaysQuote = true) val instant: Instant,
     @KomapperColumn(alwaysQuote = true) val line: Line,
     @KomapperColumn(alwaysQuote = true) val lseg: Lseg,

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlMappingTest.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlMappingTest.kt
@@ -2,12 +2,12 @@ package integration.r2dbc.postgresql
 
 import integration.r2dbc.R2dbcEnv
 import integration.r2dbc.inTransaction
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.r2dbc.R2dbcDatabase
+import kotlin.test.Test
 
 @ExtendWith(R2dbcEnv::class)
 class R2dbcPostgreSqlMappingTest(private val db: R2dbcDatabase) {

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlSetting.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlSetting.kt
@@ -4,8 +4,8 @@ import integration.core.PostgreSqlSetting
 import io.r2dbc.spi.ConnectionFactoryOptions
 import org.komapper.core.ExecutionOptions
 import org.komapper.r2dbc.R2dbcDatabase
+import org.testcontainers.containers.PostgisContainerProvider
 import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.containers.PostgreSQLContainerProvider
 import org.testcontainers.containers.PostgreSQLR2DBCDatabaseContainer
 import org.testcontainers.jdbc.ConnectionUrl
 
@@ -14,7 +14,7 @@ class R2dbcPostgreSqlSetting(private val url: String) : PostgreSqlSetting<R2dbcD
 
     private val options: ConnectionFactoryOptions by lazy {
         val connectionUrl = ConnectionUrl.newInstance(url)
-        val container = PostgreSQLContainerProvider().newInstance(connectionUrl) as PostgreSQLContainer<*>
+        val container = PostgisContainerProvider().newInstance(connectionUrl) as PostgreSQLContainer<*>
         val r2dbcContainer = PostgreSQLR2DBCDatabaseContainer(container)
         r2dbcContainer.start()
         r2dbcContainer.configure(

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlTypeTest.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlTypeTest.kt
@@ -17,6 +17,8 @@ import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.query.first
 import org.komapper.r2dbc.R2dbcDatabase
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
 import java.time.Period
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -75,6 +77,32 @@ class R2dbcPostgreSqlTypeTest(val db: R2dbcDatabase) {
             QueryDsl.from(m).where { m.id eq 1 }.first()
         }
         assertEquals(data, data2)
+    }
+
+    @Test
+    fun geometry(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.geometryData
+        val factory = GeometryFactory()
+        val data = GeometryData(
+            1,
+            factory.createPoint(Coordinate(1.0, 2.0)),
+        )
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
+    }
+
+    @Test
+    fun geometry_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.geometryData
+        val data = GeometryData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
     }
 
     @Test

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlTypeTest.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlTypeTest.kt
@@ -2,8 +2,15 @@ package integration.r2dbc.postgresql
 
 import integration.r2dbc.R2dbcEnv
 import integration.r2dbc.inTransaction
+import io.r2dbc.postgresql.codec.Box
+import io.r2dbc.postgresql.codec.Circle
 import io.r2dbc.postgresql.codec.Interval
 import io.r2dbc.postgresql.codec.Json
+import io.r2dbc.postgresql.codec.Line
+import io.r2dbc.postgresql.codec.Lseg
+import io.r2dbc.postgresql.codec.Path
+import io.r2dbc.postgresql.codec.Point
+import io.r2dbc.postgresql.codec.Polygon
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.dsl.Meta
@@ -16,6 +23,109 @@ import kotlin.test.assertEquals
 
 @ExtendWith(R2dbcEnv::class)
 class R2dbcPostgreSqlTypeTest(val db: R2dbcDatabase) {
+
+    @Test
+    fun box(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.boxData
+        val data = BoxData(
+            1,
+            Box.of(
+                Point.of(1.0, 2.0),
+                Point.of(3.0, 4.0),
+            ),
+        )
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
+    }
+
+    @Test
+    fun box_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.boxData
+        val data = BoxData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun circle(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.circleData
+        val data = CircleData(
+            1,
+            Circle.of(Point.of(1.0, 2.0), 3.0),
+        )
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
+    }
+
+    @Test
+    fun circle_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.circleData
+        val data = CircleData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun line(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.lineData
+        val data = LineData(
+            1,
+            Line.of(Point.of(1.0, 2.0), Point.of(3.0, 4.0)),
+        )
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
+    }
+
+    @Test
+    fun line_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.lineData
+        val data = LineData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun lseg(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.lsegData
+        val data = LsegData(
+            1,
+            Lseg.of(Point.of(1.0, 2.0), Point.of(3.0, 4.0)),
+        )
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
+    }
+
+    @Test
+    fun lseg_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.lsegData
+        val data = LsegData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
 
     @Test
     fun interval(info: TestInfo) = inTransaction(db, info) {
@@ -73,5 +183,85 @@ class R2dbcPostgreSqlTypeTest(val db: R2dbcDatabase) {
             QueryDsl.from(m).where { m.id eq 1 }.first()
         }
         assertEquals(data, data2)
+    }
+
+    @Test
+    fun path(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.pathData
+        val data = PathData(
+            1,
+            Path.open(
+                Point.of(1.0, 2.0),
+                Point.of(3.0, 4.0),
+            ),
+        )
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
+    }
+
+    @Test
+    fun path_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.pathData
+        val data = PathData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
+    }
+
+    @Test
+    fun point(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.pointData
+        val data = PointData(1, Point.of(1.0, 2.0))
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
+    }
+
+    @Test
+    fun point_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.pointData
+        val data = PointData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
+    }
+
+    @Test
+    fun polygon(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.polygonData
+        val data = PolygonData(
+            1,
+            Polygon.of(
+                Point.of(1.0, 2.0),
+                Point.of(3.0, 4.0),
+                Point.of(5.0, 6.0),
+                Point.of(7.0, 8.0),
+            ),
+        )
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
+    }
+
+    @Test
+    fun polygon_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.polygonData
+        val data = PolygonData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data.value, data2.value)
     }
 }

--- a/komapper-dialect-postgresql-r2dbc/build.gradle.kts
+++ b/komapper-dialect-postgresql-r2dbc/build.gradle.kts
@@ -2,4 +2,5 @@ dependencies {
     api(project(":komapper-dialect-postgresql"))
     api(project(":komapper-r2dbc"))
     api("org.postgresql:r2dbc-postgresql:1.0.2.RELEASE")
+    api("org.locationtech.jts:jts-core:1.19.0")
 }

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcBoxType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcBoxType.kt
@@ -1,0 +1,17 @@
+package org.komapper.dialect.postgresql.r2dbc
+
+import io.r2dbc.postgresql.codec.Box
+import io.r2dbc.spi.Row
+import org.komapper.r2dbc.AbstractR2dbcDataType
+
+object PostgreSqlR2dbcBoxType : AbstractR2dbcDataType<Box>(Box::class) {
+    override val name: String = "box"
+
+    override fun getValue(row: Row, index: Int): Box? {
+        return row.get(index, Box::class.java)
+    }
+
+    override fun getValue(row: Row, columnLabel: String): Box? {
+        return row.get(columnLabel, Box::class.java)
+    }
+}

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcCircleType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcCircleType.kt
@@ -1,0 +1,17 @@
+package org.komapper.dialect.postgresql.r2dbc
+
+import io.r2dbc.postgresql.codec.Circle
+import io.r2dbc.spi.Row
+import org.komapper.r2dbc.AbstractR2dbcDataType
+
+object PostgreSqlR2dbcCircleType : AbstractR2dbcDataType<Circle>(Circle::class) {
+    override val name: String = "circle"
+
+    override fun getValue(row: Row, index: Int): Circle? {
+        return row.get(index, Circle::class.java)
+    }
+
+    override fun getValue(row: Row, columnLabel: String): Circle? {
+        return row.get(columnLabel, Circle::class.java)
+    }
+}

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcDataTypeProvider.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcDataTypeProvider.kt
@@ -55,6 +55,7 @@ class PostgreSqlR2dbcDataTypeProvider(private val next: R2dbcDataTypeProvider) :
             R2dbcUShortType("integer"),
             PostgreSqlR2dbcBoxType,
             PostgreSqlR2dbcCircleType,
+            PostgreSqlR2dbcGeometryType,
             PostgreSqlR2dbcIntervalType,
             PostgreSqlR2dbcJsonType,
             PostgreSqlR2dbcLineType,

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcDataTypeProvider.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcDataTypeProvider.kt
@@ -53,8 +53,15 @@ class PostgreSqlR2dbcDataTypeProvider(private val next: R2dbcDataTypeProvider) :
             R2dbcUByteType("smallint"),
             R2dbcUIntType("bigint"),
             R2dbcUShortType("integer"),
+            PostgreSqlR2dbcBoxType,
+            PostgreSqlR2dbcCircleType,
             PostgreSqlR2dbcIntervalType,
             PostgreSqlR2dbcJsonType,
+            PostgreSqlR2dbcLineType,
+            PostgreSqlR2dbcLsegType,
+            PostgreSqlR2dbcPathType,
+            PostgreSqlR2dbcPointType,
+            PostgreSqlR2dbcPolygonType,
             PostgreSqlR2dbcUUIDType,
         )
     }

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcGeometryType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcGeometryType.kt
@@ -1,0 +1,21 @@
+package org.komapper.dialect.postgresql.r2dbc
+
+import io.r2dbc.spi.Row
+import org.komapper.r2dbc.AbstractR2dbcDataType
+import org.locationtech.jts.geom.Geometry
+
+object PostgreSqlR2dbcGeometryType : AbstractR2dbcDataType<Geometry>(Geometry::class) {
+    override val name: String = "geometry"
+
+    override fun getValue(row: Row, index: Int): Geometry? {
+        return row.get(index, Geometry::class.java)
+    }
+
+    override fun getValue(row: Row, columnLabel: String): Geometry? {
+        return row.get(columnLabel, Geometry::class.java)
+    }
+
+    override fun doToString(value: Geometry): String {
+        return "'$value'"
+    }
+}

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcLineType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcLineType.kt
@@ -1,0 +1,17 @@
+package org.komapper.dialect.postgresql.r2dbc
+
+import io.r2dbc.postgresql.codec.Line
+import io.r2dbc.spi.Row
+import org.komapper.r2dbc.AbstractR2dbcDataType
+
+object PostgreSqlR2dbcLineType : AbstractR2dbcDataType<Line>(Line::class) {
+    override val name: String = "line"
+
+    override fun getValue(row: Row, index: Int): Line? {
+        return row.get(index, Line::class.java)
+    }
+
+    override fun getValue(row: Row, columnLabel: String): Line? {
+        return row.get(columnLabel, Line::class.java)
+    }
+}

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcLsegType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcLsegType.kt
@@ -1,0 +1,17 @@
+package org.komapper.dialect.postgresql.r2dbc
+
+import io.r2dbc.postgresql.codec.Lseg
+import io.r2dbc.spi.Row
+import org.komapper.r2dbc.AbstractR2dbcDataType
+
+object PostgreSqlR2dbcLsegType : AbstractR2dbcDataType<Lseg>(Lseg::class) {
+    override val name: String = "lseg"
+
+    override fun getValue(row: Row, index: Int): Lseg? {
+        return row.get(index, Lseg::class.java)
+    }
+
+    override fun getValue(row: Row, columnLabel: String): Lseg? {
+        return row.get(columnLabel, Lseg::class.java)
+    }
+}

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPathType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPathType.kt
@@ -1,0 +1,17 @@
+package org.komapper.dialect.postgresql.r2dbc
+
+import io.r2dbc.postgresql.codec.Path
+import io.r2dbc.spi.Row
+import org.komapper.r2dbc.AbstractR2dbcDataType
+
+object PostgreSqlR2dbcPathType : AbstractR2dbcDataType<Path>(Path::class) {
+    override val name: String = "path"
+
+    override fun getValue(row: Row, index: Int): Path? {
+        return row.get(index, Path::class.java)
+    }
+
+    override fun getValue(row: Row, columnLabel: String): Path? {
+        return row.get(columnLabel, Path::class.java)
+    }
+}

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPointType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPointType.kt
@@ -1,0 +1,17 @@
+package org.komapper.dialect.postgresql.r2dbc
+
+import io.r2dbc.postgresql.codec.Point
+import io.r2dbc.spi.Row
+import org.komapper.r2dbc.AbstractR2dbcDataType
+
+object PostgreSqlR2dbcPointType : AbstractR2dbcDataType<Point>(Point::class) {
+    override val name: String = "point"
+
+    override fun getValue(row: Row, index: Int): Point? {
+        return row.get(index, Point::class.java)
+    }
+
+    override fun getValue(row: Row, columnLabel: String): Point? {
+        return row.get(columnLabel, Point::class.java)
+    }
+}

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPolygonType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPolygonType.kt
@@ -1,0 +1,17 @@
+package org.komapper.dialect.postgresql.r2dbc
+
+import io.r2dbc.postgresql.codec.Polygon
+import io.r2dbc.spi.Row
+import org.komapper.r2dbc.AbstractR2dbcDataType
+
+object PostgreSqlR2dbcPolygonType : AbstractR2dbcDataType<Polygon>(Polygon::class) {
+    override val name: String = "polygon"
+
+    override fun getValue(row: Row, index: Int): Polygon? {
+        return row.get(index, Polygon::class.java)
+    }
+
+    override fun getValue(row: Row, columnLabel: String): Polygon? {
+        return row.get(columnLabel, Polygon::class.java)
+    }
+}


### PR DESCRIPTION
We have supported the following geometric data types.

- box
- circle
- line
- lseg
- geometry
- path
- point
- polygon
