### PR TITLE
Simplify the creation of custom column expressions

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
@@ -341,7 +341,7 @@ class JdbcSelectTest(private val db: JdbcDatabase) {
     private fun fromUnixTime(value: Long): ColumnExpression<LocalDateTime, LocalDateTime> {
         val name = "fromUnixTime"
         val o1 = Operand.SimpleArgument(Long::class, value)
-        return columnExpression(LocalDateTime::class, LocalDateTime::class, { it }, name, listOf(o1)) {
+        return columnExpression(LocalDateTime::class, name, listOf(o1)) {
             append("FROM_UNIXTIME(")
             visit(o1)
             append(")")

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
@@ -2,9 +2,11 @@ package integration.jdbc
 
 import integration.core.Address
 import integration.core.Android
+import integration.core.Dbms
 import integration.core.Robot
 import integration.core.RobotInfo1
 import integration.core.RobotInfo2
+import integration.core.Run
 import integration.core.address
 import integration.core.android
 import integration.core.employee
@@ -16,9 +18,12 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.When
 import org.komapper.core.dsl.metamodel.define
 import org.komapper.core.dsl.operator.case
+import org.komapper.core.dsl.operator.columnExpression
 import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.operator.desc
 import org.komapper.core.dsl.operator.literal
@@ -28,6 +33,7 @@ import org.komapper.core.dsl.query.single
 import org.komapper.core.dsl.query.singleOrNull
 import org.komapper.jdbc.JdbcDatabase
 import java.math.BigDecimal
+import java.time.LocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -321,5 +327,24 @@ class JdbcSelectTest(private val db: JdbcDatabase) {
             QueryDsl.from(a)
         }
         assertEquals(15, list.size)
+    }
+
+    @Test
+    @Run(onlyIf = [Dbms.MYSQL])
+    fun simpleArgument() {
+        val value = db.runQuery {
+            QueryDsl.select(fromUnixTime(1447430881L)).single()
+        }
+        assertEquals(LocalDateTime.of(2015, 11, 13, 16, 8, 1), value)
+    }
+
+    private fun fromUnixTime(value: Long): ColumnExpression<LocalDateTime, LocalDateTime> {
+        val name = "fromUnixTime"
+        val o1 = Operand.SimpleArgument(Long::class, value)
+        return columnExpression(LocalDateTime::class, LocalDateTime::class, { it }, name, listOf(o1)) {
+            append("FROM_UNIXTIME(")
+            visit(o1)
+            append(")")
+        }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
@@ -642,6 +642,10 @@ class BuilderSupport(
                 buf.bind(operand.value)
             }
 
+            is Operand.SimpleArgument<*> -> {
+                buf.bind(operand.value)
+            }
+
             is Operand.Escape -> {
                 val values = buildEscapedValuePair(operand.escapeExpression, operand.masking)
                 buf.bind(values.first)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/Operand.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/Operand.kt
@@ -2,6 +2,7 @@ package org.komapper.core.dsl.expression
 
 import org.komapper.core.ThreadSafe
 import org.komapper.core.Value
+import kotlin.reflect.KClass
 
 /**
  * Represents operands in Komapper Query DSL.
@@ -37,6 +38,23 @@ sealed class Operand {
         val value: Value<S> get() {
             val interior = if (exterior == null) null else expression.unwrap(exterior)
             return Value(interior, expression.interiorClass, expression.masking)
+        }
+    }
+
+    /**
+     * A simple argument to be bound to a prepared statement.
+     *
+     * @param interiorClass the interior class
+     * @param interior the argument value
+     */
+    data class SimpleArgument<S : Any>(val interiorClass: KClass<S>, val interior: S?) : Operand() {
+        override val masking: Boolean get() = false
+
+        /**
+         * The bindable format of the argument.
+         */
+        val value: Value<S> get() {
+            return Value(interior, interiorClass, masking)
         }
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/OperatorUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/OperatorUtility.kt
@@ -11,7 +11,8 @@ import kotlin.reflect.KClass
  *
  * The [name] and [operands] are used to determine identity of the expression.
  *
- * @param T the type of expression evaluation
+ * @param T the exterior type of expression evaluation
+ * @param S the interior type of expression evaluation
  * @param baseExpression the base column expression
  * @param name the name that must be unique among user-defined column expressions
  * @param operands the operand list used in the expression
@@ -25,6 +26,27 @@ fun <T : Any, S : Any> columnExpression(
     build: SqlBuilderScope.() -> Unit,
 ): ColumnExpression<T, S> {
     return columnExpression(baseExpression.exteriorClass, baseExpression.interiorClass, baseExpression.wrap, name, operands, build)
+}
+
+/**
+ * Define a new column expression.
+ *
+ * The [name] and [operands] are used to determine identity of the expression.
+ *
+ * @param T the exterior type and interior type of expression evaluation
+ * @param klass the class of [T]
+ * @param name the name that must be unique among user-defined column expressions
+ * @param operands the operand list used in the expression
+ * @param build the SQL builder
+ * @return column expression
+ */
+fun <T : Any> columnExpression(
+    klass: KClass<T>,
+    name: String,
+    operands: List<Operand>,
+    build: SqlBuilderScope.() -> Unit,
+): ColumnExpression<T, T> {
+    return columnExpression(klass, klass, { it }, name, operands, build)
 }
 
 /**


### PR DESCRIPTION
**BEFORE**
```kotlin
private fun fromUnixTime(value: Long): ColumnExpression<LocalDateTime, LocalDateTime> {
    val name = "fromUnixTime"
    val o1 = Operand.Argument(literal(0L), value)
    return columnExpression(LocalDateTime::class, LocalDateTime::class, { it }, name, listOf(o1)) {
        append("FROM_UNIXTIME(")
        visit(o1)
        append(")")
    }
}
```

**AFTER**
```kotlin
private fun fromUnixTime(value: Long): ColumnExpression<LocalDateTime, LocalDateTime> {
    val name = "fromUnixTime"
    val o1 = Operand.SimpleArgument(Long::class, value)
    return columnExpression(LocalDateTime::class, name, listOf(o1)) {
        append("FROM_UNIXTIME(")
        visit(o1)
        append(")")
    }
}
```