### PR TITLE
Add dialect configuration to control whether output column names are included in a CTE definition.

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -269,6 +269,11 @@ interface Dialect {
     fun supportsAsKeywordForTableAlias(): Boolean = true
 
     /**
+     * Returns whether the list of column names is supported after the name of a common table expression.
+     */
+    fun supportsColumnNamesInCteDefinition(): Boolean = true
+
+    /**
      * Returns whether the conflict_target is supported in the UPSERT statement.
      */
     fun supportsConflictTargetInUpsertStatement(): Boolean = false

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilder.kt
@@ -57,12 +57,17 @@ class SelectStatementBuilder(
                         buf.append(", ")
                     }
                     buf.cutBack(2)
-                    buf.append(")")
+                    buf.append(") as (")
+                    val statement = support.buildSubqueryStatement(subquery.context)
+                    buf.append(statement)
+                    buf.append("), ")
+                } else {
+                    buf.append(" as (")
+                    val subqueryContext = assignAliasesToSubqueryColumns(subquery.context, table.properties())
+                    val statement = support.buildSubqueryStatement(subqueryContext)
+                    buf.append(statement)
+                    buf.append("), ")
                 }
-                buf.append(" as (")
-                val statement = support.buildSubqueryStatement(subquery.context)
-                buf.append(statement)
-                buf.append("), ")
             }
             buf.cutBack(2)
             buf.append(" ")
@@ -93,31 +98,7 @@ class SelectStatementBuilder(
         if (context.derivedTable == null) {
             table(context.target)
         } else {
-            fun copySubqueryContext(subqueryContext: SubqueryContext): SubqueryContext {
-                return when (subqueryContext) {
-                    is SelectContext<*, *, *> -> {
-                        val properties = context.target.properties()
-                        val columns = subqueryContext.getProjection().expressions()
-                        val aliases = properties.zip(columns).map { (outer, inner) ->
-                            if (inner is AliasExpression) {
-                                error("The alias operand is found. Komapper does not allow the use of alias operand in derived tables.")
-                            } else {
-                                AliasExpression(inner, outer.columnName, outer.alwaysQuote)
-                            }
-                        }
-                        subqueryContext.copy(select = aliases)
-                    }
-
-                    is SetOperationContext -> {
-                        subqueryContext.copy(
-                            left = copySubqueryContext(subqueryContext.left),
-                            right = copySubqueryContext(subqueryContext.right),
-                        )
-                    }
-                }
-            }
-
-            val subqueryContext = copySubqueryContext(context.derivedTable.context)
+            val subqueryContext = assignAliasesToSubqueryColumns(context.derivedTable.context, context.target.properties())
             val statement = support.buildSubqueryStatement(subqueryContext)
             buf.append("(")
             buf.append(statement)
@@ -292,6 +273,29 @@ class SelectStatementBuilder(
                 buf.append(" wait ${lockOption.second}")
             } else {
                 raiseError("wait")
+            }
+        }
+    }
+
+    private fun assignAliasesToSubqueryColumns(subqueryContext: SubqueryContext, outerColumns: List<ColumnExpression<*, *>>): SubqueryContext {
+        return when (subqueryContext) {
+            is SelectContext<*, *, *> -> {
+                val innerColumns = subqueryContext.getProjection().expressions()
+                val aliases = outerColumns.zip(innerColumns).map { (outer, inner) ->
+                    if (inner is AliasExpression) {
+                        error("The alias operand is found. Komapper does not allow the use of alias operand in derived tables.")
+                    } else {
+                        AliasExpression(inner, outer.columnName, outer.alwaysQuote)
+                    }
+                }
+                subqueryContext.copy(select = aliases)
+            }
+
+            is SetOperationContext -> {
+                subqueryContext.copy(
+                    left = assignAliasesToSubqueryColumns(subqueryContext.left, outerColumns),
+                    right = assignAliasesToSubqueryColumns(subqueryContext.right, outerColumns),
+                )
             }
         }
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilder.kt
@@ -48,14 +48,18 @@ class SelectStatementBuilder(
             }
             for ((table, subquery) in context.with.pairs) {
                 table(table, TableNameType.NAME_ONLY)
-                buf.append(" (")
-                for (p in table.properties()) {
-                    val columnName = p.getCanonicalColumnName(dialect::enquote)
-                    buf.append(columnName)
-                    buf.append(", ")
+
+                if (dialect.supportsColumnNamesInCteDefinition()) {
+                    buf.append(" (")
+                    for (p in table.properties()) {
+                        val columnName = p.getCanonicalColumnName(dialect::enquote)
+                        buf.append(columnName)
+                        buf.append(", ")
+                    }
+                    buf.cutBack(2)
+                    buf.append(")")
                 }
-                buf.cutBack(2)
-                buf.append(") as (")
+                buf.append(" as (")
                 val statement = support.buildSubqueryStatement(subquery.context)
                 buf.append(statement)
                 buf.append("), ")


### PR DESCRIPTION
In at least one case, namely ClickHouse, the following syntax is not supported:

```sql
with my_table (a, b, c) as (select ...) ...
```

but is instead limited to
```sql
with my_table as (select ...) ...
```

So I'm adding a configuration option to make expansion of column names optional within a dialect.

This follows this [discussion](https://kotlinlang.slack.com/archives/C03JF82SDHA/p1704895714562399?thread_ts=1704884009.087219&cid=C03JF82SDHA) that happened in Kotlin Slack.