### PR TITLE
Add a feature to automate the mapping of projections in TemplateQuery

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDataTypeTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDataTypeTest.kt
@@ -440,7 +440,7 @@ class JdbcDataTypeTest(val db: JdbcDatabase) {
         assertEquals("Failed to map a value to the property \"value\" of the entity class \"integration.core.EnumData\".", ex.message)
         val cause = ex.cause
         assertTrue(cause is ValueExtractingException)
-        assertEquals("Failed to extract a value from column. The column index is 1.", cause.message)
+        assertEquals("Failed to extract a value from column. The column index is 1. (Column indices start from 0.)", cause.message)
         val cause2 = cause.cause
         assertTrue(cause2 is EnumMappingException)
         assertEquals("Failed to map the value \"unknown\" to the property \"name\" of the enum class \"integration.core.enumclass.Direction\".", cause2.message)
@@ -486,7 +486,7 @@ class JdbcDataTypeTest(val db: JdbcDatabase) {
         assertEquals("Failed to map a value to the property \"value\" of the entity class \"integration.core.EnumOrdinalData\".", ex.message)
         val cause = ex.cause
         assertTrue(cause is ValueExtractingException)
-        assertEquals("Failed to extract a value from column. The column index is 1.", cause.message)
+        assertEquals("Failed to extract a value from column. The column index is 1. (Column indices start from 0.)", cause.message)
         val cause2 = cause.cause
         assertTrue(cause2 is EnumMappingException)
         assertEquals("Failed to map the value \"90\" to the property \"ordinal\" of the enum class \"integration.core.enumclass.Direction\".", cause2.message)
@@ -532,7 +532,7 @@ class JdbcDataTypeTest(val db: JdbcDatabase) {
         assertEquals("Failed to map a value to the property \"value\" of the entity class \"integration.core.EnumPropertyData\".", ex.message)
         val cause = ex.cause
         assertTrue(cause is ValueExtractingException)
-        assertEquals("Failed to extract a value from column. The column index is 1.", cause.message)
+        assertEquals("Failed to extract a value from column. The column index is 1. (Column indices start from 0.)", cause.message)
         val cause2 = cause.cause
         assertTrue(cause2 is EnumMappingException)
         assertEquals("Failed to map the value \"90\" to the property \"value\" of the enum class \"integration.core.enumclass.Color\".", cause2.message)

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcTemplateTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcTemplateTest.kt
@@ -4,10 +4,12 @@ import integration.core.Address
 import integration.core.Dbms
 import integration.core.Run
 import integration.core.address
+import integration.core.selectAsAddress
 import kotlinx.coroutines.flow.toList
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.query.Row
 import org.komapper.core.dsl.query.bind
 import org.komapper.core.dsl.query.first
@@ -301,11 +303,42 @@ class JdbcTemplateTest(private val db: JdbcDatabase) {
     }
 
     @Test
-    fun selectAsEntity() {
+    fun selectAsEntity_byIndex() {
         val a = Meta.address
         val list = db.runQuery {
             val sql = "select address_id, street, version from address order by address_id"
             QueryDsl.fromTemplate(sql).selectAsEntity(a)
+        }
+        assertEquals(15, list.size)
+        assertEquals(Address(1, "STREET 1", 1), list[0])
+    }
+
+    @Test
+    fun selectAsEntity_byName() {
+        val a = Meta.address
+        val list = db.runQuery {
+            val sql = "select street, version, address_id from address order by address_id"
+            QueryDsl.fromTemplate(sql).selectAsEntity(a, ProjectionType.NAME)
+        }
+        assertEquals(15, list.size)
+        assertEquals(Address(1, "STREET 1", 1), list[0])
+    }
+
+    @Test
+    fun selectAsAddress_byIndex() {
+        val list = db.runQuery {
+            val sql = "select address_id, street, version from address order by address_id"
+            QueryDsl.fromTemplate(sql).selectAsAddress()
+        }
+        assertEquals(15, list.size)
+        assertEquals(Address(1, "STREET 1", 1), list[0])
+    }
+
+    @Test
+    fun selectAsAddress_byName() {
+        val list = db.runQuery {
+            val sql = "select street, version, address_id from address order by address_id"
+            QueryDsl.fromTemplate(sql).selectAsAddress(ProjectionType.NAME)
         }
         assertEquals(15, list.size)
         assertEquals(Address(1, "STREET 1", 1), list[0])

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
@@ -454,7 +454,7 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
         assertEquals("Failed to map a value to the property \"value\" of the entity class \"integration.core.EnumData\".", ex.message)
         val cause = ex.cause
         assertTrue(cause is ValueExtractingException)
-        assertEquals("Failed to extract a value from column. The column index is 1.", cause.message)
+        assertEquals("Failed to extract a value from column. The column index is 1. (Column indices start from 0.)", cause.message)
         val cause2 = cause.cause
         assertTrue(cause2 is EnumMappingException)
         assertEquals("Failed to map the value \"unknown\" to the property \"name\" of the enum class \"integration.core.enumclass.Direction\".", cause2.message)
@@ -500,7 +500,7 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
         assertEquals("Failed to map a value to the property \"value\" of the entity class \"integration.core.EnumOrdinalData\".", ex.message)
         val cause = ex.cause
         assertTrue(cause is ValueExtractingException)
-        assertEquals("Failed to extract a value from column. The column index is 1.", cause.message)
+        assertEquals("Failed to extract a value from column. The column index is 1. (Column indices start from 0.)", cause.message)
         val cause2 = cause.cause
         assertTrue(cause2 is EnumMappingException)
         assertEquals("Failed to map the value \"90\" to the property \"ordinal\" of the enum class \"integration.core.enumclass.Direction\".", cause2.message)
@@ -546,7 +546,7 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
         assertEquals("Failed to map a value to the property \"value\" of the entity class \"integration.core.EnumPropertyData\".", ex.message)
         val cause = ex.cause
         assertTrue(cause is ValueExtractingException)
-        assertEquals("Failed to extract a value from column. The column index is 1.", cause.message)
+        assertEquals("Failed to extract a value from column. The column index is 1. (Column indices start from 0.)", cause.message)
         val cause2 = cause.cause
         assertTrue(cause2 is EnumMappingException)
         assertEquals("Failed to map the value \"90\" to the property \"value\" of the enum class \"integration.core.enumclass.Color\".", cause2.message)

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcTemplateTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcTemplateTest.kt
@@ -4,10 +4,12 @@ import integration.core.Address
 import integration.core.Dbms
 import integration.core.Run
 import integration.core.address
+import integration.core.selectAsAddress
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.query.Row
 import org.komapper.core.dsl.query.bind
 import org.komapper.core.dsl.query.first
@@ -247,11 +249,42 @@ class R2dbcTemplateTest(private val db: R2dbcDatabase) {
     }
 
     @Test
-    fun selectAsEntity(info: TestInfo) = inTransaction(db, info) {
+    fun selectAsEntity_byIndex(info: TestInfo) = inTransaction(db, info) {
         val a = Meta.address
         val list = db.runQuery {
             val sql = "select address_id, street, version from address order by address_id"
             QueryDsl.fromTemplate(sql).selectAsEntity(a)
+        }
+        assertEquals(15, list.size)
+        assertEquals(Address(1, "STREET 1", 1), list[0])
+    }
+
+    @Test
+    fun selectAsEntity_byName(info: TestInfo) = inTransaction(db, info) {
+        val a = Meta.address
+        val list = db.runQuery {
+            val sql = "select street, version, address_id from address order by address_id"
+            QueryDsl.fromTemplate(sql).selectAsEntity(a, ProjectionType.NAME)
+        }
+        assertEquals(15, list.size)
+        assertEquals(Address(1, "STREET 1", 1), list[0])
+    }
+
+    @Test
+    fun selectAsAddress_byIndex(info: TestInfo) = inTransaction(db, info) {
+        val list = db.runQuery {
+            val sql = "select address_id, street, version from address order by address_id"
+            QueryDsl.fromTemplate(sql).selectAsAddress()
+        }
+        assertEquals(15, list.size)
+        assertEquals(Address(1, "STREET 1", 1), list[0])
+    }
+
+    @Test
+    fun selectAsAddress_byName(info: TestInfo) = inTransaction(db, info) {
+        val list = db.runQuery {
+            val sql = "select street, version, address_id from address order by address_id"
+            QueryDsl.fromTemplate(sql).selectAsAddress(ProjectionType.NAME)
         }
         assertEquals(15, list.size)
         assertEquals(Address(1, "STREET 1", 1), list[0])

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityProjectionSelectQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityProjectionSelectQuery.kt
@@ -7,21 +7,21 @@ import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.visitor.FlowQueryVisitor
 import org.komapper.core.dsl.visitor.QueryVisitor
 
-internal class EntityConversionSelectQuery<ENTITY : Any>(
+internal class EntityProjectionSelectQuery<ENTITY : Any>(
     override val context: SelectContext<*, *, *>,
     private val metamodel: EntityMetamodel<ENTITY, *, *>,
 ) : FlowSubquery<ENTITY> {
 
     private val support: FlowSubquerySupport<ENTITY> =
-        FlowSubquerySupport(context) { EntityConversionSetOperationQuery(it, metamodel) }
+        FlowSubquerySupport(context) { EntityProjectionSetOperationQuery(it, metamodel) }
 
     override fun <VISIT_RESULT> accept(visitor: FlowQueryVisitor<VISIT_RESULT>): VISIT_RESULT {
-        return visitor.entityConversionSelectQuery(context, metamodel)
+        return visitor.entityProjectionSelectQuery(context, metamodel)
     }
 
     override fun <R> collect(collect: suspend (Flow<ENTITY>) -> R): Query<R> = object : Query<R> {
         override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
-            return visitor.entityConversionSelectQuery(context, metamodel, collect)
+            return visitor.entityProjectionSelectQuery(context, metamodel, collect)
         }
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityProjectionSetOperationQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityProjectionSetOperationQuery.kt
@@ -9,7 +9,7 @@ import org.komapper.core.dsl.options.SelectOptions
 import org.komapper.core.dsl.visitor.FlowQueryVisitor
 import org.komapper.core.dsl.visitor.QueryVisitor
 
-internal data class EntityConversionSetOperationQuery<ENTITY : Any>(
+internal data class EntityProjectionSetOperationQuery<ENTITY : Any>(
     override val context: SetOperationContext,
     private val metamodel: EntityMetamodel<ENTITY, *, *>,
 ) : FlowSetOperationQuery<ENTITY> {
@@ -17,12 +17,12 @@ internal data class EntityConversionSetOperationQuery<ENTITY : Any>(
     private val support: SetOperationQuerySupport<ENTITY> = SetOperationQuerySupport(context)
 
     override fun <VISIT_RESULT> accept(visitor: FlowQueryVisitor<VISIT_RESULT>): VISIT_RESULT {
-        return visitor.entityConversionSetOperationQuery(context, metamodel)
+        return visitor.entityProjectionSetOperationQuery(context, metamodel)
     }
 
     override fun <R> collect(collect: suspend (Flow<ENTITY>) -> R): Query<R> = object : Query<R> {
         override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
-            return visitor.entityConversionSetOperationQuery(context, metamodel, collect)
+            return visitor.entityProjectionSetOperationQuery(context, metamodel, collect)
         }
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/ProjectionType.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/ProjectionType.kt
@@ -1,0 +1,5 @@
+package org.komapper.core.dsl.query
+
+enum class ProjectionType {
+    INDEX, NAME
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationSelectQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/RelationSelectQuery.kt
@@ -186,6 +186,6 @@ internal data class RelationSelectQueryImpl<ENTITY : Any, ID : Any, META : Entit
     ): FlowSubquery<ENTITY2> {
         val list = expressions.toList()
         val newContext = support.select(*list.toTypedArray())
-        return EntityConversionSelectQuery(newContext, metamodel)
+        return EntityProjectionSelectQuery(newContext, metamodel)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateSelectQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateSelectQuery.kt
@@ -33,15 +33,16 @@ internal data class TemplateSelectQueryImpl<T>(
 internal data class TemplateEntityProjectionSelectQuery<ENTITY : Any>(
     private val context: TemplateSelectContext,
     private val metamodel: EntityMetamodel<ENTITY, *, *>,
+    private val strategy: ProjectionType,
 ) : TemplateSelectQuery<ENTITY> {
 
     override fun <VISIT_RESULT> accept(visitor: FlowQueryVisitor<VISIT_RESULT>): VISIT_RESULT {
-        return visitor.templateEntityProjectionSelectQuery(context, metamodel)
+        return visitor.templateEntityProjectionSelectQuery(context, metamodel, strategy)
     }
 
     override fun <R> collect(collect: suspend (Flow<ENTITY>) -> R): Query<R> = object : Query<R> {
         override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
-            return visitor.templateEntityProjectionSelectQuery(context, metamodel, collect)
+            return visitor.templateEntityProjectionSelectQuery(context, metamodel, strategy, collect)
         }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateSelectQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateSelectQuery.kt
@@ -30,18 +30,18 @@ internal data class TemplateSelectQueryImpl<T>(
     }
 }
 
-internal data class TemplateEntityConversionSelectQuery<ENTITY : Any>(
+internal data class TemplateEntityProjectionSelectQuery<ENTITY : Any>(
     private val context: TemplateSelectContext,
     private val metamodel: EntityMetamodel<ENTITY, *, *>,
 ) : TemplateSelectQuery<ENTITY> {
 
     override fun <VISIT_RESULT> accept(visitor: FlowQueryVisitor<VISIT_RESULT>): VISIT_RESULT {
-        return visitor.templateEntityConversionSelectQuery(context, metamodel)
+        return visitor.templateEntityProjectionSelectQuery(context, metamodel)
     }
 
     override fun <R> collect(collect: suspend (Flow<ENTITY>) -> R): Query<R> = object : Query<R> {
         override fun <VISIT_RESULT> accept(visitor: QueryVisitor<VISIT_RESULT>): VISIT_RESULT {
-            return visitor.templateEntityConversionSelectQuery(context, metamodel, collect)
+            return visitor.templateEntityProjectionSelectQuery(context, metamodel, collect)
         }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateSelectQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateSelectQueryBuilder.kt
@@ -59,6 +59,6 @@ internal data class TemplateSelectQueryBuilderImpl(
     }
 
     override fun <ENTITY : Any> selectAsEntity(metamodel: EntityMetamodel<ENTITY, *, *>): TemplateSelectQuery<ENTITY> {
-        return TemplateEntityConversionSelectQuery(context, metamodel)
+        return TemplateEntityProjectionSelectQuery(context, metamodel)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateSelectQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateSelectQueryBuilder.kt
@@ -35,9 +35,10 @@ interface TemplateSelectQueryBuilder : TemplateBinder<TemplateSelectQueryBuilder
      *
      * @param ENTITY the entity type
      * @param metamodel the entity metamodel
+     * @param strategy the projection strategy
      * @return the query that returns a list of entity
      */
-    fun <ENTITY : Any> selectAsEntity(metamodel: EntityMetamodel<ENTITY, *, *>): TemplateSelectQuery<ENTITY>
+    fun <ENTITY : Any> selectAsEntity(metamodel: EntityMetamodel<ENTITY, *, *>, strategy: ProjectionType = ProjectionType.INDEX): TemplateSelectQuery<ENTITY>
 }
 
 internal data class TemplateSelectQueryBuilderImpl(
@@ -58,7 +59,7 @@ internal data class TemplateSelectQueryBuilderImpl(
         return TemplateSelectQueryImpl(context, transform)
     }
 
-    override fun <ENTITY : Any> selectAsEntity(metamodel: EntityMetamodel<ENTITY, *, *>): TemplateSelectQuery<ENTITY> {
-        return TemplateEntityProjectionSelectQuery(context, metamodel)
+    override fun <ENTITY : Any> selectAsEntity(metamodel: EntityMetamodel<ENTITY, *, *>, strategy: ProjectionType): TemplateSelectQuery<ENTITY> {
+        return TemplateEntityProjectionSelectQuery(context, metamodel, strategy)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/ValueExtractingException.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/ValueExtractingException.kt
@@ -1,8 +1,8 @@
 package org.komapper.core.dsl.runner
 
 /**
- * @param index the index of the column starting at 0
+ * @param message the message
  * @param cause the cause
  */
-class ValueExtractingException(index: Int, cause: Exception) :
-    RuntimeException("Failed to extract a value from column. The column index is $index.", cause)
+class ValueExtractingException(message: String, cause: Exception) :
+    RuntimeException(message, cause)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/ValueExtractor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/ValueExtractor.kt
@@ -3,7 +3,7 @@ package org.komapper.core.dsl.runner
 import org.komapper.core.dsl.expression.ColumnExpression
 
 object ValueExtractor {
-    inline fun <EXTERIOR : Any, INTERIOR : Any> execute(
+    inline fun <EXTERIOR : Any, INTERIOR : Any> getByIndex(
         expression: ColumnExpression<EXTERIOR, INTERIOR>,
         index: Int,
         block: () -> INTERIOR?,
@@ -12,7 +12,21 @@ object ValueExtractor {
             val value = block()
             if (value == null) null else expression.wrap(value)
         } catch (e: Exception) {
-            throw ValueExtractingException(index, e)
+            val message = "Failed to extract a value from column. The column index is $index. (Column indices start from 0.)"
+            throw ValueExtractingException(message, e)
+        }
+    }
+
+    inline fun <EXTERIOR : Any, INTERIOR : Any> getByName(
+        expression: ColumnExpression<EXTERIOR, INTERIOR>,
+        block: () -> INTERIOR?,
+    ): EXTERIOR? {
+        return try {
+            val value = block()
+            if (value == null) null else expression.wrap(value)
+        } catch (e: Exception) {
+            val message = "Failed to extract a value from column. The column label is ${expression.columnName}."
+            throw ValueExtractingException(message, e)
         }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
@@ -18,6 +18,7 @@ import org.komapper.core.dsl.context.TemplateExecuteContext
 import org.komapper.core.dsl.context.TemplateSelectContext
 import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.query.Query
 import org.komapper.core.dsl.query.Record
 import org.komapper.core.dsl.query.Row
@@ -655,6 +656,7 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
     override fun <T : Any, R> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
+        strategy: ProjectionType,
         collect: suspend (Flow<T>) -> R,
     ): Runner {
         return TemplateSelectRunner(context)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/DefaultQueryVisitor.kt
@@ -523,7 +523,7 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         return SetOperationRunner(context)
     }
 
-    override fun <ENTITY : Any, R> entityConversionSelectQuery(
+    override fun <ENTITY : Any, R> entityProjectionSelectQuery(
         context: SelectContext<*, *, *>,
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
@@ -531,7 +531,7 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         return SelectRunner(context)
     }
 
-    override fun <ENTITY : Any, R> entityConversionSetOperationQuery(
+    override fun <ENTITY : Any, R> entityProjectionSetOperationQuery(
         context: SetOperationContext,
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
@@ -652,7 +652,7 @@ internal object DefaultQueryVisitor : QueryVisitor<Runner> {
         return TemplateSelectRunner(context)
     }
 
-    override fun <T : Any, R> templateEntityConversionSelectQuery(
+    override fun <T : Any, R> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
         collect: suspend (Flow<T>) -> R,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/FlowQueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/FlowQueryVisitor.kt
@@ -6,6 +6,7 @@ import org.komapper.core.dsl.context.SetOperationContext
 import org.komapper.core.dsl.context.TemplateSelectContext
 import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.query.Row
 
 @ThreadSafe
@@ -110,5 +111,6 @@ interface FlowQueryVisitor<VISIT_RESULT> {
     fun <T : Any> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
+        strategy: ProjectionType,
     ): VISIT_RESULT
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/FlowQueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/FlowQueryVisitor.kt
@@ -92,12 +92,12 @@ interface FlowQueryVisitor<VISIT_RESULT> {
         expressions: List<ColumnExpression<*, *>>,
     ): VISIT_RESULT
 
-    fun <ENTITY : Any> entityConversionSelectQuery(
+    fun <ENTITY : Any> entityProjectionSelectQuery(
         context: SelectContext<*, *, *>,
         metamodel: EntityMetamodel<ENTITY, *, *>,
     ): VISIT_RESULT
 
-    fun <ENTITY : Any> entityConversionSetOperationQuery(
+    fun <ENTITY : Any> entityProjectionSetOperationQuery(
         context: SetOperationContext,
         metamodel: EntityMetamodel<ENTITY, *, *>,
     ): VISIT_RESULT
@@ -107,7 +107,7 @@ interface FlowQueryVisitor<VISIT_RESULT> {
         transform: (Row) -> T,
     ): VISIT_RESULT
 
-    fun <T : Any> templateEntityConversionSelectQuery(
+    fun <T : Any> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
     ): VISIT_RESULT

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
@@ -404,13 +404,13 @@ interface QueryVisitor<VISIT_RESULT> {
         collect: suspend (Flow<Record>) -> R,
     ): VISIT_RESULT
 
-    fun <ENTITY : Any, R> entityConversionSelectQuery(
+    fun <ENTITY : Any, R> entityProjectionSelectQuery(
         context: SelectContext<*, *, *>,
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
     ): VISIT_RESULT
 
-    fun <ENTITY : Any, R> entityConversionSetOperationQuery(
+    fun <ENTITY : Any, R> entityProjectionSetOperationQuery(
         context: SetOperationContext,
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
@@ -515,7 +515,7 @@ interface QueryVisitor<VISIT_RESULT> {
         collect: suspend (Flow<T>) -> R,
     ): VISIT_RESULT
 
-    fun <T : Any, R> templateEntityConversionSelectQuery(
+    fun <T : Any, R> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
         collect: suspend (Flow<T>) -> R,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/visitor/QueryVisitor.kt
@@ -18,6 +18,7 @@ import org.komapper.core.dsl.context.TemplateExecuteContext
 import org.komapper.core.dsl.context.TemplateSelectContext
 import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.query.Query
 import org.komapper.core.dsl.query.Record
 import org.komapper.core.dsl.query.Row
@@ -518,6 +519,7 @@ interface QueryVisitor<VISIT_RESULT> {
     fun <T : Any, R> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
+        strategy: ProjectionType,
         collect: suspend (Flow<T>) -> R,
     ): VISIT_RESULT
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityMapper.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityMapper.kt
@@ -2,12 +2,16 @@ package org.komapper.jdbc.dsl.runner
 
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.runner.PropertyMappingException
 import org.komapper.jdbc.JdbcDataOperator
 import java.sql.ResultSet
 
-internal class JdbcEntityMapper(dataOperator: JdbcDataOperator, resultSet: ResultSet) {
-    private val valueExtractor = JdbcValueExtractor(dataOperator, resultSet)
+internal class JdbcEntityMapper(strategy: ProjectionType, dataOperator: JdbcDataOperator, resultSet: ResultSet) {
+    private val valueExtractor = when (strategy) {
+        ProjectionType.INDEX -> JdbcIndexedValueExtractor(dataOperator, resultSet)
+        ProjectionType.NAME -> JdbcNamedValueExtractor(dataOperator, resultSet)
+    }
 
     fun <E : Any> execute(metamodel: EntityMetamodel<E, *, *>, forceMapping: Boolean = false): E? {
         val valueMap = mutableMapOf<PropertyMetamodel<*, *, *>, Any?>()

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityStoreRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityStoreRunner.kt
@@ -5,6 +5,7 @@ import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.SelectContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.query.EntityStore
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.runner.EntityStoreFactory
 import org.komapper.core.dsl.runner.SelectRunner
 import org.komapper.jdbc.JdbcDatabaseConfig
@@ -28,7 +29,7 @@ internal class JdbcEntityStoreRunner<ENTITY : Any, ID : Any, META : EntityMetamo
             val rows = mutableListOf<Map<EntityMetamodel<*, *, *>, Any>>()
             while (rs.next()) {
                 val row = mutableMapOf<EntityMetamodel<*, *, *>, Any>()
-                val mapper = JdbcEntityMapper(config.dataOperator, rs)
+                val mapper = JdbcEntityMapper(ProjectionType.INDEX, config.dataOperator, rs)
                 for (metamodel in metamodels) {
                     val entity = mapper.execute(metamodel) ?: continue
                     row[metamodel] = entity

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcTemplateEntityProjectionSelectRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcTemplateEntityProjectionSelectRunner.kt
@@ -9,7 +9,7 @@ import org.komapper.jdbc.JdbcDataOperator
 import org.komapper.jdbc.JdbcDatabaseConfig
 import java.sql.ResultSet
 
-internal class JdbcTemplateEntityConversionSelectRunner<T, R>(
+internal class JdbcTemplateEntityProjectionSelectRunner<T, R>(
     private val context: TemplateSelectContext,
     private val transform: (JdbcDataOperator, ResultSet) -> T,
     private val collect: suspend (Flow<T>) -> R,

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
@@ -55,7 +55,7 @@ import org.komapper.jdbc.dsl.runner.JdbcSchemaDropRunner
 import org.komapper.jdbc.dsl.runner.JdbcScriptExecuteRunner
 import org.komapper.jdbc.dsl.runner.JdbcSelectRunner
 import org.komapper.jdbc.dsl.runner.JdbcSetOperationRunner
-import org.komapper.jdbc.dsl.runner.JdbcTemplateEntityConversionSelectRunner
+import org.komapper.jdbc.dsl.runner.JdbcTemplateEntityProjectionSelectRunner
 import org.komapper.jdbc.dsl.runner.JdbcTemplateExecuteRunner
 import org.komapper.jdbc.dsl.runner.JdbcTemplateSelectRunner
 
@@ -582,7 +582,7 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         return JdbcSetOperationRunner(context, transform, collect)
     }
 
-    override fun <ENTITY : Any, R> entityConversionSelectQuery(
+    override fun <ENTITY : Any, R> entityProjectionSelectQuery(
         context: SelectContext<*, *, *>,
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
@@ -591,7 +591,7 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         return JdbcSelectRunner(context, transform, collect)
     }
 
-    override fun <ENTITY : Any, R> entityConversionSetOperationQuery(
+    override fun <ENTITY : Any, R> entityProjectionSetOperationQuery(
         context: SetOperationContext,
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
@@ -727,12 +727,12 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         return JdbcTemplateSelectRunner(context, transform, collect)
     }
 
-    override fun <T : Any, R> templateEntityConversionSelectQuery(
+    override fun <T : Any, R> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
         collect: suspend (Flow<T>) -> R,
     ): JdbcRunner<*> {
         val transform = JdbcResultSetTransformers.singleEntity(metamodel)
-        return JdbcTemplateEntityConversionSelectRunner(context, transform, collect)
+        return JdbcTemplateEntityProjectionSelectRunner(context, transform, collect)
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
@@ -18,6 +18,7 @@ import org.komapper.core.dsl.context.TemplateSelectContext
 import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.query.EntityStore
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.query.Query
 import org.komapper.core.dsl.query.Record
 import org.komapper.core.dsl.query.Row
@@ -730,9 +731,10 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
     override fun <T : Any, R> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
+        strategy: ProjectionType,
         collect: suspend (Flow<T>) -> R,
     ): JdbcRunner<*> {
-        val transform = JdbcResultSetTransformers.singleEntity(metamodel)
+        val transform = JdbcResultSetTransformers.singleEntity(metamodel, strategy)
         return JdbcTemplateEntityProjectionSelectRunner(context, transform, collect)
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -27,11 +27,15 @@ import org.komapper.processor.Symbols.KotlinInstant
 import org.komapper.processor.Symbols.KotlinLocalDateTime
 import org.komapper.processor.Symbols.LocalDateTime
 import org.komapper.processor.Symbols.Operand
+import org.komapper.processor.Symbols.ProjectionType
+import org.komapper.processor.Symbols.ProjectionType_INDEX
 import org.komapper.processor.Symbols.PropertyDescriptor
 import org.komapper.processor.Symbols.PropertyMetamodel
 import org.komapper.processor.Symbols.PropertyMetamodelImpl
 import org.komapper.processor.Symbols.SelectQuery
 import org.komapper.processor.Symbols.Sequence
+import org.komapper.processor.Symbols.TemplateSelectQuery
+import org.komapper.processor.Symbols.TemplateSelectQueryBuilder
 import org.komapper.processor.Symbols.UUID
 import org.komapper.processor.Symbols.checkMetamodelVersion
 import org.komapper.processor.Symbols.toKotlinInstant
@@ -737,6 +741,11 @@ internal class EntityMetamodelGenerator(
     }
 
     private fun projection() {
+        projectionForSelectQuery()
+        projectionForTemplateSelectQueryBuilder()
+    }
+
+    private fun projectionForSelectQuery() {
         if (entity.projection == null) return
         val function = entity.projection.function
         val params = entity.properties.flatMap { p ->
@@ -756,6 +765,17 @@ internal class EntityMetamodelGenerator(
         w.println("fun <E, Q: $SelectQuery<E, Q>> $SelectQuery<E, Q>.$function($paramList")
         w.println("    ): $FlowSubquery<$entityTypeName> {")
         w.println("    return selectAsEntity($unitTypeName.`${aliases.first()}`,$argList)")
+        w.println("}")
+        w.println()
+    }
+
+    private fun projectionForTemplateSelectQueryBuilder() {
+        if (entity.projection == null) return
+        val function = entity.projection.function
+        w.println("fun $TemplateSelectQueryBuilder.$function(")
+        w.println("        strategy: $ProjectionType = $ProjectionType_INDEX")
+        w.println("    ): $TemplateSelectQuery<$entityTypeName> {")
+        w.println("    return selectAsEntity($unitTypeName.`${aliases.first()}`, strategy)")
         w.println("}")
         w.println()
     }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -44,5 +44,9 @@ internal object Symbols {
     const val KomapperExperimentalAssociation = "org.komapper.annotation.KomapperExperimentalAssociation"
     const val SelectQuery = "org.komapper.core.dsl.query.SelectQuery"
     const val FlowSubquery = "org.komapper.core.dsl.query.FlowSubquery"
+    const val TemplateSelectQueryBuilder = "org.komapper.core.dsl.query.TemplateSelectQueryBuilder"
+    const val TemplateSelectQuery = "org.komapper.core.dsl.query.TemplateSelectQuery"
+    const val ProjectionType = "org.komapper.core.dsl.query.ProjectionType"
+    const val ProjectionType_INDEX = "org.komapper.core.dsl.query.ProjectionType.INDEX"
     const val ColumnExpression = "org.komapper.core.dsl.expression.ColumnExpression"
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityMapper.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityMapper.kt
@@ -3,11 +3,15 @@ package org.komapper.r2dbc.dsl.runner
 import io.r2dbc.spi.Row
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.runner.PropertyMappingException
 import org.komapper.r2dbc.R2dbcDataOperator
 
-internal class R2dbcEntityMapper(dataOperator: R2dbcDataOperator, row: Row) {
-    private val valueExtractor = R2dbcValueExtractor(dataOperator, row)
+internal class R2dbcEntityMapper(strategy: ProjectionType, dataOperator: R2dbcDataOperator, row: Row) {
+    private val valueExtractor = when (strategy) {
+        ProjectionType.INDEX -> R2dbcIndexedValueExtractor(dataOperator, row)
+        ProjectionType.NAME -> R2dbcNamedValueExtractor(dataOperator, row)
+    }
 
     fun <E : Any> execute(metamodel: EntityMetamodel<E, *, *>, forceMapping: Boolean = false): E? {
         val valueMap = mutableMapOf<PropertyMetamodel<*, *, *>, Any?>()

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityStoreRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityStoreRunner.kt
@@ -7,6 +7,7 @@ import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.SelectContext
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.query.EntityStore
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.runner.EntityStoreFactory
 import org.komapper.core.dsl.runner.SelectRunner
 import org.komapper.r2dbc.R2dbcDatabaseConfig
@@ -29,7 +30,7 @@ internal class R2dbcEntityStoreRunner<ENTITY : Any, ID : Any, META : EntityMetam
         val executor = R2dbcExecutor(config, context.options)
         val rows: Flow<Map<EntityMetamodel<*, *, *>, Any>> = executor.executeQuery(statement) { dataOperator, r2dbcRow ->
             val row = mutableMapOf<EntityMetamodel<*, *, *>, Any>()
-            val mapper = R2dbcEntityMapper(dataOperator, r2dbcRow)
+            val mapper = R2dbcEntityMapper(ProjectionType.INDEX, dataOperator, r2dbcRow)
             for (metamodel in metamodels) {
                 val entity = mapper.execute(metamodel) ?: continue
                 row[metamodel] = entity

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcTemplateEntityProjectionSelectFlowBuilder.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcTemplateEntityProjectionSelectFlowBuilder.kt
@@ -10,7 +10,7 @@ import org.komapper.r2dbc.R2dbcDataOperator
 import org.komapper.r2dbc.R2dbcDatabaseConfig
 import org.komapper.r2dbc.R2dbcExecutor
 
-internal class R2dbcTemplateEntityConversionSelectFlowBuilder<T>(
+internal class R2dbcTemplateEntityProjectionSelectFlowBuilder<T>(
     private val context: TemplateSelectContext,
     private val transform: (R2dbcDataOperator, Row) -> T,
 ) : R2dbcFlowBuilder<T> {

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcTemplateEntityProjectionSelectRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcTemplateEntityProjectionSelectRunner.kt
@@ -8,13 +8,13 @@ import org.komapper.core.dsl.context.TemplateSelectContext
 import org.komapper.r2dbc.R2dbcDataOperator
 import org.komapper.r2dbc.R2dbcDatabaseConfig
 
-internal class R2dbcTemplateEntityConversionSelectRunner<T, R>(
+internal class R2dbcTemplateEntityProjectionSelectRunner<T, R>(
     context: TemplateSelectContext,
     transform: (R2dbcDataOperator, Row) -> T,
     private val collect: suspend (Flow<T>) -> R,
 ) : R2dbcRunner<R> {
 
-    private val flowBuilder = R2dbcTemplateEntityConversionSelectFlowBuilder(context, transform)
+    private val flowBuilder = R2dbcTemplateEntityProjectionSelectFlowBuilder(context, transform)
 
     override fun check(config: DatabaseConfig) {
         flowBuilder.check(config)

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcFlowQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcFlowQueryVisitor.kt
@@ -12,7 +12,7 @@ import org.komapper.r2dbc.dsl.runner.R2dbcFlowBuilder
 import org.komapper.r2dbc.dsl.runner.R2dbcRowTransformers
 import org.komapper.r2dbc.dsl.runner.R2dbcSelectFlowBuilder
 import org.komapper.r2dbc.dsl.runner.R2dbcSetOperationFlowBuilder
-import org.komapper.r2dbc.dsl.runner.R2dbcTemplateEntityConversionSelectFlowBuilder
+import org.komapper.r2dbc.dsl.runner.R2dbcTemplateEntityProjectionSelectFlowBuilder
 import org.komapper.r2dbc.dsl.runner.R2dbcTemplateSelectFlowBuilder
 
 object R2dbcFlowQueryVisitor : FlowQueryVisitor<R2dbcFlowBuilder<*>> {
@@ -144,7 +144,7 @@ object R2dbcFlowQueryVisitor : FlowQueryVisitor<R2dbcFlowBuilder<*>> {
         return R2dbcSetOperationFlowBuilder(context, transform)
     }
 
-    override fun <ENTITY : Any> entityConversionSelectQuery(
+    override fun <ENTITY : Any> entityProjectionSelectQuery(
         context: SelectContext<*, *, *>,
         metamodel: EntityMetamodel<ENTITY, *, *>,
     ): R2dbcFlowBuilder<*> {
@@ -152,7 +152,7 @@ object R2dbcFlowQueryVisitor : FlowQueryVisitor<R2dbcFlowBuilder<*>> {
         return R2dbcSelectFlowBuilder(context, transform)
     }
 
-    override fun <ENTITY : Any> entityConversionSetOperationQuery(
+    override fun <ENTITY : Any> entityProjectionSetOperationQuery(
         context: SetOperationContext,
         metamodel: EntityMetamodel<ENTITY, *, *>,
     ): R2dbcFlowBuilder<*> {
@@ -167,11 +167,11 @@ object R2dbcFlowQueryVisitor : FlowQueryVisitor<R2dbcFlowBuilder<*>> {
         return R2dbcTemplateSelectFlowBuilder(context, transform)
     }
 
-    override fun <T : Any> templateEntityConversionSelectQuery(
+    override fun <T : Any> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
     ): R2dbcFlowBuilder<*> {
         val transform = R2dbcRowTransformers.singleEntity(metamodel)
-        return R2dbcTemplateEntityConversionSelectFlowBuilder(context, transform)
+        return R2dbcTemplateEntityProjectionSelectFlowBuilder(context, transform)
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcFlowQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcFlowQueryVisitor.kt
@@ -5,6 +5,7 @@ import org.komapper.core.dsl.context.SetOperationContext
 import org.komapper.core.dsl.context.TemplateSelectContext
 import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.query.Record
 import org.komapper.core.dsl.query.Row
 import org.komapper.core.dsl.visitor.FlowQueryVisitor
@@ -170,8 +171,9 @@ object R2dbcFlowQueryVisitor : FlowQueryVisitor<R2dbcFlowBuilder<*>> {
     override fun <T : Any> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
+        strategy: ProjectionType,
     ): R2dbcFlowBuilder<*> {
-        val transform = R2dbcRowTransformers.singleEntity(metamodel)
+        val transform = R2dbcRowTransformers.singleEntity(metamodel, strategy)
         return R2dbcTemplateEntityProjectionSelectFlowBuilder(context, transform)
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
@@ -18,6 +18,7 @@ import org.komapper.core.dsl.context.TemplateSelectContext
 import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.query.EntityStore
+import org.komapper.core.dsl.query.ProjectionType
 import org.komapper.core.dsl.query.Query
 import org.komapper.core.dsl.query.Record
 import org.komapper.core.dsl.query.Row
@@ -726,9 +727,10 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
     override fun <T : Any, R> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
+        strategy: ProjectionType,
         collect: suspend (Flow<T>) -> R,
     ): R2dbcRunner<*> {
-        val transform = R2dbcRowTransformers.singleEntity(metamodel)
+        val transform = R2dbcRowTransformers.singleEntity(metamodel, strategy)
         return R2dbcTemplateEntityProjectionSelectRunner(context, transform, collect)
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
@@ -55,7 +55,7 @@ import org.komapper.r2dbc.dsl.runner.R2dbcSchemaDropRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcScriptExecuteRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcSelectRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcSetOperationRunner
-import org.komapper.r2dbc.dsl.runner.R2dbcTemplateEntityConversionSelectRunner
+import org.komapper.r2dbc.dsl.runner.R2dbcTemplateEntityProjectionSelectRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcTemplateExecuteRunner
 import org.komapper.r2dbc.dsl.runner.R2dbcTemplateSelectRunner
 
@@ -578,7 +578,7 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         return R2dbcSetOperationRunner(context, transform, collect)
     }
 
-    override fun <ENTITY : Any, R> entityConversionSelectQuery(
+    override fun <ENTITY : Any, R> entityProjectionSelectQuery(
         context: SelectContext<*, *, *>,
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
@@ -587,7 +587,7 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         return R2dbcSelectRunner(context, transform, collect)
     }
 
-    override fun <ENTITY : Any, R> entityConversionSetOperationQuery(
+    override fun <ENTITY : Any, R> entityProjectionSetOperationQuery(
         context: SetOperationContext,
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
@@ -723,12 +723,12 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         return R2dbcTemplateSelectRunner(context, transform, collect)
     }
 
-    override fun <T : Any, R> templateEntityConversionSelectQuery(
+    override fun <T : Any, R> templateEntityProjectionSelectQuery(
         context: TemplateSelectContext,
         metamodel: EntityMetamodel<T, *, *>,
         collect: suspend (Flow<T>) -> R,
     ): R2dbcRunner<*> {
         val transform = R2dbcRowTransformers.singleEntity(metamodel)
-        return R2dbcTemplateEntityConversionSelectRunner(context, transform, collect)
+        return R2dbcTemplateEntityProjectionSelectRunner(context, transform, collect)
     }
 }


### PR DESCRIPTION
This feature generates an extension function at compile time that converts the results of TemplateQuery into specific entities. When mapping the SQL SELECT list to an entity, you can choose to use either the column index or the column name.


**entity**
```kotlin
@KomapperEntity
@KomapperProjection
data class Address(
    @KomapperId
    @KomapperColumn(name = "address_id")
    val addressId: Int,
    val street: String,
    @KomapperVersion val version: Int,
)
```

**mapping by column index**
```kotlin
val sql = "select address_id, street, version from address order by address_id"
val query: Query<List<Address>> = QueryDsl.fromTemplate(sql).selectAsAddress()
```

**mapping by column name**
```kotlin
val sql = "select street, version, address_id from address order by address_id"
val query: Query<List<Address>> = QueryDsl.fromTemplate(sql).selectAsAddress(ProjectionType.NAME)
```