### PR TITLE
Support inline views

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectSubqueryTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectSubqueryTest.kt
@@ -71,15 +71,15 @@ class JdbcSelectSubqueryTest(private val db: JdbcDatabase) {
         assertEquals(3, list.size)
         list[0].let { record ->
             assertEquals("ACCOUNTING", record[v[d.departmentName]])
-            assertEquals(BigDecimal("8750.00"), record[v[sum(e.salary)]])
+            assertEqualsBigDecimal(BigDecimal("8750.00"), record[v[sum(e.salary)]])
         }
         list[1].let { record ->
             assertEquals("RESEARCH", record[v[d.departmentName]])
-            assertEquals(BigDecimal("10875.00"), record[v[sum(e.salary)]])
+            assertEqualsBigDecimal(BigDecimal("10875.00"), record[v[sum(e.salary)]])
         }
         list[2].let { record ->
             assertEquals("SALES", record[v[d.departmentName]])
-            assertEquals(BigDecimal("9400.00"), record[v[sum(e.salary)]])
+            assertEqualsBigDecimal(BigDecimal("9400.00"), record[v[sum(e.salary)]])
         }
     }
 
@@ -96,15 +96,15 @@ class JdbcSelectSubqueryTest(private val db: JdbcDatabase) {
         assertEquals(3, list.size)
         list[0].let { record ->
             assertEquals("ACCOUNTING", record[v[d.departmentName alias "a"]])
-            assertEquals(BigDecimal("8750.00"), record[v[sum(e.salary) alias "b"]])
+            assertEqualsBigDecimal(BigDecimal("8750.00"), record[v[sum(e.salary) alias "b"]])
         }
         list[1].let { record ->
             assertEquals("RESEARCH", record[v[d.departmentName alias "a"]])
-            assertEquals(BigDecimal("10875.00"), record[v[sum(e.salary) alias "b"]])
+            assertEqualsBigDecimal(BigDecimal("10875.00"), record[v[sum(e.salary) alias "b"]])
         }
         list[2].let { record ->
             assertEquals("SALES", record[v[d.departmentName alias "a"]])
-            assertEquals(BigDecimal("9400.00"), record[v[sum(e.salary) alias "b"]])
+            assertEqualsBigDecimal(BigDecimal("9400.00"), record[v[sum(e.salary) alias "b"]])
         }
     }
 
@@ -130,12 +130,16 @@ class JdbcSelectSubqueryTest(private val db: JdbcDatabase) {
         list[0].let { record ->
             assertEquals(1, record[q3[e.employeeId alias "ID"]])
             assertEquals("SMITH", record[q3[e.employeeName alias "NAME"]])
-            assertEquals(BigDecimal("800.00"), record[e.salary])
+            assertEqualsBigDecimal(BigDecimal("800.00"), record[e.salary])
         }
         list[1].let { record ->
             assertEquals(3, record[q3[e.employeeId alias "ID"]])
             assertEquals("SALES", record[q3[e.employeeName alias "NAME"]])
-            assertEquals(BigDecimal("1250.00"), record[e.salary])
+            assertEqualsBigDecimal(BigDecimal("1250.00"), record[e.salary])
         }
+    }
+
+    private fun assertEqualsBigDecimal(expected: BigDecimal, actual: BigDecimal?) {
+        assertEquals(0, expected.compareTo(actual))
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectSubqueryTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectSubqueryTest.kt
@@ -5,9 +5,12 @@ import integration.core.employee
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.operator.alias
 import org.komapper.core.dsl.operator.count
 import org.komapper.core.dsl.operator.max
+import org.komapper.core.dsl.operator.sum
 import org.komapper.jdbc.JdbcDatabase
+import java.math.BigDecimal
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -53,5 +56,86 @@ class JdbcSelectSubqueryTest(private val db: JdbcDatabase) {
         }
         val list = db.runQuery { query }
         assertEquals(6, list.size)
+    }
+
+    @Test
+    fun subquery_as_inlineView_property() {
+        val d = Meta.department
+        val e = Meta.employee
+        val v = QueryDsl.from(e)
+            .innerJoin(d) { e.departmentId eq d.departmentId }
+            .groupBy(d.departmentName)
+            .select(d.departmentName, sum(e.salary))
+        val query = QueryDsl.from(v).orderBy(v[d.departmentName])
+        val list = db.runQuery { query }
+        assertEquals(3, list.size)
+        list[0].let { record ->
+            assertEquals("ACCOUNTING", record[v[d.departmentName]])
+            assertEquals(BigDecimal("8750.00"), record[v[sum(e.salary)]])
+        }
+        list[1].let { record ->
+            assertEquals("RESEARCH", record[v[d.departmentName]])
+            assertEquals(BigDecimal("10875.00"), record[v[sum(e.salary)]])
+        }
+        list[2].let { record ->
+            assertEquals("SALES", record[v[d.departmentName]])
+            assertEquals(BigDecimal("9400.00"), record[v[sum(e.salary)]])
+        }
+    }
+
+    @Test
+    fun subquery_as_inlineView_alias() {
+        val d = Meta.department
+        val e = Meta.employee
+        val v = QueryDsl.from(e)
+            .innerJoin(d) { e.departmentId eq d.departmentId }
+            .groupBy(d.departmentName)
+            .select(d.departmentName alias "a", sum(e.salary) alias "b")
+        val query = QueryDsl.from(v).orderBy(v[d.departmentName alias "a"])
+        val list = db.runQuery { query }
+        assertEquals(3, list.size)
+        list[0].let { record ->
+            assertEquals("ACCOUNTING", record[v[d.departmentName alias "a"]])
+            assertEquals(BigDecimal("8750.00"), record[v[sum(e.salary) alias "b"]])
+        }
+        list[1].let { record ->
+            assertEquals("RESEARCH", record[v[d.departmentName alias "a"]])
+            assertEquals(BigDecimal("10875.00"), record[v[sum(e.salary) alias "b"]])
+        }
+        list[2].let { record ->
+            assertEquals("SALES", record[v[d.departmentName alias "a"]])
+            assertEquals(BigDecimal("9400.00"), record[v[sum(e.salary) alias "b"]])
+        }
+    }
+
+    @Test
+    fun subquery_as_inlineView_union() {
+        val d = Meta.department
+        val e = Meta.employee
+
+        val q1 =
+            QueryDsl.from(e).where { e.employeeId eq 1 }
+                .select(e.employeeId alias "ID", e.employeeName alias "NAME")
+        val q2 = QueryDsl.from(d).where { d.departmentId eq 3 }
+            .select(d.departmentId alias "ID", d.departmentName alias "NAME")
+        val q3 = q1.union(q2)
+
+        val query = QueryDsl.from(q3)
+            .innerJoin(e) { e.employeeId eq q3[e.employeeId alias "ID"] }
+            .selectAsRecord(q3[e.employeeId alias "ID"], q3[e.employeeName alias "NAME"], e.salary)
+
+        val list = db.runQuery { query }
+        assertEquals(2, list.size)
+
+        list[0].let { record ->
+            assertEquals(1, record[q3[e.employeeId alias "ID"]])
+            assertEquals("SMITH", record[q3[e.employeeName alias "NAME"]])
+            assertEquals(BigDecimal("800.00"), record[e.salary])
+        }
+        list[1].let { record ->
+            assertEquals(3, record[q3[e.employeeId alias "ID"]])
+            assertEquals("SALES", record[q3[e.employeeName alias "NAME"]])
+            assertEquals(BigDecimal("1250.00"), record[e.salary])
+        }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
@@ -10,11 +10,16 @@ import org.komapper.core.dsl.context.ScriptContext
 import org.komapper.core.dsl.context.SelectContext
 import org.komapper.core.dsl.context.TemplateExecuteContext
 import org.komapper.core.dsl.context.TemplateSelectContext
+import org.komapper.core.dsl.context.inlineViewMetamodel
+import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.query.DeleteQueryBuilder
 import org.komapper.core.dsl.query.DeleteQueryBuilderImpl
+import org.komapper.core.dsl.query.InlineViewSelectQuery
 import org.komapper.core.dsl.query.InsertQueryBuilder
 import org.komapper.core.dsl.query.InsertQueryBuilderImpl
+import org.komapper.core.dsl.query.Record
+import org.komapper.core.dsl.query.RelationSelectQuery
 import org.komapper.core.dsl.query.SchemaCreateQuery
 import org.komapper.core.dsl.query.SchemaCreateQueryImpl
 import org.komapper.core.dsl.query.SchemaDropQuery
@@ -49,6 +54,19 @@ object QueryDsl {
         metamodel: META,
     ): SelectQueryBuilder<ENTITY, ID, META> {
         return SelectQueryBuilderImpl(SelectContext(metamodel))
+    }
+
+    /**
+     * Creates a SELECT query using an inline view.
+     *
+     * @param subquery the inline vie
+     * @return the query
+     */
+    fun from(
+        subquery: SubqueryExpression<*>,
+    ): RelationSelectQuery<Record> {
+        val metamodel = subquery.context.inlineViewMetamodel
+        return InlineViewSelectQuery(SelectContext(metamodel))
     }
 
     /**

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SubqueryContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SubqueryContext.kt
@@ -1,6 +1,41 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.expression.AliasExpression
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.metamodel.InlineViewMetamodel
 
 @ThreadSafe
 sealed interface SubqueryContext
+
+internal val SubqueryContext.inlineViewMetamodel: InlineViewMetamodel
+    get() = InlineViewMetamodel(this)
+
+internal val SubqueryContext.columns: List<ColumnExpression<*, *>>
+    get() = when (this) {
+        is SelectContext<*, *, *> -> getProjection().expressions()
+        is SetOperationContext -> left.columns
+    }
+
+internal val SubqueryContext.columnAndAliasPairs: List<Pair<ColumnExpression<*, *>, String>>
+    get() = columns.mapIndexed { index, column ->
+        val alias = when (column) {
+            is AliasExpression<*, *> -> column.alias
+            else -> buildAlias(column, index)
+        }
+        column to alias
+    }
+
+internal fun SubqueryContext.makeAlias(column: ColumnExpression<*, *>): String {
+    val index = columns.indexOf(column)
+    return if (index > -1) {
+        buildAlias(column, index)
+    } else {
+        error("The column \"${column.columnName}\" is not found in the select list of the subquery.")
+    }
+}
+
+private fun buildAlias(column: ColumnExpression<*, *>, index: Int): String {
+    val alias = "c${index}_${column.columnName}_"
+    return if (alias.length > 50) alias.substring(0, 50) else alias
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/AliasExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/AliasExpression.kt
@@ -1,6 +1,6 @@
 package org.komapper.core.dsl.expression
 
-internal class AliasExpression<T : Any, S : Any>(
+internal data class AliasExpression<T : Any, S : Any>(
     val expression: ColumnExpression<T, S>,
     val alias: String,
 ) : ColumnExpression<T, S> by expression

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/SubqueryExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/SubqueryExpression.kt
@@ -2,8 +2,21 @@ package org.komapper.core.dsl.expression
 
 import org.komapper.core.ThreadSafe
 import org.komapper.core.dsl.context.SubqueryContext
+import org.komapper.core.dsl.context.inlineViewMetamodel
+import org.komapper.core.dsl.context.makeAlias
+import org.komapper.core.dsl.metamodel.InlineViewPropertyMetamodel
 
 @ThreadSafe
 interface SubqueryExpression<T> {
     val context: SubqueryContext
+
+    operator fun <EXTERIOR : Any, INTERIOR : Any> get(expression: ColumnExpression<EXTERIOR, INTERIOR>): ColumnExpression<EXTERIOR, INTERIOR> {
+        val metamodel = context.inlineViewMetamodel
+        return if (expression is AliasExpression<*, *>) {
+            InlineViewPropertyMetamodel(metamodel, expression as ColumnExpression<EXTERIOR, INTERIOR>, expression.alias)
+        } else {
+            val alias = context.makeAlias(expression)
+            InlineViewPropertyMetamodel(metamodel, expression, alias)
+        }
+    }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/InlineViewMetamodel.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/InlineViewMetamodel.kt
@@ -1,0 +1,135 @@
+package org.komapper.core.dsl.metamodel
+
+import org.komapper.core.dsl.context.SubqueryContext
+import org.komapper.core.dsl.context.columnAndAliasPairs
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.query.Record
+import org.komapper.core.dsl.query.RecordImpl
+import java.time.Clock
+import kotlin.reflect.KClass
+
+internal data class InlineViewMetamodel(val context: SubqueryContext) :
+    EntityMetamodel<Record, List<Any>, InlineViewMetamodel> {
+
+    override fun declaration(): EntityMetamodelDeclaration<InlineViewMetamodel> {
+        return {}
+    }
+
+    override fun idGenerator(): IdGenerator<Record, List<Any>>? {
+        return null
+    }
+
+    override fun idProperties(): List<PropertyMetamodel<Record, *, *>> {
+        return properties()
+    }
+
+    override fun versionProperty(): PropertyMetamodel<Record, *, *>? {
+        return null
+    }
+
+    override fun createdAtProperty(): PropertyMetamodel<Record, *, *>? {
+        return null
+    }
+
+    override fun updatedAtProperty(): PropertyMetamodel<Record, *, *>? {
+        return null
+    }
+
+    override fun properties(): List<PropertyMetamodel<Record, *, *>> {
+        return context.columnAndAliasPairs.map { (column, alias) ->
+            InlineViewPropertyMetamodel(this, column, alias)
+        }
+    }
+
+    override fun convertToId(generatedKey: Long): List<Any>? {
+        return null
+    }
+
+    override fun versionAssignment(): Pair<PropertyMetamodel<Record, *, *>, Operand>? {
+        return null
+    }
+
+    override fun createdAtAssignment(c: Clock): Pair<PropertyMetamodel<Record, *, *>, Operand>? {
+        return null
+    }
+
+    override fun updatedAtAssignment(c: Clock): Pair<PropertyMetamodel<Record, *, *>, Operand>? {
+        return null
+    }
+
+    override fun newEntity(m: Map<PropertyMetamodel<*, *, *>, Any?>): Record {
+        @Suppress("UNCHECKED_CAST")
+        m as Map<ColumnExpression<*, *>, Any?>
+        return RecordImpl(m)
+    }
+
+    override fun newMetamodel(
+        table: String,
+        catalog: String,
+        schema: String,
+        alwaysQuote: Boolean,
+        disableSequenceAssignment: Boolean,
+        declaration: EntityMetamodelDeclaration<InlineViewMetamodel>,
+    ): InlineViewMetamodel {
+        throw UnsupportedOperationException()
+    }
+
+    override fun postUpdate(e: Record): Record {
+        return e
+    }
+
+    override fun preUpdate(e: Record, c: Clock): Record {
+        return e
+    }
+
+    override fun preInsert(e: Record, c: Clock): Record {
+        return e
+    }
+
+    override fun extractId(e: Record): List<Any> {
+        return properties()
+    }
+
+    override fun klass(): KClass<Record> {
+        return Record::class
+    }
+
+    override fun tableName(): String {
+        return ""
+    }
+
+    override fun catalogName(): String {
+        return ""
+    }
+
+    override fun schemaName(): String {
+        return ""
+    }
+
+    override fun alwaysQuote(): Boolean {
+        return false
+    }
+
+    override fun disableSequenceAssignment(): Boolean {
+        return true
+    }
+}
+
+internal data class InlineViewPropertyMetamodel<EXTERIOR : Any, INTERIOR : Any>(
+    override val owner: EntityMetamodel<Record, *, *>,
+    private val delegatee: ColumnExpression<EXTERIOR, INTERIOR>,
+    override val columnName: String,
+) :
+    PropertyMetamodel<Record, EXTERIOR, INTERIOR> {
+    override val name: String get() = columnName
+    override val getter: (Record) -> EXTERIOR? get() = throw UnsupportedOperationException()
+    override val setter: (Record, EXTERIOR) -> Record get() = throw UnsupportedOperationException()
+    override val nullable: Boolean get() = throw UnsupportedOperationException()
+    override val exteriorClass: KClass<EXTERIOR> get() = delegatee.exteriorClass
+    override val interiorClass: KClass<INTERIOR> get() = delegatee.interiorClass
+    override val wrap: (INTERIOR) -> EXTERIOR get() = delegatee.wrap
+    override val unwrap: (EXTERIOR) -> INTERIOR get() = delegatee.unwrap
+    override val alwaysQuote: Boolean get() = true
+    override val masking: Boolean get() = delegatee.masking
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/Record.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/Record.kt
@@ -64,4 +64,8 @@ class RecordImpl(private val map: Map<ColumnExpression<*, *>, Any?>) : Record {
         val value = map[key]
         return if (value == null) null else key.exteriorClass.cast(value)
     }
+
+    override fun toString(): String {
+        return map.entries.map { (key, value) -> key.columnName to value }.toString()
+    }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationSelectQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationSelectQuery.kt
@@ -13,6 +13,7 @@ import org.komapper.core.dsl.expression.SortExpression
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.InlineViewMetamodel
 import org.komapper.core.dsl.operator.plus
 import org.komapper.core.dsl.options.SelectOptions
 import org.komapper.core.dsl.visitor.FlowQueryVisitor
@@ -21,7 +22,7 @@ import org.komapper.core.dsl.visitor.QueryVisitor
 /**
  * Represents a query to retrieve rows.
  */
-interface RelationSelectQuery<ENTITY : Any> : SelectQuery<ENTITY, RelationSelectQuery<ENTITY>>
+interface RelationSelectQuery<ENTITY> : SelectQuery<ENTITY, RelationSelectQuery<ENTITY>>
 
 internal data class RelationSelectQueryImpl<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     override val context: SelectContext<ENTITY, ID, META>,
@@ -111,6 +112,163 @@ internal data class RelationSelectQueryImpl<ENTITY : Any, ID : Any, META : Entit
     }
 
     override fun unionAll(other: SubqueryExpression<ENTITY>): FlowSetOperationQuery<ENTITY> {
+        return subquerySupport.unionAll(other)
+    }
+
+    override fun <T : Any, S : Any> select(expression: ScalarExpression<T, S>): ScalarQuery<T?, T, S> {
+        val newContext = support.select(expression)
+        val query = SingleColumnSelectQuery(newContext, expression)
+        return NullableScalarQuery(query, expression)
+    }
+
+    override fun <T : Any, S : Any> selectNotNull(expression: ScalarExpression<T, S>): ScalarQuery<T, T, S> {
+        val newContext = support.select(expression)
+        val query = SingleNotNullColumnSelectQuery(newContext, expression)
+        return NotNullScalarQuery(query, expression)
+    }
+
+    override fun <A : Any> select(expression: ColumnExpression<A, *>): FlowSubquery<A?> {
+        val newContext = support.select(expression)
+        return SingleColumnSelectQuery(newContext, expression)
+    }
+
+    override fun <A : Any> selectNotNull(expression: ColumnExpression<A, *>): FlowSubquery<A> {
+        val newContext = support.select(expression)
+        return SingleNotNullColumnSelectQuery(newContext, expression)
+    }
+
+    override fun <A : Any, B : Any> select(
+        expression1: ColumnExpression<A, *>,
+        expression2: ColumnExpression<B, *>,
+    ): FlowSubquery<Pair<A?, B?>> {
+        val newContext = support.select(expression1, expression2)
+        return PairColumnsSelectQuery(newContext, expression1 to expression2)
+    }
+
+    override fun <A : Any, B : Any> selectNotNull(
+        expression1: ColumnExpression<A, *>,
+        expression2: ColumnExpression<B, *>,
+    ): FlowSubquery<Pair<A, B>> {
+        val newContext = support.select(expression1, expression2)
+        return PairNotNullColumnsSelectQuery(newContext, expression1 to expression2)
+    }
+
+    override fun <A : Any, B : Any, C : Any> select(
+        expression1: ColumnExpression<A, *>,
+        expression2: ColumnExpression<B, *>,
+        expression3: ColumnExpression<C, *>,
+    ): FlowSubquery<Triple<A?, B?, C?>> {
+        val newContext = support.select(expression1, expression2, expression3)
+        return TripleColumnsSelectQuery(newContext, Triple(expression1, expression2, expression3))
+    }
+
+    override fun <A : Any, B : Any, C : Any> selectNotNull(
+        expression1: ColumnExpression<A, *>,
+        expression2: ColumnExpression<B, *>,
+        expression3: ColumnExpression<C, *>,
+    ): FlowSubquery<Triple<A, B, C>> {
+        val newContext = support.select(expression1, expression2, expression3)
+        return TripleNotNullColumnsSelectQuery(newContext, Triple(expression1, expression2, expression3))
+    }
+
+    override fun select(vararg expressions: ColumnExpression<*, *>): FlowSubquery<Record> {
+        return selectAsRecord(*expressions)
+    }
+
+    override fun selectAsRecord(vararg expressions: ColumnExpression<*, *>): FlowSubquery<Record> {
+        val list = expressions.toList()
+        val newContext = support.select(*list.toTypedArray())
+        return MultipleColumnsSelectQuery(newContext, list)
+    }
+}
+
+internal data class InlineViewSelectQuery(
+    override val context: SelectContext<Record, List<Any>, InlineViewMetamodel>,
+) : RelationSelectQuery<Record> {
+
+    private val support: SelectQuerySupport<Record, List<Any>, InlineViewMetamodel> = SelectQuerySupport(context)
+
+    private val subquerySupport: FlowSubquerySupport<Record> =
+        FlowSubquerySupport(context) { InlineViewSetOperationQuery(it, metamodel = context.target) }
+
+    override fun distinct(): RelationSelectQuery<Record> {
+        val newContext = context.copy(distinct = true)
+        return copy(context = newContext)
+    }
+
+    override fun <ENTITY2 : Any, ID2 : Any, META2 : EntityMetamodel<ENTITY2, ID2, META2>> innerJoin(relationship: Relationship<ENTITY2, ID2, META2>): RelationSelectQuery<Record> {
+        val newContext = support.join(InnerJoin(relationship.metamodel, relationship.on))
+        return copy(context = newContext)
+    }
+
+    override fun <ENTITY2 : Any, ID2 : Any, META2 : EntityMetamodel<ENTITY2, ID2, META2>> leftJoin(relationship: Relationship<ENTITY2, ID2, META2>): RelationSelectQuery<Record> {
+        val newContext = support.join(LeftJoin(relationship.metamodel, relationship.on))
+        return copy(context = newContext)
+    }
+
+    override fun where(declaration: WhereDeclaration): RelationSelectQuery<Record> {
+        val newContext = support.where(declaration)
+        return copy(context = newContext)
+    }
+
+    override fun groupBy(expressions: List<ColumnExpression<*, *>>): RelationSelectQuery<Record> {
+        val newContext = context.copy(groupBy = context.groupBy + expressions)
+        return copy(context = newContext)
+    }
+
+    override fun having(declaration: HavingDeclaration): RelationSelectQuery<Record> {
+        val newContext = context.copy(having = context.having + declaration)
+        return copy(context = newContext)
+    }
+
+    override fun orderBy(expressions: List<SortExpression>): RelationSelectQuery<Record> {
+        val newContext = support.orderBy(expressions)
+        return copy(context = newContext)
+    }
+
+    override fun offset(offset: Int): RelationSelectQuery<Record> {
+        val newContext = support.offset(offset)
+        return copy(context = newContext)
+    }
+
+    override fun limit(limit: Int): RelationSelectQuery<Record> {
+        val newContext = support.limit(limit)
+        return copy(context = newContext)
+    }
+
+    override fun forUpdate(declaration: ForUpdateDeclaration): RelationSelectQuery<Record> {
+        val newContext = support.forUpdate(declaration)
+        return copy(context = newContext)
+    }
+
+    override fun options(configure: (SelectOptions) -> SelectOptions): RelationSelectQuery<Record> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+
+    override fun <VISIT_RESULT> accept(visitor: FlowQueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.relationSelectQuery(context)
+    }
+
+    override fun <R> collect(collect: suspend (Flow<Record>) -> R): Query<R> = object : Query<R> {
+        override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+            return visitor.relationSelectQuery(context, collect)
+        }
+    }
+
+    override fun except(other: SubqueryExpression<Record>): FlowSetOperationQuery<Record> {
+        return subquerySupport.except(other)
+    }
+
+    override fun intersect(other: SubqueryExpression<Record>): FlowSetOperationQuery<Record> {
+        return subquerySupport.intersect(other)
+    }
+
+    override fun union(other: SubqueryExpression<Record>): FlowSetOperationQuery<Record> {
+        return subquerySupport.union(other)
+    }
+
+    override fun unionAll(other: SubqueryExpression<Record>): FlowSetOperationQuery<Record> {
         return subquerySupport.unionAll(other)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationSetOperationQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationSetOperationQuery.kt
@@ -5,6 +5,7 @@ import org.komapper.core.dsl.context.SetOperationContext
 import org.komapper.core.dsl.expression.SortExpression
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.InlineViewMetamodel
 import org.komapper.core.dsl.options.SelectOptions
 import org.komapper.core.dsl.visitor.FlowQueryVisitor
 import org.komapper.core.dsl.visitor.QueryVisitor
@@ -14,7 +15,7 @@ import org.komapper.core.dsl.visitor.QueryVisitor
  *
  * @param ENTITY the entity type
  */
-interface RelationSetOperationQuery<ENTITY : Any> : FlowSetOperationQuery<ENTITY>
+interface RelationSetOperationQuery<ENTITY> : FlowSetOperationQuery<ENTITY>
 
 internal data class RelationSetOperationQueryImpl<ENTITY : Any>(
     override val context: SetOperationContext,
@@ -58,6 +59,53 @@ internal data class RelationSetOperationQueryImpl<ENTITY : Any>(
     }
 
     override fun options(configure: (SelectOptions) -> SelectOptions): FlowSetOperationQuery<ENTITY> {
+        val newContext = context.copy(options = configure(context.options))
+        return copy(context = newContext)
+    }
+}
+
+internal data class InlineViewSetOperationQuery(
+    override val context: SetOperationContext,
+    private val metamodel: EntityMetamodel<Record, List<Any>, InlineViewMetamodel>,
+) : RelationSetOperationQuery<Record> {
+
+    private val support: SetOperationQuerySupport<Record> = SetOperationQuerySupport(context)
+
+    override fun <VISIT_RESULT> accept(visitor: FlowQueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+        return visitor.setOperationQuery(context, metamodel)
+    }
+
+    override fun <R> collect(collect: suspend (Flow<Record>) -> R): Query<R> = object : Query<R> {
+        override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
+            return visitor.setOperationQuery(context, metamodel, collect)
+        }
+    }
+
+    override fun except(other: SubqueryExpression<Record>): FlowSetOperationQuery<Record> {
+        return copy(context = support.except(other))
+    }
+
+    override fun intersect(other: SubqueryExpression<Record>): FlowSetOperationQuery<Record> {
+        return copy(context = support.intersect(other))
+    }
+
+    override fun union(other: SubqueryExpression<Record>): FlowSetOperationQuery<Record> {
+        return copy(context = support.union(other))
+    }
+
+    override fun unionAll(other: SubqueryExpression<Record>): FlowSetOperationQuery<Record> {
+        return copy(context = support.unionAll(other))
+    }
+
+    override fun orderBy(vararg aliases: CharSequence): FlowSetOperationQuery<Record> {
+        return copy(context = support.orderBy(*aliases))
+    }
+
+    override fun orderBy(vararg expressions: SortExpression): FlowSetOperationQuery<Record> {
+        return copy(context = support.orderBy(*expressions))
+    }
+
+    override fun options(configure: (SelectOptions) -> SelectOptions): FlowSetOperationQuery<Record> {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SelectQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SelectQuery.kt
@@ -17,7 +17,7 @@ import org.komapper.core.dsl.options.SelectOptions
  * @param ENTITY the entity type
  * @param QUERY the query type
  */
-interface SelectQuery<ENTITY : Any, QUERY : SelectQuery<ENTITY, QUERY>> :
+interface SelectQuery<ENTITY, QUERY : SelectQuery<ENTITY, QUERY>> :
     FlowSubquery<ENTITY> {
     /**
      * Builds a query with the DISTINCT keyword specified.


### PR DESCRIPTION

We have added support for Inline Views.
For example, you can write as follows:

```kotlin
val d = Meta.department
val e = Meta.employee

val inlineView = QueryDsl.from(e)
    .innerJoin(d) { e.departmentId eq d.departmentId }
    .groupBy(d.departmentName)
    .select(d.departmentName, sum(e.salary))

val query = QueryDsl.from(inlineView).orderBy(inlineView[d.departmentName])
```

The above query will be converted into the following SQL:

```sql
select 
    t0_."c0_department_name_", 
    t0_."c1_salary_" 
from (
    select 
        t2_.department_name as "c0_department_name_", 
        sum(t1_.salary) as "c1_salary_" 
    from 
        employee as t1_ 
    inner join 
        department as t2_ on (t1_.department_id = t2_.department_id) 
    group by 
        t2_.department_name
    ) as t0_ 
order by 
    t0_."c0_department_name_" asc
```