### PR TITLE
Specify that Maps and Sets preserve the order of elements

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityStore.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/EntityStore.kt
@@ -7,6 +7,8 @@ import java.util.concurrent.ConcurrentMap
 
 /**
  * The store containing the retrieved entities.
+ * All Maps and Sets returned by this interface preserve the order of elements.
+ * This also applies to Sets contained within the values of the Maps.
  */
 @ThreadSafe
 interface EntityStore {


### PR DESCRIPTION
We have added a note to the EntityStore source code and [the Association API documentation](https://www.komapper.org/docs/reference/association/).

Close #1256 


