### PR TITLE
Change to not specify conflict_target by default for ON CONFLICT DO NOTHING in PostgreSQL

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertSingleTest.kt
@@ -484,9 +484,19 @@ class JdbcInsertSingleTest(private val db: JdbcDatabase) {
     }
 
     @Test
-    fun onDuplicateKeyIgnore_ignored() {
+    fun onDuplicateKeyIgnore_ignored_primaryKeyCollision() {
         val a = Meta.address
         val address = Address(1, "STREET 100", 0)
+        val query = QueryDsl.insert(a).onDuplicateKeyIgnore().single(address)
+        val count = db.runQuery { query }
+        assertEquals(0, count)
+    }
+
+    @Test
+    @Run(onlyIf = [Dbms.MARIADB, Dbms.MYSQL, Dbms.MYSQL_5, Dbms.POSTGRESQL])
+    fun onDuplicateKeyIgnore_ignored_uniqueKeyCollision() {
+        val a = Meta.address
+        val address = Address(16, "STREET 1", 0)
         val query = QueryDsl.insert(a).onDuplicateKeyIgnore().single(address)
         val count = db.runQuery { query }
         assertEquals(0, count)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
@@ -27,7 +27,7 @@ data class EntityInsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
         return EntityUpsertContext(
             insertContext = this,
             target = target,
-            keys = keys.ifEmpty { target.idProperties() },
+            keys = keys,
             duplicateKeyType = duplicateKeyType,
         )
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
@@ -21,6 +21,7 @@ data class EntityUpsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
         alwaysQuote = false,
         disableSequenceAssignment = false,
         declaration = {},
+        disableAutoIncrement = false,
     ),
     val keys: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
     val conflictTarget: String? = null,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyUpdateQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyUpdateQueryBuilder.kt
@@ -209,7 +209,7 @@ private fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> e
     entity: ENTITY,
 ): Query<ENTITY> {
     return EntityUpsertSingleUpdateQuery(context, entity).flatMap { newEntity ->
-        val keys = context.keys.map { it to it.getter(newEntity) }
+        val keys = context.keys.ifEmpty { context.target.idProperties() }.map { it to it.getter(newEntity) }
         QueryDsl.from(context.target).where {
             for ((property, value) in keys) {
                 @Suppress("UNCHECKED_CAST")

--- a/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-h2/src/main/kotlin/org/komapper/dialect/h2/H2EntityUpsertStatementBuilder.kt
@@ -42,7 +42,7 @@ internal class H2EntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Ent
         table(excluded, TableNameType.ALIAS_ONLY)
         buf.append(" on ")
         val excludedPropertyMap = excluded.properties().associateBy { it.name }
-        for (key in context.keys) {
+        for (key in context.keys.ifEmpty { context.target.idProperties() }) {
             column(key)
             buf.append(" = ")
             column(excludedPropertyMap[key.name]!!)

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleEntityUpsertStatementBuilder.kt
@@ -32,8 +32,10 @@ internal class OracleEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META :
     private val sourceStatementBuilder = SourceStatementBuilder(dialect, context, entities)
 
     override fun build(assignments: List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>): Statement {
+        val keys = context.keys.ifEmpty { context.target.idProperties() }
+
         @Suppress("NAME_SHADOWING")
-        val assignments = assignments.filter { (left, _) -> left !in context.keys }
+        val assignments = assignments.filter { (left, _) -> left !in keys }
         buf.append("merge into ")
         table(target, TableNameType.NAME_AND_ALIAS)
         buf.append(" using (")
@@ -42,7 +44,7 @@ internal class OracleEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META :
         table(excluded, TableNameType.ALIAS_ONLY)
         buf.append(" on (")
         val excludedPropertyMap = excluded.properties().associateBy { it.name }
-        for (key in context.keys) {
+        for (key in keys) {
             column(key)
             buf.append(" = ")
             column(excludedPropertyMap[key.name]!!)

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
@@ -91,7 +91,7 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
         } else {
             if (keys.isNotEmpty()) {
                 buf.append(" (")
-                for (p in context.keys) {
+                for (p in keys) {
                     column(p)
                     buf.append(", ")
                 }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerEntityUpsertStatementBuilder.kt
@@ -48,7 +48,7 @@ internal class SqlServerEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, MET
         buf.append(")")
         buf.append(" on ")
         val excludedPropertyMap = excluded.properties().associateBy { it.name }
-        for (key in context.keys) {
+        for (key in context.keys.ifEmpty { context.target.idProperties() }) {
             column(key)
             buf.append(" = ")
             column(excludedPropertyMap[key.name]!!)


### PR DESCRIPTION
```kotlin
val a = Meta.address
val query = QueryDsl.insert(a).onDuplicateKeyIgnore().single(address)
```

The above query corresponds to the following SQL.
Please note that no columns are specified after "on conflict".

```sql
insert into address as t0_ (address_id, street, version) values (?, ?, ?) on conflict do nothing
```

To specify particular columns, the following query is needed.

```kotlin
val a = Meta.address
val query = QueryDsl.insert(a).onDuplicateKeyIgnore(a.street).single(address)
```
The above query corresponds to the following SQL.

```sql
insert into address as t0_ (address_id, street, version) values (?, ?, ?) on conflict (street) do nothing
```
