### PR TITLE
Enables the projection of SELECT query into an entity

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -14,6 +14,7 @@ import org.komapper.annotation.KomapperLink
 import org.komapper.annotation.KomapperManyToOne
 import org.komapper.annotation.KomapperOneToMany
 import org.komapper.annotation.KomapperOneToOne
+import org.komapper.annotation.KomapperProjection
 import org.komapper.annotation.KomapperSequence
 import org.komapper.annotation.KomapperTable
 import org.komapper.annotation.KomapperUpdatedAt
@@ -26,6 +27,7 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 
 @KomapperEntity
+@KomapperProjection
 data class Address(
     @KomapperId
     @KomapperColumn(name = "address_id")
@@ -128,7 +130,11 @@ data class Human(
 @KomapperManyToOne(Department::class)
 @KomapperOneToOne(Address::class)
 @KomapperManyToOne(Employee::class, link = KomapperLink(target = "manager"))
-@KomapperOneToMany(Employee::class, navigator = "employees", link = KomapperLink(source = "manager", target = "employee"))
+@KomapperOneToMany(
+    Employee::class,
+    navigator = "employees",
+    link = KomapperLink(source = "manager", target = "employee"),
+)
 @KomapperEntity(["employee", "manager"])
 data class Employee(
     @KomapperId
@@ -155,6 +161,7 @@ data class RobotInfo2(
 )
 
 @KomapperEntity
+@KomapperProjection
 @KomapperTable("employee")
 data class Robot(
     @KomapperId

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
@@ -22,6 +22,18 @@ annotation class KomapperEntity(
 )
 
 /**
+ * Indicates that the result of a SELECT query can be projected into an instance of an annotated entity class.
+ *
+ * @property function the function name for performing projection.
+ * The default function name is a concatenation of "selectAs" and the simple name of the entity class.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class KomapperProjection(
+    val function: String = "",
+)
+
+/**
  * Indicates that the annotated property is a primary key.
  * @property virtual If `true`, the annotated property does not actually map to a primary key
  */
@@ -237,6 +249,7 @@ annotation class KomapperAutoIncrement
  * @property entity the entity class
  * @property aliases the names of the entity metamodel instances
  * @property unit the unit object class
+ * @property projectable whether it is possible to project the results of the SELECT statement onto an entity
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
@@ -244,6 +257,7 @@ annotation class KomapperEntityDef(
     val entity: KClass<*>,
     val aliases: Array<String> = [],
     val unit: KClass<*> = Void::class,
+    val projectable: Boolean = false,
 )
 
 /**

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Config.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Config.kt
@@ -14,6 +14,7 @@ internal data class Config(
     val alwaysQuote: Boolean,
     val enableEntityMetamodelListing: Boolean,
     val enableEntityStoreContext: Boolean,
+    val enableEntityProjection: Boolean,
 ) {
     companion object {
         private const val PREFIX = "komapper.prefix"
@@ -24,6 +25,7 @@ internal data class Config(
         private const val ALWAYS_QUOTE = "komapper.alwaysQuote"
         private const val ENABLE_ENTITY_METAMODEL_LISTING = "komapper.enableEntityMetamodelListing"
         private const val ENABLE_ENTITY_STORE_CONTEXT = "komapper.enableEntityStoreContext"
+        private const val ENABLE_ENTITY_PROJECTION = "komapper.enableEntityProjection"
 
         fun create(options: Map<String, String>): Config {
             val prefix = options.getOrDefault(PREFIX, "_")
@@ -48,7 +50,18 @@ internal data class Config(
             val alwaysQuote = options[ALWAYS_QUOTE]?.toBooleanStrict() ?: false
             val enableEntityMetamodelListing = options[ENABLE_ENTITY_METAMODEL_LISTING]?.toBooleanStrict() ?: false
             val enableEntityStoreContext = options[ENABLE_ENTITY_STORE_CONTEXT]?.toBooleanStrict() ?: false
-            return Config(prefix, suffix, enumStrategy, namingStrategy, metaObject, alwaysQuote, enableEntityMetamodelListing, enableEntityStoreContext)
+            val enableEntityProjection = options[ENABLE_ENTITY_PROJECTION]?.toBooleanStrict() ?: false
+            return Config(
+                prefix,
+                suffix,
+                enumStrategy,
+                namingStrategy,
+                metaObject,
+                alwaysQuote,
+                enableEntityMetamodelListing,
+                enableEntityStoreContext,
+                enableEntityProjection,
+            )
         }
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
@@ -25,6 +25,7 @@ internal data class EntityDefinitionSource(
 internal data class EntityDef(
     val definitionSource: EntityDefinitionSource,
     val table: Table,
+    val projection: Projection?,
     val aggregateRoot: AggregateRoot?,
     val associations: List<Association>,
     val properties: List<PropertyDef>,
@@ -53,6 +54,7 @@ internal data class CompositePropertyDef(
 internal data class Entity(
     val declaration: KSClassDeclaration,
     val table: Table,
+    val projection: Projection?,
     val aggregateRoot: AggregateRoot?,
     val associations: List<Association>,
     val properties: List<Property>,
@@ -281,4 +283,8 @@ internal data class AggregateRoot(
     val navigator: String,
     val targetEntity: EntityDefinitionSource,
     val target: String,
+)
+
+internal data class Projection(
+    val function: String,
 )

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
@@ -24,6 +24,7 @@ internal class EntityDefFactory(
 
     fun create(): EntityDef {
         val table = annotationSupport.getTable(definitionSource)
+        val projection = annotationSupport.getProjection(definitionSource)
         val aggregateRoot = annotationSupport.getAggregateRoot(definitionSource)
         val associations = annotationSupport.getAssociations(definitionSource)
         validateAssociations(associations)
@@ -32,7 +33,7 @@ internal class EntityDefFactory(
         val leafProperties = allProperties.filterIsInstance<LeafPropertyDef>()
         validateCompositeProperties(compositeProperties)
         validateLeafProperties(leafProperties)
-        return EntityDef(definitionSource, table, aggregateRoot, associations, allProperties)
+        return EntityDef(definitionSource, table, projection, aggregateRoot, associations, allProperties)
     }
 
     private fun createAllProperties(): List<PropertyDef> {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
@@ -55,6 +55,7 @@ internal class EntityFactory(
         return Entity(
             entityDef.definitionSource.entityDeclaration,
             entityDef.table,
+            entityDef.projection,
             entityDef.aggregateRoot,
             entityDef.associations,
             properties,

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -42,4 +42,7 @@ internal object Symbols {
     const val EntityStore = "org.komapper.core.dsl.query.EntityStore"
     const val EntityStoreContext = "org.komapper.core.dsl.query.EntityStoreContext"
     const val KomapperExperimentalAssociation = "org.komapper.annotation.KomapperExperimentalAssociation"
+    const val SelectQuery = "org.komapper.core.dsl.query.SelectQuery"
+    const val FlowSubquery = "org.komapper.core.dsl.query.FlowSubquery"
+    const val ColumnExpression = "org.komapper.core.dsl.expression.ColumnExpression"
 }


### PR DESCRIPTION

This PR introduces the followings:

- The `@KomapperProjection` annotation
- The `komapper.enableEntityProjection` option for annotation processor

We can define an entity class with the `@KomapperProjection` annotation as follows:

```kotlin
@KomapperEntity
@KomapperProjection
data class Address(
    @KomapperId
    @KomapperColumn(name = "address_id")
    val addressId: Int,
    val street: String,
    @KomapperVersion val version: Int,
)
```

The above definition generates the `selectAsAddress` extension function.
The `selectAsAddress` function can be used as follows:

```kotlin
val e = Meta.employee

val query: Query<List<Address>> = QueryDsl.from(e)
    .where { e.employeeName startsWith "S" }
    .selectAsAddress(
        version = e.version,
        addressId = e.employeeId,
        street = concat(e.employeeName, " STREET"),
    )
```

When the `komapper.enableEntityProjection` option is enabled, it results in the same effect as if `@KomapperProjection` annotation was applied to all entity classes.

```kotlin
ksp {
    arg("komapper.enableEntityMetamodelListing", "true")
}
```