### PR TITLE
The closing of R2DBC connections is performed by first converting it into a Flow

### DIFF
--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcSession.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcSession.kt
@@ -2,9 +2,9 @@ package org.komapper.r2dbc
 
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ConnectionFactory
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.reactive.collect
 import org.komapper.core.ThreadSafe
 import org.komapper.tx.core.CoroutineTransactionOperator
 import org.komapper.tx.core.FlowTransactionOperator
@@ -63,6 +63,6 @@ class DefaultR2dbcSession(override val connectionFactory: ConnectionFactory) : R
     }
 
     override suspend fun releaseConnection(connection: Connection) {
-        connection.close().collect { }
+        connection.close().asFlow().collect()
     }
 }

--- a/komapper-tx-context-r2dbc/src/main/kotlin/org/komapper/tx/context/r2dbc/ContextualR2dbcDatabase.kt
+++ b/komapper-tx-context-r2dbc/src/main/kotlin/org/komapper/tx/context/r2dbc/ContextualR2dbcDatabase.kt
@@ -3,7 +3,8 @@ package org.komapper.tx.context.r2dbc
 import io.r2dbc.spi.ConnectionFactory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.reactive.collect
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.reactive.asFlow
 import org.komapper.core.Database
 import org.komapper.core.dsl.query.FlowQuery
 import org.komapper.core.dsl.query.Query
@@ -121,7 +122,7 @@ internal class ContextualR2dbcDatabaseImpl(
                 }
 
                 override suspend fun releaseConnection(connection: io.r2dbc.spi.Connection) {
-                    connection.close().collect { }
+                    connection.close().asFlow().collect()
                 }
             }
         }

--- a/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcTransactionConnection.kt
+++ b/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcTransactionConnection.kt
@@ -2,11 +2,11 @@ package org.komapper.tx.r2dbc
 
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ValidationDepth
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.asPublisher
-import kotlinx.coroutines.reactive.collect
 import org.reactivestreams.Publisher
 
 interface R2dbcTransactionConnection : Connection {
@@ -21,7 +21,7 @@ private class R2dbcTransactionConnectionImpl(
     override suspend fun dispose() {
         val isValid = connection.validate(ValidationDepth.LOCAL).asFlow().single()
         if (isValid) {
-            connection.close().collect {}
+            connection.close().asFlow().collect()
         }
     }
 

--- a/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcTransactionSession.kt
+++ b/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcTransactionSession.kt
@@ -2,7 +2,8 @@ package org.komapper.tx.r2dbc
 
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ConnectionFactory
-import kotlinx.coroutines.reactive.collect
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.reactive.asFlow
 import org.komapper.core.LoggerFacade
 import org.komapper.r2dbc.R2dbcSession
 import org.komapper.tx.core.CoroutineTransactionOperator
@@ -33,6 +34,6 @@ class R2dbcTransactionSession(
     }
 
     override suspend fun releaseConnection(connection: Connection) {
-        connection.close().collect { }
+        connection.close().asFlow().collect()
     }
 }


### PR DESCRIPTION
This method should correctly convey the context.