### PR TITLE
Make `@KomapperProjection` independent from `@KomapperEntity`

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -369,7 +369,7 @@ data class EmployeeSalary(
 @KomapperProjection
 data class AddressDto(
     @KomapperColumn("address_id") val idValue: Int,
-    @KomapperColumn("street") val streetValue: String,
+    @KomapperColumn("street") val streetValue: String?,
 )
 
 data class DepartmentDto(

--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -15,6 +15,7 @@ import org.komapper.annotation.KomapperManyToOne
 import org.komapper.annotation.KomapperOneToMany
 import org.komapper.annotation.KomapperOneToOne
 import org.komapper.annotation.KomapperProjection
+import org.komapper.annotation.KomapperProjectionDef
 import org.komapper.annotation.KomapperSequence
 import org.komapper.annotation.KomapperTable
 import org.komapper.annotation.KomapperUpdatedAt
@@ -364,3 +365,17 @@ data class EmployeeSalary(
     val salary: BigDecimal,
     val averageSalary: BigDecimal,
 )
+
+@KomapperProjection
+data class AddressDto(
+    @KomapperColumn("address_id") val idValue: Int,
+    @KomapperColumn("street") val streetValue: String,
+)
+
+data class DepartmentDto(
+    val department: String,
+    val memberCount: Long,
+)
+
+@KomapperProjectionDef(DepartmentDto::class)
+object DepartmentDtoDef

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectProjectionTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectProjectionTest.kt
@@ -14,6 +14,7 @@ import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.operator.count
+import org.komapper.core.dsl.operator.nullLiteral
 import org.komapper.core.dsl.operator.transform
 import org.komapper.core.dsl.query.first
 import org.komapper.core.dsl.query.single
@@ -430,5 +431,20 @@ class JdbcSelectProjectionTest(private val db: JdbcDatabase) {
 
         val dto = db.runQuery(query)
         assertEquals(AddressDto(10, "10"), dto)
+    }
+
+    @Test
+    fun selectAsDto_projection_nullLiteral() {
+        val a = Meta.address
+
+        val query = QueryDsl.from(a)
+            .where { a.addressId eq 10 }
+            .selectAsAddressDto(
+                idValue = a.addressId,
+                streetValue = nullLiteral(),
+            ).single()
+
+        val dto = db.runQuery(query)
+        assertEquals(AddressDto(10, null), dto)
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectProjectionTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectProjectionTest.kt
@@ -1,10 +1,13 @@
 package integration.jdbc
 
 import integration.core.Address
+import integration.core.AddressDto
 import integration.core.address
 import integration.core.department
 import integration.core.employee
 import integration.core.selectAsAddress
+import integration.core.selectAsAddressDto
+import integration.core.selectAsDepartmentDto
 import integration.core.selectAsRobot
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.dsl.Meta
@@ -12,6 +15,7 @@ import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.operator.count
 import org.komapper.core.dsl.query.first
+import org.komapper.core.dsl.query.single
 import org.komapper.jdbc.JdbcDatabase
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -377,5 +381,38 @@ class JdbcSelectProjectionTest(private val db: JdbcDatabase) {
             Address(10, "TURNER STREET", 1),
         )
         assertEquals(expected, list)
+    }
+
+    @Test
+    fun selectAsDto_projection() {
+        val a = Meta.address
+
+        val query = QueryDsl.from(a)
+            .where { a.addressId eq 10 }
+            .selectAsAddressDto(
+                idValue = a.addressId,
+                streetValue = a.street,
+            ).single()
+
+        val dto = db.runQuery(query)
+        assertEquals(AddressDto(10, "STREET 10"), dto)
+    }
+
+    @Test
+    fun selectAsDto_projectionDef() {
+        val e = Meta.employee
+        val d = Meta.department
+
+        val query = QueryDsl.from(d)
+            .innerJoin(e) { d.departmentId eq e.departmentId }
+            .groupBy(d.departmentId, d.departmentName)
+            .having { d.departmentId eq 1 }
+            .selectAsDepartmentDto(
+                department = d.departmentName,
+                memberCount = count(),
+            ).single()
+
+        val dto = db.runQuery(query)
+        assertEquals(3, dto.memberCount)
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectProjectionTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectProjectionTest.kt
@@ -14,6 +14,7 @@ import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.operator.count
+import org.komapper.core.dsl.operator.transform
 import org.komapper.core.dsl.query.first
 import org.komapper.core.dsl.query.single
 import org.komapper.jdbc.JdbcDatabase
@@ -414,5 +415,20 @@ class JdbcSelectProjectionTest(private val db: JdbcDatabase) {
 
         val dto = db.runQuery(query)
         assertEquals(3, dto.memberCount)
+    }
+
+    @Test
+    fun selectAsDto_projection_transform() {
+        val a = Meta.address
+
+        val query = QueryDsl.from(a)
+            .where { a.addressId eq 10 }
+            .selectAsAddressDto(
+                idValue = a.addressId,
+                streetValue = a.addressId.transform { it.toString() },
+            ).single()
+
+        val dto = db.runQuery(query)
+        assertEquals(AddressDto(10, "10"), dto)
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcTemplateTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcTemplateTest.kt
@@ -1,10 +1,12 @@
 package integration.jdbc
 
 import integration.core.Address
+import integration.core.AddressDto
 import integration.core.Dbms
 import integration.core.Run
 import integration.core.address
 import integration.core.selectAsAddress
+import integration.core.selectAsAddressDto
 import kotlinx.coroutines.flow.toList
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.dsl.Meta
@@ -342,5 +344,25 @@ class JdbcTemplateTest(private val db: JdbcDatabase) {
         }
         assertEquals(15, list.size)
         assertEquals(Address(1, "STREET 1", 1), list[0])
+    }
+
+    @Test
+    fun selectAsAddressDto_byIndex() {
+        val list = db.runQuery {
+            val sql = "select address_id, street from address order by address_id"
+            QueryDsl.fromTemplate(sql).selectAsAddressDto()
+        }
+        assertEquals(15, list.size)
+        assertEquals(AddressDto(1, "STREET 1"), list[0])
+    }
+
+    @Test
+    fun selectAsAddressDto_byName() {
+        val list = db.runQuery {
+            val sql = "select street, address_id from address order by address_id"
+            QueryDsl.fromTemplate(sql).selectAsAddressDto(ProjectionType.NAME)
+        }
+        assertEquals(15, list.size)
+        assertEquals(AddressDto(1, "STREET 1"), list[0])
     }
 }

--- a/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
+++ b/komapper-annotation/src/main/kotlin/org/komapper/annotation/Annotations.kt
@@ -22,10 +22,10 @@ annotation class KomapperEntity(
 )
 
 /**
- * Indicates that the result of a SELECT query can be projected into an instance of an annotated entity class.
+ * Indicates that the result of a SELECT query can be projected into an instance of an annotated class.
+ * The default function name is a concatenation of "selectAs" and the simple name of the class.
  *
  * @property function the function name for performing projection.
- * The default function name is a concatenation of "selectAs" and the simple name of the entity class.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
@@ -256,6 +256,22 @@ annotation class KomapperEntityDef(
     val entity: KClass<*>,
     val aliases: Array<String> = [],
     val unit: KClass<*> = Void::class,
+)
+
+/**
+ * Indicates that the result of a SELECT query can be projected into an instance of a [projection] class.
+ * The default function name is a concatenation of "selectAs" and the simple name of the [projection] class.
+ *
+ * The [projection] class must be a data class.
+ *
+ * @property projection the projection class
+ * @property function the function name for performing projection
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class KomapperProjectionDef(
+    val projection: KClass<*>,
+    val function: String = "",
 )
 
 /**

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/ProjectionMeta.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/ProjectionMeta.kt
@@ -1,0 +1,9 @@
+package org.komapper.core.dsl
+
+import org.komapper.core.ThreadSafe
+
+/**
+ * The entry point for projection metamodels.
+ */
+@ThreadSafe
+object ProjectionMeta

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
@@ -29,6 +29,7 @@ import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.PercentRank
 import org.komapper.core.dsl.expression.PropertyExpression
 import org.komapper.core.dsl.expression.Rank
+import org.komapper.core.dsl.expression.ReadOnlyColumnExpression
 import org.komapper.core.dsl.expression.RowNumber
 import org.komapper.core.dsl.expression.ScalarAliasExpression
 import org.komapper.core.dsl.expression.ScalarArithmeticExpression
@@ -125,7 +126,9 @@ class BuilderSupport(
                 visitUserDefinedExpression(expression)
             }
 
-            is PropertyExpression<*, *> -> {
+            is ReadOnlyColumnExpression<*, *>,
+            is PropertyExpression<*, *>,
+            -> {
                 val name = expression.getCanonicalColumnName(dialect::enquote)
                 val owner = expression.owner
                 val alias = aliasManager.getAlias(owner)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
@@ -23,8 +23,10 @@ import org.komapper.core.dsl.expression.LastValue
 import org.komapper.core.dsl.expression.Lead
 import org.komapper.core.dsl.expression.LiteralExpression
 import org.komapper.core.dsl.expression.MathematicalFunction
+import org.komapper.core.dsl.expression.NonNullLiteralExpression
 import org.komapper.core.dsl.expression.NthValue
 import org.komapper.core.dsl.expression.Ntile
+import org.komapper.core.dsl.expression.NullLiteralExpression
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.PercentRank
 import org.komapper.core.dsl.expression.PropertyExpression
@@ -98,7 +100,7 @@ class BuilderSupport(
                 visitConditionalExpression(expression)
             }
 
-            is LiteralExpression<*> -> {
+            is LiteralExpression<*, *> -> {
                 visitLiteralExpression(expression)
             }
 
@@ -243,9 +245,12 @@ class BuilderSupport(
         buf.append(")")
     }
 
-    private fun visitLiteralExpression(expression: LiteralExpression<*>) {
-        val string = dialect.formatValue(expression.value, expression.interiorClass, false)
-        buf.append(string)
+    private fun visitLiteralExpression(expression: LiteralExpression<*, *>) {
+        val literal = when (expression) {
+            is NullLiteralExpression -> "null"
+            is NonNullLiteralExpression -> dialect.formatValue(expression.value, expression.interiorClass, false)
+        }
+        buf.append(literal)
     }
 
     private fun visitMathematicalFunction(function: MathematicalFunction<*, *>) {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/LiteralExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/LiteralExpression.kt
@@ -2,8 +2,29 @@ package org.komapper.core.dsl.expression
 
 import kotlin.reflect.KClass
 
-internal data class LiteralExpression<T : Any>(val value: T, private val klass: KClass<T>) :
-    ColumnExpression<T, T> {
+internal sealed interface LiteralExpression<EXTERNAL : Any, INTERNAL : Any> : ColumnExpression<EXTERNAL, INTERNAL>
+
+data class NullLiteralExpression<EXTERNAL : Any, INTERNAL : Any>(
+    override val exteriorClass: KClass<EXTERNAL>,
+    override val interiorClass: KClass<INTERNAL>,
+) :
+    LiteralExpression<EXTERNAL, INTERNAL> {
+    override val owner: TableExpression<*>
+        get() = throw UnsupportedOperationException()
+    override val wrap: (INTERNAL) -> EXTERNAL
+        get() = throw UnsupportedOperationException()
+    override val unwrap: (EXTERNAL) -> INTERNAL
+        get() = throw UnsupportedOperationException()
+    override val columnName: String
+        get() = throw UnsupportedOperationException()
+    override val alwaysQuote: Boolean get() = false
+    override val masking: Boolean get() = false
+}
+
+internal data class NonNullLiteralExpression<T : Any>(
+    val value: T,
+    private val klass: KClass<T>,
+) : LiteralExpression<T, T> {
     override val owner: TableExpression<*>
         get() = throw UnsupportedOperationException()
     override val exteriorClass: KClass<T> = klass

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ReadOnlyColumnExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ReadOnlyColumnExpression.kt
@@ -1,0 +1,16 @@
+package org.komapper.core.dsl.expression
+
+import kotlin.reflect.KClass
+
+class ReadOnlyColumnExpression<EXTERIOR : Any, INTERIOR : Any>(
+    override val owner: TableExpression<*>,
+    override val exteriorClass: KClass<EXTERIOR>,
+    override val interiorClass: KClass<INTERIOR>,
+    override val wrap: (INTERIOR) -> EXTERIOR,
+    override val columnName: String,
+    override val alwaysQuote: Boolean,
+    override val masking: Boolean,
+) : ColumnExpression<EXTERIOR, INTERIOR> {
+    override val unwrap: (EXTERIOR) -> INTERIOR
+        get() = throw UnsupportedOperationException()
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/LiteralExpressions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/LiteralExpressions.kt
@@ -1,35 +1,43 @@
 package org.komapper.core.dsl.operator
 
 import org.komapper.core.dsl.expression.ColumnExpression
-import org.komapper.core.dsl.expression.LiteralExpression
+import org.komapper.core.dsl.expression.NonNullLiteralExpression
+import org.komapper.core.dsl.expression.NullLiteralExpression
 import java.math.BigDecimal
+
+/**
+ * Builds a null literal.
+ */
+inline fun <reified EXTERIOR : Any> nullLiteral(): ColumnExpression<EXTERIOR, *> {
+    return NullLiteralExpression(EXTERIOR::class, String::class)
+}
 
 /**
  * Builds a [Boolean] literal.
  */
 fun literal(value: Boolean): ColumnExpression<Boolean, Boolean> {
-    return LiteralExpression(value, Boolean::class)
+    return NonNullLiteralExpression(value, Boolean::class)
 }
 
 /**
  * Builds a [Int] literal.
  */
 fun literal(value: Int): ColumnExpression<Int, Int> {
-    return LiteralExpression(value, Int::class)
+    return NonNullLiteralExpression(value, Int::class)
 }
 
 /**
  * Builds a [Long] literal.
  */
 fun literal(value: Long): ColumnExpression<Long, Long> {
-    return LiteralExpression(value, Long::class)
+    return NonNullLiteralExpression(value, Long::class)
 }
 
 /**
  * Builds a [BigDecimal] literal.
  */
 fun literal(value: BigDecimal): ColumnExpression<BigDecimal, BigDecimal> {
-    return LiteralExpression(value, BigDecimal::class)
+    return NonNullLiteralExpression(value, BigDecimal::class)
 }
 
 /**
@@ -39,5 +47,5 @@ fun literal(value: BigDecimal): ColumnExpression<BigDecimal, BigDecimal> {
  */
 fun literal(value: String): ColumnExpression<String, String> {
     require("'" !in value) { "The value must not contain the single quotation." }
-    return LiteralExpression(value, String::class)
+    return NonNullLiteralExpression(value, String::class)
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityMapper.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityMapper.kt
@@ -1,5 +1,6 @@
 package org.komapper.jdbc.dsl.runner
 
+import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.query.ProjectionType
@@ -13,11 +14,12 @@ internal class JdbcEntityMapper(strategy: ProjectionType, dataOperator: JdbcData
         ProjectionType.NAME -> JdbcNamedValueExtractor(dataOperator, resultSet)
     }
 
-    fun <E : Any> execute(metamodel: EntityMetamodel<E, *, *>, forceMapping: Boolean = false): E? {
+    fun <E : Any> execute(metamodel: EntityMetamodel<E, *, *>, columns: List<ColumnExpression<*, *>> = emptyList(), forceMapping: Boolean = false): E? {
         val valueMap = mutableMapOf<PropertyMetamodel<*, *, *>, Any?>()
-        for (p in metamodel.properties()) {
+        val properties = metamodel.properties()
+        for ((p, c) in properties.zip(columns.ifEmpty { properties })) {
             val value = try {
-                valueExtractor.execute(p)
+                valueExtractor.execute(c)
             } catch (e: Exception) {
                 throw PropertyMappingException(metamodel.klass(), p.name, e)
             }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcResultSetTransformers.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcResultSetTransformers.kt
@@ -10,10 +10,10 @@ import java.sql.ResultSet
 
 internal object JdbcResultSetTransformers {
 
-    fun <T : Any> singleEntity(metamodel: EntityMetamodel<T, *, *>, strategy: ProjectionType = ProjectionType.INDEX): (JdbcDataOperator, ResultSet) -> T =
+    fun <T : Any> singleEntity(metamodel: EntityMetamodel<T, *, *>, columns: List<ColumnExpression<*, *>> = emptyList(), strategy: ProjectionType = ProjectionType.INDEX): (JdbcDataOperator, ResultSet) -> T =
         { dataOperator, rs ->
             val mapper = JdbcEntityMapper(strategy, dataOperator, rs)
-            val entity = mapper.execute(metamodel, true)
+            val entity = mapper.execute(metamodel, columns, true)
             checkNotNull(entity)
         }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/visitor/JdbcQueryVisitor.kt
@@ -588,7 +588,8 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
     ): JdbcRunner<*> {
-        val transform = JdbcResultSetTransformers.singleEntity(metamodel)
+        val columns = context.getProjection().expressions()
+        val transform = JdbcResultSetTransformers.singleEntity(metamodel, columns)
         return JdbcSelectRunner(context, transform, collect)
     }
 
@@ -597,7 +598,8 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
     ): JdbcRunner<*> {
-        val transform = JdbcResultSetTransformers.singleEntity(metamodel)
+        val columns = context.getProjection().expressions()
+        val transform = JdbcResultSetTransformers.singleEntity(metamodel, columns)
         return JdbcSetOperationRunner(context, transform, collect)
     }
 
@@ -734,7 +736,7 @@ object JdbcQueryVisitor : QueryVisitor<JdbcRunner<*>> {
         strategy: ProjectionType,
         collect: suspend (Flow<T>) -> R,
     ): JdbcRunner<*> {
-        val transform = JdbcResultSetTransformers.singleEntity(metamodel, strategy)
+        val transform = JdbcResultSetTransformers.singleEntity(metamodel, strategy = strategy)
         return JdbcTemplateEntityProjectionSelectRunner(context, transform, collect)
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Data.kt
@@ -19,6 +19,7 @@ internal data class EntityDefinitionSource(
     val aliases: List<String>,
     val unitDeclaration: KSClassDeclaration?,
     val unitTypeName: String,
+    val projection: Projection?,
     val stubAnnotation: KSAnnotation?,
 )
 

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityAnalyzer.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityAnalyzer.kt
@@ -1,28 +1,61 @@
 package org.komapper.processor
 
 import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
+import org.komapper.annotation.KomapperEmbeddedId
+import org.komapper.annotation.KomapperId
 
 internal class EntityAnalyzer(
     private val logger: KSPLogger,
+    private val resolver: Resolver,
     private val config: Config,
     private val definitionSourceResolver: EntityDefinitionSourceResolver,
+    private val requiresIdValidation: Boolean,
 ) {
 
     fun analyze(symbol: KSAnnotated): EntityAnalysisResult {
         val definitionSource = try {
-            definitionSourceResolver.resolve(symbol)
+            definitionSourceResolver.resolve(resolver, symbol)
         } catch (e: Exit) {
             return EntityAnalysisResult.Error(e)
         }
-        return try {
-            val entityDef = EntityDefFactory(logger, config, definitionSource).create()
-            val entity = EntityFactory(logger, config, entityDef).create()
-            val model = EntityModel(definitionSource, entity)
-            EntityAnalysisResult.Success(model)
-        } catch (e: Exit) {
-            val model = EntityModel(definitionSource)
-            EntityAnalysisResult.Failure(model, e)
+        return if (definitionSource == null) {
+            EntityAnalysisResult.Skip
+        } else {
+            try {
+                val entityDef = EntityDefFactory(logger, config, resolver, definitionSource).create()
+                val entity = EntityFactory(logger, config, resolver, entityDef).create()
+                validateEntity(entity)
+                val model = EntityModel(definitionSource, entity)
+                EntityAnalysisResult.Success(model)
+            } catch (e: Exit) {
+                val model = EntityModel(definitionSource)
+                EntityAnalysisResult.Failure(model, e)
+            }
+        }
+    }
+
+    private fun validateEntity(entity: Entity) {
+        if (entity.declaration.simpleName.asString().startsWith("__")) {
+            report("The class name cannot start with '__'.", entity.declaration)
+        }
+        for (p in entity.properties) {
+            val name = (p.declaration.simpleName).asString()
+            if (name.startsWith("__")) {
+                report("The property name cannot start with '__'.", p.node)
+            }
+        }
+        if (requiresIdValidation) {
+            if (entity.embeddedIdProperty == null && entity.idProperties.isEmpty()) {
+                report("The entity class must have at least one id property.", entity.declaration)
+            }
+            if (entity.embeddedIdProperty != null && entity.idProperties.isNotEmpty()) {
+                report(
+                    "The entity class can have either @${KomapperEmbeddedId::class.simpleName} or @${KomapperId::class.simpleName}.",
+                    entity.declaration,
+                )
+            }
         }
     }
 }
@@ -31,4 +64,5 @@ internal sealed class EntityAnalysisResult {
     data class Success(val model: EntityModel) : EntityAnalysisResult()
     data class Failure(val model: EntityModel, val exit: Exit) : EntityAnalysisResult()
     data class Error(val exit: Exit) : EntityAnalysisResult()
+    object Skip : EntityAnalysisResult()
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityDefFactory.kt
@@ -2,6 +2,7 @@ package org.komapper.processor
 
 import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSValueParameter
 import org.komapper.annotation.KomapperAutoIncrement
@@ -17,9 +18,10 @@ import org.komapper.annotation.KomapperVersion
 internal class EntityDefFactory(
     @Suppress("unused") private val logger: KSPLogger,
     private val config: Config,
+    private val resolver: Resolver,
     private val definitionSource: EntityDefinitionSource,
 ) {
-    private val annotationSupport: AnnotationSupport = AnnotationSupport(logger, config)
+    private val annotationSupport: AnnotationSupport = AnnotationSupport(logger, config, resolver)
     private val defDeclaration = definitionSource.defDeclaration
 
     fun create(): EntityDef {

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -752,11 +752,11 @@ internal class EntityMetamodelGenerator(
             when (p) {
                 is CompositeProperty -> {
                     p.embeddable.properties.map {
-                        "`$p#$it`" to "$ColumnExpression<${it.exteriorTypeName}, ${it.interiorTypeName}>"
+                        "`$p#$it`" to "$ColumnExpression<${it.exteriorTypeName}, *>"
                     }
                 }
                 is LeafProperty -> {
-                    listOf("`$p`" to "$ColumnExpression<${p.exteriorTypeName}, ${p.interiorTypeName}>")
+                    listOf("`$p`" to "$ColumnExpression<${p.exteriorTypeName}, *>")
                 }
             }
         }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityProcessorProvider.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityProcessorProvider.kt
@@ -3,12 +3,38 @@ package org.komapper.processor
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperEntityDef
+import org.komapper.annotation.KomapperProjection
+import org.komapper.annotation.KomapperProjectionDef
 import org.komapper.core.ThreadSafe
 
 @ThreadSafe
 class EntityProcessorProvider : SymbolProcessorProvider {
     override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
         val config = Config.create(environment.options)
-        return EntityProcessor(environment, config)
+        val processingAnnotations = listOf(
+            ProcessingAnnotation(
+                KomapperEntityDef::class,
+                SeparateDefinitionSourceResolver(config),
+                true,
+            ),
+            ProcessingAnnotation(
+                KomapperEntity::class,
+                SelfDefinitionSourceResolver(config),
+                true,
+            ),
+            ProcessingAnnotation(
+                KomapperProjectionDef::class,
+                SeparateProjectionDefinitionSourceResolver(config),
+                false,
+            ),
+            ProcessingAnnotation(
+                KomapperProjection::class,
+                SelfProjectionDefinitionSourceResolver(config),
+                false,
+            ),
+        )
+        return EntityProcessor(environment, config, processingAnnotations)
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/ProcessingAnnotation.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/ProcessingAnnotation.kt
@@ -1,0 +1,9 @@
+package org.komapper.processor
+
+import kotlin.reflect.KClass
+
+internal data class ProcessingAnnotation(
+    val annotationClass: KClass<*>,
+    val definitionSourceResolver: EntityDefinitionSourceResolver,
+    val requiresIdValidation: Boolean,
+)

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -22,6 +22,7 @@ internal object Symbols {
     const val EntityDescriptor = "__EntityDescriptor"
     const val EntityMetamodelDeclaration = "org.komapper.core.dsl.metamodel.EntityMetamodelDeclaration"
     const val Meta = "org.komapper.core.dsl.Meta"
+    const val ProjectionMeta = "org.komapper.core.dsl.ProjectionMeta"
     const val KomapperStub = "KomapperStub"
     const val Operand = "org.komapper.core.dsl.expression.Operand"
     const val Argument = "$Operand.Argument"

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityMapper.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityMapper.kt
@@ -1,6 +1,7 @@
 package org.komapper.r2dbc.dsl.runner
 
 import io.r2dbc.spi.Row
+import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.query.ProjectionType
@@ -13,11 +14,12 @@ internal class R2dbcEntityMapper(strategy: ProjectionType, dataOperator: R2dbcDa
         ProjectionType.NAME -> R2dbcNamedValueExtractor(dataOperator, row)
     }
 
-    fun <E : Any> execute(metamodel: EntityMetamodel<E, *, *>, forceMapping: Boolean = false): E? {
+    fun <E : Any> execute(metamodel: EntityMetamodel<E, *, *>, columns: List<ColumnExpression<*, *>> = emptyList(), forceMapping: Boolean = false): E? {
         val valueMap = mutableMapOf<PropertyMetamodel<*, *, *>, Any?>()
-        for (p in metamodel.properties()) {
+        val properties = metamodel.properties()
+        for ((p, c) in properties.zip(columns.ifEmpty { properties })) {
             val value = try {
-                valueExtractor.execute(p)
+                valueExtractor.execute(c)
             } catch (e: Exception) {
                 throw PropertyMappingException(metamodel.klass(), p.name, e)
             }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRowTransformers.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRowTransformers.kt
@@ -10,10 +10,10 @@ import org.komapper.r2dbc.R2dbcDataOperator
 
 internal object R2dbcRowTransformers {
 
-    fun <ENTITY : Any> singleEntity(metamodel: EntityMetamodel<ENTITY, *, *>, strategy: ProjectionType = ProjectionType.INDEX): (R2dbcDataOperator, Row) -> ENTITY =
+    fun <ENTITY : Any> singleEntity(metamodel: EntityMetamodel<ENTITY, *, *>, columns: List<ColumnExpression<*, *>> = emptyList(), strategy: ProjectionType = ProjectionType.INDEX): (R2dbcDataOperator, Row) -> ENTITY =
         { dataOperator, row ->
             val mapper = R2dbcEntityMapper(strategy, dataOperator, row)
-            mapper.execute(metamodel, true) as ENTITY
+            mapper.execute(metamodel, columns, true) as ENTITY
         }
 
     fun <A : Any> singleColumn(expression: ColumnExpression<A, *>): (R2dbcDataOperator, Row) -> A? {

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcFlowQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcFlowQueryVisitor.kt
@@ -173,7 +173,7 @@ object R2dbcFlowQueryVisitor : FlowQueryVisitor<R2dbcFlowBuilder<*>> {
         metamodel: EntityMetamodel<T, *, *>,
         strategy: ProjectionType,
     ): R2dbcFlowBuilder<*> {
-        val transform = R2dbcRowTransformers.singleEntity(metamodel, strategy)
+        val transform = R2dbcRowTransformers.singleEntity(metamodel, strategy = strategy)
         return R2dbcTemplateEntityProjectionSelectFlowBuilder(context, transform)
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/visitor/R2dbcQueryVisitor.kt
@@ -584,7 +584,8 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
     ): R2dbcRunner<*> {
-        val transform = R2dbcRowTransformers.singleEntity(metamodel)
+        val columns = context.getProjection().expressions()
+        val transform = R2dbcRowTransformers.singleEntity(metamodel, columns)
         return R2dbcSelectRunner(context, transform, collect)
     }
 
@@ -593,7 +594,8 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         metamodel: EntityMetamodel<ENTITY, *, *>,
         collect: suspend (Flow<ENTITY>) -> R,
     ): R2dbcRunner<*> {
-        val transform = R2dbcRowTransformers.singleEntity(metamodel)
+        val columns = context.getProjection().expressions()
+        val transform = R2dbcRowTransformers.singleEntity(metamodel, columns)
         return R2dbcSetOperationRunner(context, transform, collect)
     }
 
@@ -730,7 +732,7 @@ object R2dbcQueryVisitor : QueryVisitor<R2dbcRunner<*>> {
         strategy: ProjectionType,
         collect: suspend (Flow<T>) -> R,
     ): R2dbcRunner<*> {
-        val transform = R2dbcRowTransformers.singleEntity(metamodel, strategy)
+        val transform = R2dbcRowTransformers.singleEntity(metamodel, strategy = strategy)
         return R2dbcTemplateEntityProjectionSelectRunner(context, transform, collect)
     }
 }


### PR DESCRIPTION
The class annotated with `@KomapperProjection` no longer needs to have `@KomapperId`.

**Entity and Projection**
```kotlin
@KomapperEntity
data class Person(@KomapperId val id:Int, val firstName: String, val lastName: String, val age: Int)

@KomapperProjection
data class PersonDto(val name: String, val age: Int)
```

**Query**
```kotlin
val p = Meta.person
val query: Query<List<PersonDto>> = QueryDsl.from(p)
  .selectAsPersonDto(
    name = concat(concat(p.fristName, " "), p.lastName), 
    age = p.age,
  )
```