### PR TITLE
Revert "Update actions/labeler action to v5 (#1153)"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,6 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This reverts commit 0f5ab25ddb9ebf10d739a6a04c221758bd595a33.

It seems that there is an issue with labeler action v5.
https://github.com/actions/labeler/issues/712