### PR TITLE
Support using generic types for entity properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m
 org.gradle.parallel=true
 
 group=org.komapper
-version=1.18.2-SNAPSHOT
+version=2.0.0-SNAPSHOT
 description=Kotlin ORM for JDBC and R2DBC
 
 kotlinVersion=2.0.0

--- a/integration-test-core/src/main/kotlin/integration/core/EntitiesDataType.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/EntitiesDataType.kt
@@ -156,6 +156,14 @@ data class LongData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true)
 data class OffsetDateTimeData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: OffsetDateTime?)
 
 @KomapperEntity
+@KomapperTable("string_data")
+data class PairOfStringData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Pair<String, String>?)
+
+@KomapperEntity
+@KomapperTable("string_data")
+data class PairOfIntData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Pair<Int, Int>?)
+
+@KomapperEntity
 @KomapperTable("period_data")
 data class PeriodData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Period?)
 

--- a/integration-test-core/src/main/kotlin/integration/core/WrappedStringTypeConverter.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/WrappedStringTypeConverter.kt
@@ -1,11 +1,12 @@
 package integration.core
 
 import org.komapper.core.spi.DataTypeConverter
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class WrappedStringTypeConverter : DataTypeConverter<WrappedString, String> {
-    override val exteriorClass: KClass<WrappedString> = WrappedString::class
-    override val interiorClass: KClass<String> = String::class
+    override val exteriorType: KType = typeOf<WrappedString>()
+    override val interiorType: KType = typeOf<String>()
 
     override fun unwrap(exterior: WrappedString): String {
         return exterior.value

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/MoodType.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/MoodType.kt
@@ -5,12 +5,13 @@ import org.komapper.jdbc.spi.JdbcUserDefinedDataType
 import java.sql.JDBCType
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class MoodType : JdbcUserDefinedDataType<Mood> {
     override val name: String = "mood"
 
-    override val klass: KClass<Mood> = Mood::class
+    override val type: KType = typeOf<Mood>()
 
     override val jdbcType: JDBCType = JDBCType.OTHER
 

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/PairOfIntType.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/PairOfIntType.kt
@@ -1,0 +1,37 @@
+package integration.jdbc
+
+import org.komapper.jdbc.spi.JdbcUserDefinedDataType
+import java.sql.JDBCType
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+class PairOfIntType : JdbcUserDefinedDataType<Pair<Int, Int>> {
+
+    override val name: String = "varchar(500)"
+    override val type: KType = typeOf<Pair<Int, Int>>()
+    override val jdbcType: JDBCType = JDBCType.VARCHAR
+
+    override fun getValue(rs: ResultSet, index: Int): Pair<Int, Int>? {
+        return rs.getString(index)?.let {
+            val values = it.split(",")
+            return Pair(values[0].toInt(), values[1].toInt())
+        }
+    }
+
+    override fun getValue(rs: ResultSet, columnLabel: String): Pair<Int, Int>? {
+        return rs.getString(columnLabel)?.let {
+            val values = it.split(",")
+            return Pair(values[0].toInt(), values[1].toInt())
+        }
+    }
+
+    override fun setValue(ps: PreparedStatement, index: Int, value: Pair<Int, Int>) {
+        return ps.setString(index, "${value.first},${value.second}")
+    }
+
+    override fun toString(value: Pair<Int, Int>): String {
+        return "'${value.first},${value.second}'"
+    }
+}

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/PairOfStringType.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/PairOfStringType.kt
@@ -1,0 +1,37 @@
+package integration.jdbc
+
+import org.komapper.jdbc.spi.JdbcUserDefinedDataType
+import java.sql.JDBCType
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+class PairOfStringType : JdbcUserDefinedDataType<Pair<String, String>> {
+
+    override val name: String = "varchar(500)"
+    override val type: KType = typeOf<Pair<String, String>>()
+    override val jdbcType: JDBCType = JDBCType.VARCHAR
+
+    override fun getValue(rs: ResultSet, index: Int): Pair<String, String>? {
+        return rs.getString(index)?.let {
+            val values = it.split(",")
+            return Pair(values[0], values[1])
+        }
+    }
+
+    override fun getValue(rs: ResultSet, columnLabel: String): Pair<String, String>? {
+        return rs.getString(columnLabel)?.let {
+            val values = it.split(",")
+            return Pair(values[0], values[1])
+        }
+    }
+
+    override fun setValue(ps: PreparedStatement, index: Int, value: Pair<String, String>) {
+        return ps.setString(index, "${value.first},${value.second}")
+    }
+
+    override fun toString(value: Pair<String, String>): String {
+        return "'${value.first},${value.second}'"
+    }
+}

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/UserDefinedIntType.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/UserDefinedIntType.kt
@@ -5,12 +5,13 @@ import org.komapper.jdbc.spi.JdbcUserDefinedDataType
 import java.sql.JDBCType
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class UserDefinedIntType : JdbcUserDefinedDataType<UserDefinedInt> {
     override val name: String = "integer"
 
-    override val klass: KClass<UserDefinedInt> = UserDefinedInt::class
+    override val type: KType = typeOf<UserDefinedInt>()
 
     override val jdbcType: JDBCType = JDBCType.INTEGER
 

--- a/integration-test-jdbc/src/main/kotlin/integration/jdbc/UserDefinedStringType.kt
+++ b/integration-test-jdbc/src/main/kotlin/integration/jdbc/UserDefinedStringType.kt
@@ -5,12 +5,13 @@ import org.komapper.jdbc.spi.JdbcUserDefinedDataType
 import java.sql.JDBCType
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class UserDefinedStringType : JdbcUserDefinedDataType<UserDefinedString> {
     override val name: String = "varchar(100)"
 
-    override val klass: KClass<UserDefinedString> = UserDefinedString::class
+    override val type: KType = typeOf<UserDefinedString>()
 
     override val jdbcType: JDBCType = JDBCType.VARCHAR
 

--- a/integration-test-jdbc/src/main/resources/META-INF/services/org.komapper.jdbc.spi.JdbcUserDefinedDataType
+++ b/integration-test-jdbc/src/main/resources/META-INF/services/org.komapper.jdbc.spi.JdbcUserDefinedDataType
@@ -1,3 +1,5 @@
 integration.jdbc.MoodType
+integration.jdbc.PairOfIntType
+integration.jdbc.PairOfStringType
 integration.jdbc.UserDefinedIntType
 integration.jdbc.UserDefinedStringType

--- a/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/PostgreSqlDataTypeTest.kt
+++ b/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/PostgreSqlDataTypeTest.kt
@@ -7,6 +7,7 @@ import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.query.first
 import org.komapper.jdbc.JdbcDatabase
+import kotlin.reflect.typeOf
 import kotlin.test.assertEquals
 
 @ExtendWith(JdbcEnv::class)
@@ -31,7 +32,7 @@ class PostgreSqlDataTypeTest(private val db: JdbcDatabase) {
 
         val result = db.runQuery {
             QueryDsl.fromTemplate("select value->'b' as x from json_data")
-                .select { it.get("x", Json::class)!! }
+                .select { it.get<Json>("x", typeOf<Json>())!! }
                 .first()
         }
         assertEquals("\"Hello\"", result.data)

--- a/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/PostgreSqlJsonType.kt
+++ b/integration-test-jdbc/src/postgresql/kotlin/integration/jdbc/postgresql/PostgreSqlJsonType.kt
@@ -6,11 +6,12 @@ import org.postgresql.util.PGobject
 import java.sql.JDBCType
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class PostgreSqlJsonType : JdbcDataType<Json> {
     private val stringType = JdbcStringType("")
-    override val klass: KClass<Json> = Json::class
+    override val type: KType = typeOf<Json>()
     override val name: String = "jsonb"
     override val jdbcType: JDBCType = stringType.jdbcType
 

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDataTypeTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDataTypeTest.kt
@@ -25,6 +25,8 @@ import integration.core.LocalDateTimeData
 import integration.core.LocalTimeData
 import integration.core.LongData
 import integration.core.OffsetDateTimeData
+import integration.core.PairOfIntData
+import integration.core.PairOfStringData
 import integration.core.Run
 import integration.core.ShortData
 import integration.core.StringData
@@ -67,6 +69,8 @@ import integration.core.localDateTimeData
 import integration.core.localTimeData
 import integration.core.longData
 import integration.core.offsetDateTimeData
+import integration.core.pairOfIntData
+import integration.core.pairOfStringData
 import integration.core.shortData
 import integration.core.stringData
 import integration.core.uByteData
@@ -884,6 +888,58 @@ class JdbcDataTypeTest(val db: JdbcDatabase) {
     fun offsetDateTime_null() {
         val m = Meta.offsetDateTimeData
         val data = OffsetDateTimeData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun pairOfInt() {
+        val m = Meta.pairOfIntData
+        val data = PairOfIntData(1, 10 to 20)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+        val data3 = db.runQuery {
+            QueryDsl.from(m).where { m.value eq (10 to 20) }.first()
+        }
+        assertEquals(data, data3)
+    }
+
+    @Test
+    fun pairOfInt_null() {
+        val m = Meta.pairOfIntData
+        val data = PairOfIntData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun pairOfString() {
+        val m = Meta.pairOfStringData
+        val data = PairOfStringData(1, "a" to "b")
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+        val data3 = db.runQuery {
+            QueryDsl.from(m).where { m.value eq ("a" to "b") }.first()
+        }
+        assertEquals(data, data3)
+    }
+
+    @Test
+    fun pairOfString_null() {
+        val m = Meta.pairOfStringData
+        val data = PairOfStringData(1, null)
         db.runQuery { QueryDsl.insert(m).single(data) }
         val data2 = db.runQuery {
             QueryDsl.from(m).where { m.id eq 1 }.first()

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcLiteralTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcLiteralTest.kt
@@ -2,7 +2,6 @@ package integration.jdbc
 
 import integration.core.booleanData
 import integration.core.enumData
-import integration.core.enumclass.Direction
 import integration.core.intData
 import integration.core.longData
 import integration.core.stringData
@@ -13,7 +12,6 @@ import org.komapper.core.dsl.operator.literal
 import org.komapper.core.dsl.operator.nullLiteral
 import org.komapper.core.dsl.query.first
 import org.komapper.jdbc.JdbcDatabase
-import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -95,7 +93,7 @@ class JdbcLiteralTest(val db: JdbcDatabase) {
         db.runQuery {
             QueryDsl.insert(m).values {
                 m.id eq 1
-                m.value eq nullLiteral()
+                m.value eq nullLiteral(m.value)
             }
         }
         val result = db.runQuery {
@@ -110,7 +108,7 @@ class JdbcLiteralTest(val db: JdbcDatabase) {
         db.runQuery {
             QueryDsl.insert(m).values {
                 m.id eq 1
-                m.value eq nullLiteral(typeOf<Direction>(), typeOf<String>())
+                m.value eq nullLiteral(m.value)
             }
         }
         val result = db.runQuery {

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcLiteralTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcLiteralTest.kt
@@ -13,6 +13,7 @@ import org.komapper.core.dsl.operator.literal
 import org.komapper.core.dsl.operator.nullLiteral
 import org.komapper.core.dsl.query.first
 import org.komapper.jdbc.JdbcDatabase
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -94,7 +95,7 @@ class JdbcLiteralTest(val db: JdbcDatabase) {
         db.runQuery {
             QueryDsl.insert(m).values {
                 m.id eq 1
-                m.value eq nullLiteral(String::class)
+                m.value eq nullLiteral()
             }
         }
         val result = db.runQuery {
@@ -109,7 +110,7 @@ class JdbcLiteralTest(val db: JdbcDatabase) {
         db.runQuery {
             QueryDsl.insert(m).values {
                 m.id eq 1
-                m.value eq nullLiteral(Direction::class, String::class)
+                m.value eq nullLiteral(typeOf<Direction>(), typeOf<String>())
             }
         }
         val result = db.runQuery {

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
@@ -34,6 +34,7 @@ import org.komapper.core.dsl.query.singleOrNull
 import org.komapper.jdbc.JdbcDatabase
 import java.math.BigDecimal
 import java.time.LocalDateTime
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -340,8 +341,8 @@ class JdbcSelectTest(private val db: JdbcDatabase) {
 
     private fun fromUnixTime(value: Long): ColumnExpression<LocalDateTime, LocalDateTime> {
         val name = "fromUnixTime"
-        val o1 = Operand.SimpleArgument(Long::class, value)
-        return columnExpression(LocalDateTime::class, name, listOf(o1)) {
+        val o1 = Operand.SimpleArgument(typeOf<Long>(), value)
+        return columnExpression(typeOf<LocalDateTime>(), name, listOf(o1)) {
             append("FROM_UNIXTIME(")
             visit(o1)
             append(")")

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/MoodType.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/MoodType.kt
@@ -4,12 +4,13 @@ import integration.core.enumclass.Mood
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
 import org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class MoodType : R2dbcUserDefinedDataType<Mood> {
     override val name: String = "mood"
 
-    override val klass: KClass<Mood> = Mood::class
+    override val type: KType = typeOf<Mood>()
 
     override val r2dbcType: Class<Mood> = Mood::class.javaObjectType
 

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/PairOfIntType.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/PairOfIntType.kt
@@ -1,0 +1,40 @@
+package integration.r2dbc
+
+import io.r2dbc.spi.Row
+import io.r2dbc.spi.Statement
+import org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+class PairOfIntType : R2dbcUserDefinedDataType<Pair<Int, Int>> {
+
+    override val name: String = "varchar(500)"
+    override val type: KType = typeOf<Pair<Int, Int>>()
+    override val r2dbcType: Class<String> = String::class.javaObjectType
+
+    override fun getValue(row: Row, index: Int): Pair<Int, Int>? {
+        return row.get(index, r2dbcType)?.let {
+            val values = it.split(",")
+            return Pair(values[0].toInt(), values[1].toInt())
+        }
+    }
+
+    override fun getValue(row: Row, columnLabel: String): Pair<Int, Int>? {
+        return row.get(columnLabel, r2dbcType)?.let {
+            val values = it.split(",")
+            return Pair(values[0].toInt(), values[1].toInt())
+        }
+    }
+
+    override fun setValue(statement: Statement, index: Int, value: Pair<Int, Int>) {
+        statement.bind(index, "${value.first},${value.second}")
+    }
+
+    override fun setValue(statement: Statement, name: String, value: Pair<Int, Int>) {
+        statement.bind(name, "${value.first},${value.second}")
+    }
+
+    override fun toString(value: Pair<Int, Int>): String {
+        return "'${value.first},${value.second}'"
+    }
+}

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/PairOfStringType.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/PairOfStringType.kt
@@ -1,0 +1,40 @@
+package integration.r2dbc
+
+import io.r2dbc.spi.Row
+import io.r2dbc.spi.Statement
+import org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+class PairOfStringType : R2dbcUserDefinedDataType<Pair<String, String>> {
+
+    override val name: String = "varchar(500)"
+    override val type: KType = typeOf<Pair<String, String>>()
+    override val r2dbcType: Class<String> = String::class.javaObjectType
+
+    override fun getValue(row: Row, index: Int): Pair<String, String>? {
+        return row.get(index, r2dbcType)?.let {
+            val values = it.split(",")
+            return Pair(values[0], values[1])
+        }
+    }
+
+    override fun getValue(row: Row, columnLabel: String): Pair<String, String>? {
+        return row.get(columnLabel, r2dbcType)?.let {
+            val values = it.split(",")
+            return Pair(values[0], values[1])
+        }
+    }
+
+    override fun setValue(statement: Statement, index: Int, value: Pair<String, String>) {
+        statement.bind(index, "${value.first},${value.second}")
+    }
+
+    override fun setValue(statement: Statement, name: String, value: Pair<String, String>) {
+        statement.bind(name, "${value.first},${value.second}")
+    }
+
+    override fun toString(value: Pair<String, String>): String {
+        return "'${value.first},${value.second}'"
+    }
+}

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/UserDefinedIntType.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/UserDefinedIntType.kt
@@ -4,13 +4,14 @@ import integration.core.UserDefinedInt
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
 import org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class UserDefinedIntType : R2dbcUserDefinedDataType<UserDefinedInt> {
 
     override val name: String = "integer"
 
-    override val klass: KClass<UserDefinedInt> = UserDefinedInt::class
+    override val type: KType = typeOf<UserDefinedInt>()
 
     override val r2dbcType: Class<*> = Int::class.javaObjectType
 

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/UserDefinedStringType.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/UserDefinedStringType.kt
@@ -4,12 +4,13 @@ import integration.core.UserDefinedString
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
 import org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class UserDefinedStringType : R2dbcUserDefinedDataType<UserDefinedString> {
     override val name: String = "varchar(100)"
 
-    override val klass: KClass<UserDefinedString> = UserDefinedString::class
+    override val type: KType = typeOf<UserDefinedString>()
 
     override val r2dbcType: Class<*> = String::class.javaObjectType
 

--- a/integration-test-r2dbc/src/main/resources/META-INF/services/org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
+++ b/integration-test-r2dbc/src/main/resources/META-INF/services/org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
@@ -1,3 +1,5 @@
 integration.r2dbc.MoodType
+integration.r2dbc.PairOfIntType
+integration.r2dbc.PairOfStringType
 integration.r2dbc.UserDefinedIntType
 integration.r2dbc.UserDefinedStringType

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlTypeTest.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlTypeTest.kt
@@ -20,6 +20,7 @@ import org.komapper.r2dbc.R2dbcDatabase
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
 import java.time.Period
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -196,7 +197,7 @@ class R2dbcPostgreSqlTypeTest(val db: R2dbcDatabase) {
 
         val result = db.runQuery {
             QueryDsl.fromTemplate("select value->'b' as x from json_data")
-                .select { it.get("x", Json::class)!! }
+                .select { it.get<Json>("x", typeOf<Json>())!! }
                 .first()
         }
         assertEquals("\"Hello\"", result.asString())

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
@@ -23,6 +23,8 @@ import integration.core.LocalDateTimeData
 import integration.core.LocalTimeData
 import integration.core.LongData
 import integration.core.OffsetDateTimeData
+import integration.core.PairOfIntData
+import integration.core.PairOfStringData
 import integration.core.Run
 import integration.core.ShortData
 import integration.core.StringData
@@ -64,6 +66,8 @@ import integration.core.localDateTimeData
 import integration.core.localTimeData
 import integration.core.longData
 import integration.core.offsetDateTimeData
+import integration.core.pairOfIntData
+import integration.core.pairOfStringData
 import integration.core.shortData
 import integration.core.stringData
 import integration.core.uByteData
@@ -862,6 +866,58 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
     fun offsetDateTime_null(info: TestInfo) = inTransaction(db, info) {
         val m = Meta.offsetDateTimeData
         val data = OffsetDateTimeData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun pairOfInt(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.pairOfIntData
+        val data = PairOfIntData(1, 10 to 20)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+        val data3 = db.runQuery {
+            QueryDsl.from(m).where { m.value eq (10 to 20) }.first()
+        }
+        assertEquals(data, data3)
+    }
+
+    @Test
+    fun pairOfInt_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.pairOfIntData
+        val data = PairOfIntData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+    }
+
+    @Test
+    fun pairOfString(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.pairOfStringData
+        val data = PairOfStringData(1, "a" to "b")
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertEquals(data, data2)
+        val data3 = db.runQuery {
+            QueryDsl.from(m).where { m.value eq ("a" to "b") }.first()
+        }
+        assertEquals(data, data3)
+    }
+
+    @Test
+    fun pairOfString_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.pairOfStringData
+        val data = PairOfStringData(1, null)
         db.runQuery { QueryDsl.insert(m).single(data) }
         val data2 = db.runQuery {
             QueryDsl.from(m).where { m.id eq 1 }.first()

--- a/komapper-core/src/main/kotlin/org/komapper/core/CoreUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/CoreUtility.kt
@@ -1,0 +1,9 @@
+package org.komapper.core
+
+import kotlin.reflect.KType
+
+fun KType.mustNotBeMarkedNullable(className: String?, propertyName: String) {
+    if (this.isMarkedNullable) {
+        error("The '$propertyName' property of '$className' must not be marked as nullable: $this")
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/DataOperator.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/DataOperator.kt
@@ -1,6 +1,7 @@
 package org.komapper.core
 
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 @ThreadSafe
 interface DataOperator {
@@ -8,37 +9,37 @@ interface DataOperator {
      * Formats the value.
      *
      * @param value the value
-     * @param valueClass the class of the value
+     * @param type the type of the value
      * @param masking whether to mask the value
      * @return the formatted value
      */
-    fun <T : Any> formatValue(value: T?, valueClass: KClass<out T>, masking: Boolean): String
+    fun <T : Any> formatValue(value: T?, type: KType, masking: Boolean): String
 
     /**
      * Returns the data type name.
      *
-     * @param klass the class corresponding the data type
+     * @param type the type corresponding the data type
      * @return the data type name
      */
-    fun getDataTypeName(klass: KClass<*>): String
+    fun <T : Any> getDataTypeName(type: KType): String
 }
 
 object DryRunDataOperator : DataOperator {
 
-    override fun <T : Any> formatValue(value: T?, valueClass: KClass<out T>, masking: Boolean): String {
+    override fun <T : Any> formatValue(value: T?, type: KType, masking: Boolean): String {
         return if (masking) {
             "*****"
         } else if (value == null) {
             "null"
         } else {
-            when (valueClass) {
+            when (type.classifier as KClass<*>) {
                 String::class -> "'$value'"
                 else -> value.toString()
             }
         }
     }
 
-    override fun getDataTypeName(klass: KClass<*>): String {
+    override fun <T : Any> getDataTypeName(type: KType): String {
         throw UnsupportedOperationException()
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/DataTypeConverters.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/DataTypeConverters.kt
@@ -7,6 +7,10 @@ object DataTypeConverters {
 
     fun get(): List<DataTypeConverter<*, *>> {
         val loader = ServiceLoader.load(DataTypeConverter::class.java)
-        return loader.toList()
+        return loader.toList().onEach {
+            val className = it::class.qualifiedName
+            it.exteriorType.mustNotBeMarkedNullable(className, "exteriorType")
+            it.interiorType.mustNotBeMarkedNullable(className, "interiorType")
+        }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/LoggerFacade.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/LoggerFacade.kt
@@ -1,6 +1,6 @@
 package org.komapper.core
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * The facade of logger.
@@ -20,7 +20,7 @@ interface LoggerFacade {
      * @param statement the sql statement
      * @param format the format of the sql statement
      */
-    fun sqlWithArgs(statement: Statement, format: (Any?, KClass<*>, Boolean) -> CharSequence)
+    fun sqlWithArgs(statement: Statement, format: (Any?, KType, Boolean) -> CharSequence)
 
     /**
      * Logs the beginning of transaction.
@@ -94,7 +94,7 @@ class DefaultLoggerFacade(private val logger: Logger) : LoggerFacade {
         }
     }
 
-    override fun sqlWithArgs(statement: Statement, format: (Any?, KClass<*>, Boolean) -> CharSequence) {
+    override fun sqlWithArgs(statement: Statement, format: (Any?, KType, Boolean) -> CharSequence) {
         logger.trace(LogCategory.SQL_WITH_ARGS) {
             statement.toSqlWithArgs(format)
         }

--- a/komapper-core/src/main/kotlin/org/komapper/core/Statement.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Statement.kt
@@ -1,6 +1,6 @@
 package org.komapper.core
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * The SQL statement.
@@ -30,7 +30,7 @@ data class Statement(val parts: List<StatementPart>) {
     /**
      * The return parameters of the SQL statement.
      */
-    val returnParamTypes: List<KClass<*>> = parts.filterIsInstance<StatementPart.ReturnParameter>().map { it.dataType }
+    val returnParamTypes: List<KType> = parts.filterIsInstance<StatementPart.ReturnParameter>().map { it.dataType }
 
     /**
      * Converts the SQL statement to an SQL string.
@@ -55,13 +55,13 @@ data class Statement(val parts: List<StatementPart>) {
      *
      * @param format the format function of the bound values
      */
-    fun toSqlWithArgs(format: (Any?, KClass<*>, Boolean) -> CharSequence): String {
+    fun toSqlWithArgs(format: (Any?, KType, Boolean) -> CharSequence): String {
         return parts.joinToString(separator = "") { part ->
             when (part) {
                 is StatementPart.Text -> part.text
                 is StatementPart.Value -> {
                     val value = part.value
-                    format(value.any, value.klass, value.masking)
+                    format(value.any, value.type, value.masking)
                 }
                 is StatementPart.ReturnParameter -> part
             }

--- a/komapper-core/src/main/kotlin/org/komapper/core/Statement.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Statement.kt
@@ -30,7 +30,7 @@ data class Statement(val parts: List<StatementPart>) {
     /**
      * The return parameters of the SQL statement.
      */
-    val returnParamTypes: List<KType> = parts.filterIsInstance<StatementPart.ReturnParameter>().map { it.dataType }
+    val returnParamTypes: List<KType> = parts.filterIsInstance<StatementPart.ReturnParameter>().map { it.type }
 
     /**
      * Converts the SQL statement to an SQL string.

--- a/komapper-core/src/main/kotlin/org/komapper/core/StatementBuffer.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/StatementBuffer.kt
@@ -1,6 +1,6 @@
 package org.komapper.core
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * The buffer for the SQL statement.
@@ -33,7 +33,7 @@ class StatementBuffer {
         return this
     }
 
-    fun registerReturnParameter(dataType: KClass<*>): StatementBuffer {
+    fun registerReturnParameter(dataType: KType): StatementBuffer {
         parts.add(StatementPart.ReturnParameter(dataType))
         return this
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/StatementBuffer.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/StatementBuffer.kt
@@ -33,8 +33,8 @@ class StatementBuffer {
         return this
     }
 
-    fun registerReturnParameter(dataType: KType): StatementBuffer {
-        parts.add(StatementPart.ReturnParameter(dataType))
+    fun registerReturnParameter(type: KType): StatementBuffer {
+        parts.add(StatementPart.ReturnParameter(type))
         return this
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/StatementPart.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/StatementPart.kt
@@ -1,6 +1,6 @@
 package org.komapper.core
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * The part of the SQL Statement.
@@ -9,5 +9,5 @@ import kotlin.reflect.KClass
 sealed class StatementPart : CharSequence {
     data class Text(val text: CharSequence) : StatementPart(), CharSequence by text
     data class Value(val value: org.komapper.core.Value<*>) : StatementPart(), CharSequence by "?"
-    data class ReturnParameter(val dataType: KClass<*>) : StatementPart(), CharSequence by "?"
+    data class ReturnParameter(val dataType: KType) : StatementPart(), CharSequence by "?"
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/StatementPart.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/StatementPart.kt
@@ -9,5 +9,5 @@ import kotlin.reflect.KType
 sealed class StatementPart : CharSequence {
     data class Text(val text: CharSequence) : StatementPart(), CharSequence by text
     data class Value(val value: org.komapper.core.Value<*>) : StatementPart(), CharSequence by "?"
-    data class ReturnParameter(val dataType: KType) : StatementPart(), CharSequence by "?"
+    data class ReturnParameter(val type: KType) : StatementPart(), CharSequence by "?"
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/Value.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Value.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.KType
 @ThreadSafe
 data class Value<T : Any>(val any: T?, val type: KType, val masking: Boolean = false) {
     init {
-        require( !type.isMarkedNullable) { "The type must not be nullable." }
+        require(!type.isMarkedNullable) { "The type must not be nullable." }
         require(type.classifier as? KClass<*> != null) { "The type must be a class." }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/Value.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Value.kt
@@ -1,15 +1,19 @@
 package org.komapper.core
 
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * The value bound to the SQL statement.
  *
  * @property any the value
- * @property klass the class of the value
+ * @property type the type of the value
  * @property masking whether the value is masked or not in log
  */
 @ThreadSafe
-data class Value<T : Any>(val any: T?, val klass: KClass<out T>, val masking: Boolean = false) {
-    constructor(any: T) : this(any, any::class)
+data class Value<T : Any>(val any: T?, val type: KType, val masking: Boolean = false) {
+    init {
+        require( !type.isMarkedNullable) { "The type must not be nullable." }
+        require(type.classifier as? KClass<*> != null) { "The type must be a class." }
+    }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
@@ -49,6 +49,7 @@ import org.komapper.core.dsl.expression.WindowFrameBound
 import org.komapper.core.dsl.expression.WindowFrameExclusion
 import org.komapper.core.dsl.expression.WindowFrameKind
 import org.komapper.core.dsl.expression.WindowFunction
+import kotlin.reflect.typeOf
 
 class BuilderSupport(
     private val dialect: BuilderDialect,
@@ -258,7 +259,7 @@ class BuilderSupport(
     private fun visitLiteralExpression(expression: LiteralExpression<*, *>) {
         val literal = when (expression) {
             is NullLiteralExpression -> "null"
-            is NonNullLiteralExpression -> dialect.formatValue(expression.value, expression.interiorClass, false)
+            is NonNullLiteralExpression -> dialect.formatValue(expression.value, expression.interiorType, false)
         }
         buf.append(literal)
     }
@@ -589,7 +590,7 @@ class BuilderSupport(
             is WindowFrameBound.UnboundedPreceding -> buf.append("unbounded preceding")
             is WindowFrameBound.Following -> {
                 if (dialect.supportsParameterBindingForWindowFrameBoundOffset()) {
-                    buf.bind(Value(bound.offset, Int::class))
+                    buf.bind(Value(bound.offset, typeOf<Int>()))
                 } else {
                     buf.append(bound.offset.toString())
                 }
@@ -598,7 +599,7 @@ class BuilderSupport(
 
             is WindowFrameBound.Preceding -> {
                 if (dialect.supportsParameterBindingForWindowFrameBoundOffset()) {
-                    buf.bind(Value(bound.offset, Int::class))
+                    buf.bind(Value(bound.offset, typeOf<Int>()))
                 } else {
                     buf.append(bound.offset.toString())
                 }
@@ -645,8 +646,8 @@ class BuilderSupport(
             }
         }
         visit(escapeExpression)
-        val first = Value(patternBuf.toString(), String::class, masking)
-        val second = Value(finalEscapeSequence, String::class)
+        val first = Value(patternBuf.toString(), typeOf<String>(), masking)
+        val second = Value(finalEscapeSequence, typeOf<String>())
         return first to second
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/OffsetLimitStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/OffsetLimitStatementBuilder.kt
@@ -4,6 +4,7 @@ import org.komapper.core.BuilderDialect
 import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
 import org.komapper.core.Value
+import kotlin.reflect.typeOf
 
 interface OffsetLimitStatementBuilder {
     fun build(): Statement
@@ -20,12 +21,12 @@ class OffsetLimitStatementBuilderImpl(
     override fun build(): Statement {
         if (offset >= 0) {
             buf.append(" offset ")
-            buf.bind(Value(offset, Int::class))
+            buf.bind(Value(offset, typeOf<Int>()))
             buf.append(" rows")
         }
         if (limit > 0) {
             buf.append(" fetch first ")
-            buf.bind(Value(limit, Int::class))
+            buf.bind(Value(limit, typeOf<Int>()))
             buf.append(" rows only")
         }
         return buf.toStatement()

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SchemaStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SchemaStatementBuilder.kt
@@ -66,8 +66,8 @@ abstract class AbstractSchemaStatementBuilder(
         return listOf(buf.toStatement())
     }
 
-    protected open fun resolveDataTypeName(property: PropertyMetamodel<*, *, *>): String {
-        return dialect.getDataTypeName(property.interiorClass)
+    protected open fun <INTERIOR : Any> resolveDataTypeName(property: PropertyMetamodel<*, *, INTERIOR>): String {
+        return dialect.getDataTypeName<INTERIOR>(property.interiorType)
     }
 
     protected open fun resolveIdentity(property: PropertyMetamodel<*, *, *>): String {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/AggregateFunction.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/AggregateFunction.kt
@@ -1,13 +1,14 @@
 package org.komapper.core.dsl.expression
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 sealed class AggregateFunction<T : Any, S : Any> : ScalarExpression<T, S>, WindowFunction<T, S> {
     internal data class Avg(val expression: ColumnExpression<*, *>) : ColumnExpression<Double, Double>,
         AggregateFunction<Double, Double>() {
         override val owner: TableExpression<*> get() = expression.owner
-        override val exteriorClass: KClass<Double> get() = Double::class
-        override val interiorClass: KClass<Double> = Double::class
+        override val exteriorType: KType = typeOf<Double>()
+        override val interiorType: KType = typeOf<Double>()
         override val columnName: String get() = expression.columnName
         override val alwaysQuote: Boolean get() = expression.alwaysQuote
         override val masking: Boolean get() = expression.masking
@@ -17,8 +18,8 @@ sealed class AggregateFunction<T : Any, S : Any> : ScalarExpression<T, S>, Windo
 
     internal object CountAsterisk : ColumnExpression<Long, Long>, AggregateFunction<Long, Long>() {
         override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
-        override val exteriorClass: KClass<Long> get() = Long::class
-        override val interiorClass: KClass<Long> get() = Long::class
+        override val exteriorType: KType = typeOf<Long>()
+        override val interiorType: KType = typeOf<Long>()
         override val columnName: String get() = throw UnsupportedOperationException()
         override val alwaysQuote: Boolean get() = throw UnsupportedOperationException()
         override val masking: Boolean get() = throw UnsupportedOperationException()
@@ -29,8 +30,8 @@ sealed class AggregateFunction<T : Any, S : Any> : ScalarExpression<T, S>, Windo
     internal data class Count(val expression: ColumnExpression<*, *>) : ColumnExpression<Long, Long>,
         AggregateFunction<Long, Long>() {
         override val owner: TableExpression<*> get() = expression.owner
-        override val exteriorClass: KClass<Long> get() = Long::class
-        override val interiorClass: KClass<Long> = Long::class
+        override val exteriorType: KType = typeOf<Long>()
+        override val interiorType: KType = typeOf<Long>()
         override val columnName: String get() = expression.columnName
         override val alwaysQuote: Boolean get() = expression.alwaysQuote
         override val masking: Boolean get() = expression.masking

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ColumnExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ColumnExpression.kt
@@ -1,6 +1,6 @@
 package org.komapper.core.dsl.expression
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 sealed interface InteriorExpression<out INTERIOR>
 
@@ -12,8 +12,8 @@ sealed interface InteriorExpression<out INTERIOR>
  */
 sealed interface ColumnExpression<EXTERIOR : Any, INTERIOR : Any> : SortExpression, InteriorExpression<INTERIOR> {
     val owner: TableExpression<*>
-    val exteriorClass: KClass<EXTERIOR>
-    val interiorClass: KClass<INTERIOR>
+    val exteriorType: KType
+    val interiorType: KType
     val wrap: (INTERIOR) -> EXTERIOR
     val unwrap: (EXTERIOR) -> INTERIOR
     val columnName: String

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/LiteralExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/LiteralExpression.kt
@@ -1,12 +1,12 @@
 package org.komapper.core.dsl.expression
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 internal sealed interface LiteralExpression<EXTERNAL : Any, INTERNAL : Any> : ColumnExpression<EXTERNAL, INTERNAL>
 
 data class NullLiteralExpression<EXTERNAL : Any, INTERNAL : Any>(
-    override val exteriorClass: KClass<EXTERNAL>,
-    override val interiorClass: KClass<INTERNAL>,
+    override val exteriorType: KType,
+    override val interiorType: KType,
 ) :
     LiteralExpression<EXTERNAL, INTERNAL> {
     override val owner: TableExpression<*>
@@ -23,12 +23,12 @@ data class NullLiteralExpression<EXTERNAL : Any, INTERNAL : Any>(
 
 internal data class NonNullLiteralExpression<T : Any>(
     val value: T,
-    private val klass: KClass<T>,
+    private val type: KType,
 ) : LiteralExpression<T, T> {
     override val owner: TableExpression<*>
         get() = throw UnsupportedOperationException()
-    override val exteriorClass: KClass<T> = klass
-    override val interiorClass: KClass<T> = klass
+    override val exteriorType: KType = type
+    override val interiorType: KType = type
     override val wrap: (T) -> T get() = { it }
     override val unwrap: (T) -> T get() = { it }
     override val columnName: String

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/MathematicalFunction.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/MathematicalFunction.kt
@@ -1,13 +1,14 @@
 package org.komapper.core.dsl.expression
 
 import java.math.BigDecimal
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 internal sealed class MathematicalFunction<T : Any, S : Any> : ColumnExpression<T, S> {
     internal object Random : MathematicalFunction<BigDecimal, BigDecimal>() {
         override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
-        override val exteriorClass: KClass<BigDecimal> get() = BigDecimal::class
-        override val interiorClass: KClass<BigDecimal> get() = BigDecimal::class
+        override val exteriorType: KType = typeOf<BigDecimal>()
+        override val interiorType: KType = typeOf<BigDecimal>()
         override val columnName: String get() = throw UnsupportedOperationException()
         override val alwaysQuote: Boolean get() = throw UnsupportedOperationException()
         override val masking: Boolean get() = throw UnsupportedOperationException()

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/Operand.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/Operand.kt
@@ -2,7 +2,7 @@ package org.komapper.core.dsl.expression
 
 import org.komapper.core.ThreadSafe
 import org.komapper.core.Value
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * Represents operands in Komapper Query DSL.
@@ -37,24 +37,24 @@ sealed class Operand {
          */
         val value: Value<S> get() {
             val interior = if (exterior == null) null else expression.unwrap(exterior)
-            return Value(interior, expression.interiorClass, expression.masking)
+            return Value(interior, expression.interiorType, expression.masking)
         }
     }
 
     /**
      * A simple argument to be bound to a prepared statement.
      *
-     * @param interiorClass the interior class
+     * @param interiorType the interior type
      * @param interior the argument value
      */
-    data class SimpleArgument<S : Any>(val interiorClass: KClass<S>, val interior: S?) : Operand() {
+    data class SimpleArgument<S : Any>(val interiorType: KType, val interior: S?) : Operand() {
         override val masking: Boolean get() = false
 
         /**
          * The bindable format of the argument.
          */
         val value: Value<S> get() {
-            return Value(interior, interiorClass, masking)
+            return Value(interior, interiorType, masking)
         }
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ReadOnlyColumnExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ReadOnlyColumnExpression.kt
@@ -1,11 +1,11 @@
 package org.komapper.core.dsl.expression
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 class ReadOnlyColumnExpression<EXTERIOR : Any, INTERIOR : Any>(
     override val owner: TableExpression<*>,
-    override val exteriorClass: KClass<EXTERIOR>,
-    override val interiorClass: KClass<INTERIOR>,
+    override val exteriorType: KType,
+    override val interiorType: KType,
     override val wrap: (INTERIOR) -> EXTERIOR,
     override val columnName: String,
     override val alwaysQuote: Boolean,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/StringFunction.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/StringFunction.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.expression
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 internal sealed class StringFunction<T : Any, S : Any> : ColumnExpression<T, S> {
     internal data class Concat<T : Any>(
@@ -16,8 +17,8 @@ internal sealed class StringFunction<T : Any, S : Any> : ColumnExpression<T, S> 
         val startIndex: Operand?,
     ) : StringFunction<Int, Int>() {
         override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
-        override val exteriorClass: KClass<Int> get() = Int::class
-        override val interiorClass: KClass<Int> get() = Int::class
+        override val exteriorType: KType = typeOf<Int>()
+        override val interiorType: KType = typeOf<Int>()
         override val wrap: (Int) -> Int get() = { it }
         override val unwrap: (Int) -> Int get() = { it }
         override val columnName: String get() = throw UnsupportedOperationException()

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/UserDefinedExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/UserDefinedExpression.kt
@@ -1,10 +1,10 @@
 package org.komapper.core.dsl.expression
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 internal class UserDefinedExpression<EXTERIOR : Any, INTERIOR : Any>(
-    override val exteriorClass: KClass<EXTERIOR>,
-    override val interiorClass: KClass<INTERIOR>,
+    override val exteriorType: KType,
+    override val interiorType: KType,
     override val wrap: (INTERIOR) -> EXTERIOR,
     private val name: String,
     private val operands: List<Operand>,
@@ -25,8 +25,8 @@ internal class UserDefinedExpression<EXTERIOR : Any, INTERIOR : Any>(
 
         other as UserDefinedExpression<*, *>
 
-        if (exteriorClass != other.exteriorClass) return false
-        if (interiorClass != other.interiorClass) return false
+        if (exteriorType != other.exteriorType) return false
+        if (interiorType != other.interiorType) return false
         if (name != other.name) return false
         if (operands != other.operands) return false
 
@@ -34,8 +34,8 @@ internal class UserDefinedExpression<EXTERIOR : Any, INTERIOR : Any>(
     }
 
     override fun hashCode(): Int {
-        var result = exteriorClass.hashCode()
-        result = 31 * result + interiorClass.hashCode()
+        var result = exteriorType.hashCode()
+        result = 31 * result + interiorType.hashCode()
         result = 31 * result + name.hashCode()
         result = 31 * result + operands.hashCode()
         return result

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/WindowFunction.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/WindowFunction.kt
@@ -2,14 +2,15 @@
 
 package org.komapper.core.dsl.expression
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 sealed interface WindowFunction<T : Any, S : Any> : ColumnExpression<T, S>
 
 internal object RowNumber : WindowFunction<Long, Long> {
     override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
-    override val exteriorClass: KClass<Long> = Long::class
-    override val interiorClass: KClass<Long> = Long::class
+    override val exteriorType: KType = typeOf<Long>()
+    override val interiorType: KType = typeOf<Long>()
     override val wrap: (Long) -> Long = { it }
     override val unwrap: (Long) -> Long = { it }
     override val columnName: String get() = throw UnsupportedOperationException()
@@ -19,8 +20,8 @@ internal object RowNumber : WindowFunction<Long, Long> {
 
 internal object Rank : WindowFunction<Long, Long> {
     override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
-    override val exteriorClass: KClass<Long> = Long::class
-    override val interiorClass: KClass<Long> = Long::class
+    override val exteriorType: KType = typeOf<Long>()
+    override val interiorType: KType = typeOf<Long>()
     override val wrap: (Long) -> Long = { it }
     override val unwrap: (Long) -> Long = { it }
     override val columnName: String get() = throw UnsupportedOperationException()
@@ -30,8 +31,8 @@ internal object Rank : WindowFunction<Long, Long> {
 
 internal object DenseRank : WindowFunction<Long, Long> {
     override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
-    override val exteriorClass: KClass<Long> = Long::class
-    override val interiorClass: KClass<Long> = Long::class
+    override val exteriorType: KType = typeOf<Long>()
+    override val interiorType: KType = typeOf<Long>()
     override val wrap: (Long) -> Long = { it }
     override val unwrap: (Long) -> Long = { it }
     override val columnName: String get() = throw UnsupportedOperationException()
@@ -41,8 +42,8 @@ internal object DenseRank : WindowFunction<Long, Long> {
 
 internal object PercentRank : WindowFunction<Double, Double> {
     override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
-    override val exteriorClass: KClass<Double> = Double::class
-    override val interiorClass: KClass<Double> = Double::class
+    override val exteriorType: KType = typeOf<Double>()
+    override val interiorType: KType = typeOf<Double>()
     override val wrap: (Double) -> Double = { it }
     override val unwrap: (Double) -> Double = { it }
     override val columnName: String get() = throw UnsupportedOperationException()
@@ -52,8 +53,8 @@ internal object PercentRank : WindowFunction<Double, Double> {
 
 internal object CumeDist : WindowFunction<Double, Double> {
     override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
-    override val exteriorClass: KClass<Double> = Double::class
-    override val interiorClass: KClass<Double> = Double::class
+    override val exteriorType: KType = typeOf<Double>()
+    override val interiorType: KType = typeOf<Double>()
     override val wrap: (Double) -> Double = { it }
     override val unwrap: (Double) -> Double = { it }
     override val columnName: String get() = throw UnsupportedOperationException()
@@ -63,8 +64,8 @@ internal object CumeDist : WindowFunction<Double, Double> {
 
 internal data class Ntile(val bucketSize: Operand) : WindowFunction<Int, Int> {
     override val owner: TableExpression<*> get() = throw UnsupportedOperationException()
-    override val exteriorClass: KClass<Int> = Int::class
-    override val interiorClass: KClass<Int> = Int::class
+    override val exteriorType: KType = typeOf<Int>()
+    override val interiorType: KType = typeOf<Int>()
     override val wrap: (Int) -> Int = { it }
     override val unwrap: (Int) -> Int = { it }
     override val columnName: String get() = throw UnsupportedOperationException()
@@ -111,8 +112,8 @@ internal data class WindowDefinitionImpl<T : Any, S : Any>(
     override val frame: WindowFrame?,
 ) : WindowDefinition<T, S> {
     override val owner: TableExpression<*> get() = function.owner
-    override val exteriorClass: KClass<T> get() = function.exteriorClass
-    override val interiorClass: KClass<S> get() = function.interiorClass
+    override val exteriorType: KType = function.exteriorType
+    override val interiorType: KType = function.interiorType
     override val wrap: (S) -> T get() = function.wrap
     override val unwrap: (T) -> S get() = function.unwrap
     override val columnName: String get() = function.columnName

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
@@ -13,7 +13,7 @@ interface EntityMetamodel<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY,
          * The version of the metamodel.
          * This version will be incremented as the specification changes.
          */
-        const val METAMODEL_VERSION: Int = 1
+        const val METAMODEL_VERSION: Int = 2
     }
     fun declaration(): EntityMetamodelDeclaration<META>
     fun idGenerator(): IdGenerator<ENTITY, ID>?

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/PropertyDescriptor.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/PropertyDescriptor.kt
@@ -1,12 +1,12 @@
 package org.komapper.core.dsl.metamodel
 
 import org.komapper.core.ThreadSafe
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 @ThreadSafe
 class PropertyDescriptor<ENTITY, EXTERIOR : Any, INTERIOR : Any>(
-    val exteriorClass: KClass<EXTERIOR>,
-    val interiorClass: KClass<INTERIOR>,
+    val exteriorType: KType,
+    val interiorType: KType,
     val name: String,
     val columnName: String,
     val alwaysQuote: Boolean,

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/PropertyMetamodel.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/PropertyMetamodel.kt
@@ -3,7 +3,7 @@ package org.komapper.core.dsl.metamodel
 import org.komapper.core.ThreadSafe
 import org.komapper.core.Value
 import org.komapper.core.dsl.expression.PropertyExpression
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 @ThreadSafe
 interface PropertyMetamodel<ENTITY : Any, EXTERIOR : Any, INTERIOR : Any> : PropertyExpression<EXTERIOR, INTERIOR> {
@@ -16,7 +16,7 @@ interface PropertyMetamodel<ENTITY : Any, EXTERIOR : Any, INTERIOR : Any> : Prop
     fun toValue(entity: ENTITY): Value<INTERIOR> {
         val exterior = getter(entity)
         val interior = if (exterior == null) null else unwrap(exterior)
-        return Value(interior, interiorClass, masking)
+        return Value(interior, interiorType, masking)
     }
 }
 
@@ -25,8 +25,8 @@ class PropertyMetamodelImpl<ENTITY : Any, EXTERIOR : Any, INTERIOR : Any>(
     override val owner: EntityMetamodel<ENTITY, *, *>,
     private val descriptor: PropertyDescriptor<ENTITY, EXTERIOR, INTERIOR>,
 ) : PropertyMetamodel<ENTITY, EXTERIOR, INTERIOR> {
-    override val exteriorClass: KClass<EXTERIOR> get() = descriptor.exteriorClass
-    override val interiorClass: KClass<INTERIOR> get() = descriptor.interiorClass
+    override val exteriorType: KType = descriptor.exteriorType
+    override val interiorType: KType = descriptor.interiorType
     override val name: String get() = descriptor.name
     override val columnName: String get() = descriptor.columnName
     override val alwaysQuote: Boolean get() = descriptor.alwaysQuote
@@ -42,8 +42,8 @@ class PropertyMetamodelImpl<ENTITY : Any, EXTERIOR : Any, INTERIOR : Any>(
 class PropertyMetamodelStub<ENTITY : Any, EXTERIOR : Any> :
     PropertyMetamodel<ENTITY, EXTERIOR, EXTERIOR> {
     override val owner: EntityMetamodel<ENTITY, *, *> get() = fail()
-    override val exteriorClass: KClass<EXTERIOR> get() = fail()
-    override val interiorClass: KClass<EXTERIOR> get() = fail()
+    override val exteriorType: KType get() = fail()
+    override val interiorType: KType get() = fail()
     override val name: String get() = fail()
     override val columnName: String get() = fail()
     override val alwaysQuote: Boolean get() = fail()

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/LiteralExpressions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/LiteralExpressions.kt
@@ -4,28 +4,20 @@ import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.NonNullLiteralExpression
 import org.komapper.core.dsl.expression.NullLiteralExpression
 import java.math.BigDecimal
-import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
 /**
  * Builds a null literal.
  */
-inline fun <reified T : Any> nullLiteral(): ColumnExpression<T, T> {
-    return NullLiteralExpression(typeOf<T>(), typeOf<String>())
+inline fun <reified EXTERIOR : Any> nullLiteral(): ColumnExpression<EXTERIOR, *> {
+    return NullLiteralExpression<EXTERIOR, String>(typeOf<EXTERIOR>(), typeOf<String>())
 }
 
 /**
  * Builds a null literal.
  */
-fun <EXTERIOR : Any> nullLiteral(exteriorType: KType): ColumnExpression<EXTERIOR, *> {
-    return NullLiteralExpression<EXTERIOR, String>(exteriorType, typeOf<String>())
-}
-
-/**
- * Builds a null literal.
- */
-fun <EXTERIOR : Any, INTERIOR : Any> nullLiteral(exteriorType: KType, interiorType: KType): ColumnExpression<EXTERIOR, INTERIOR> {
-    return NullLiteralExpression(exteriorType, interiorType)
+fun <EXTERIOR : Any, INTERIOR : Any> nullLiteral(expression: ColumnExpression<EXTERIOR, INTERIOR>): ColumnExpression<EXTERIOR, INTERIOR> {
+    return NullLiteralExpression(expression.exteriorType, expression.interiorType)
 }
 
 /**

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/LiteralExpressions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/LiteralExpressions.kt
@@ -4,55 +4,56 @@ import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.NonNullLiteralExpression
 import org.komapper.core.dsl.expression.NullLiteralExpression
 import java.math.BigDecimal
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 /**
  * Builds a null literal.
  */
-inline fun <reified EXTERIOR : Any> nullLiteral(): ColumnExpression<EXTERIOR, *> {
-    return NullLiteralExpression(EXTERIOR::class, String::class)
+inline fun <reified T : Any> nullLiteral(): ColumnExpression<T, T> {
+    return NullLiteralExpression(typeOf<T>(), typeOf<T>())
 }
 
 /**
  * Builds a null literal.
  */
-fun <T : Any> nullLiteral(klass: KClass<T>): ColumnExpression<T, T> {
-    return NullLiteralExpression(klass, klass)
+fun <EXTERIOR : Any> nullLiteral(exteriorType: KType): ColumnExpression<EXTERIOR, *> {
+    return NullLiteralExpression<EXTERIOR, String>(exteriorType, typeOf<String>())
 }
 
 /**
  * Builds a null literal.
  */
-fun <EXTERIOR : Any, INTERIOR : Any> nullLiteral(exteriorClass: KClass<EXTERIOR>, interiorClass: KClass<INTERIOR>): ColumnExpression<EXTERIOR, INTERIOR> {
-    return NullLiteralExpression(exteriorClass, interiorClass)
+fun <EXTERIOR : Any, INTERIOR : Any> nullLiteral(exteriorType: KType, interiorType: KType): ColumnExpression<EXTERIOR, INTERIOR> {
+    return NullLiteralExpression(exteriorType, interiorType)
 }
 
 /**
  * Builds a [Boolean] literal.
  */
 fun literal(value: Boolean): ColumnExpression<Boolean, Boolean> {
-    return NonNullLiteralExpression(value, Boolean::class)
+    return NonNullLiteralExpression(value, typeOf<Boolean>())
 }
 
 /**
  * Builds a [Int] literal.
  */
 fun literal(value: Int): ColumnExpression<Int, Int> {
-    return NonNullLiteralExpression(value, Int::class)
+    return NonNullLiteralExpression(value, typeOf<Int>())
 }
 
 /**
  * Builds a [Long] literal.
  */
 fun literal(value: Long): ColumnExpression<Long, Long> {
-    return NonNullLiteralExpression(value, Long::class)
+    return NonNullLiteralExpression(value, typeOf<Long>())
 }
 
 /**
  * Builds a [BigDecimal] literal.
  */
 fun literal(value: BigDecimal): ColumnExpression<BigDecimal, BigDecimal> {
-    return NonNullLiteralExpression(value, BigDecimal::class)
+    return NonNullLiteralExpression(value, typeOf<BigDecimal>())
 }
 
 /**
@@ -62,5 +63,5 @@ fun literal(value: BigDecimal): ColumnExpression<BigDecimal, BigDecimal> {
  */
 fun literal(value: String): ColumnExpression<String, String> {
     require("'" !in value) { "The value must not contain the single quotation." }
-    return NonNullLiteralExpression(value, String::class)
+    return NonNullLiteralExpression(value, typeOf<String>())
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/LiteralExpressions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/LiteralExpressions.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.typeOf
  * Builds a null literal.
  */
 inline fun <reified T : Any> nullLiteral(): ColumnExpression<T, T> {
-    return NullLiteralExpression(typeOf<T>(), typeOf<T>())
+    return NullLiteralExpression(typeOf<T>(), typeOf<String>())
 }
 
 /**

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/Record.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/Record.kt
@@ -2,7 +2,6 @@ package org.komapper.core.dsl.query
 
 import org.komapper.core.ThreadSafe
 import org.komapper.core.dsl.expression.ColumnExpression
-import kotlin.reflect.cast
 
 /**
  * Represents a single row detached from the result set obtained by query execution.
@@ -62,7 +61,8 @@ class RecordImpl(private val map: Map<ColumnExpression<*, *>, Any?>) : Record {
 
     override fun <T : Any> get(key: ColumnExpression<T, *>): T? {
         val value = map[key]
-        return if (value == null) null else key.exteriorClass.cast(value)
+        @Suppress("UNCHECKED_CAST")
+        return if (value == null) null else value as T
     }
 
     override fun toString(): String {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/Row.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/Row.kt
@@ -7,7 +7,8 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.util.UUID
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 /**
  * Represents a single row connected to the result set obtained by query execution.
@@ -16,25 +17,26 @@ import kotlin.reflect.KClass
  * Note that columns are numbered from 0.
  */
 interface Row {
-    fun <T : Any> get(index: Int, klass: KClass<T>): T?
-    fun <T : Any> get(columnLabel: String, klass: KClass<T>): T?
+    fun <T : Any> get(index: Int, type: KType): T?
+
+    fun <T : Any> get(columnLabel: String, type: KType): T?
 }
 
 inline fun <reified T : Any> Row.get(index: Int): T? {
-    return get(index, T::class)
+    return get(index, typeOf<T>())
 }
 
 inline fun <reified T : Any> Row.get(columnLabel: String): T? {
-    return get(columnLabel, T::class)
+    return get(columnLabel, typeOf<T>())
 }
 
 inline fun <reified T : Any> Row.getNotNull(index: Int): T {
-    val nullable = get(index, T::class)
+    val nullable = get<T>(index, typeOf<T>())
     return checkNotNull(nullable) { "The returning value is null. index=$index" }
 }
 
 inline fun <reified T : Any> Row.getNotNull(columnLabel: String): T {
-    val nullable = get(columnLabel, T::class)
+    val nullable = get<T>(columnLabel, typeOf<T>())
     return checkNotNull(nullable) { "The returning value is null. columnLabel=$columnLabel" }
 }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/ScalarQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/ScalarQuery.kt
@@ -4,7 +4,7 @@ import org.komapper.core.dsl.context.SubqueryContext
 import org.komapper.core.dsl.expression.ScalarExpression
 import org.komapper.core.dsl.expression.ScalarQueryExpression
 import org.komapper.core.dsl.expression.TableExpression
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * Represents a query that returns a scalar.
@@ -30,10 +30,10 @@ internal data class NullableScalarQuery<A, B : Any, C : Any>(
         get() = query.context
     override val owner: TableExpression<*>
         get() = expression.owner
-    override val exteriorClass: KClass<B>
-        get() = expression.exteriorClass
-    override val interiorClass: KClass<C>
-        get() = expression.interiorClass
+    override val exteriorType: KType
+        get() = expression.exteriorType
+    override val interiorType: KType
+        get() = expression.interiorType
     override val wrap: (C) -> B
         get() = expression.wrap
     override val unwrap: (B) -> C
@@ -56,10 +56,10 @@ internal data class NotNullScalarQuery<A, B : Any, C : Any>(
         get() = query.context
     override val owner: TableExpression<*>
         get() = expression.owner
-    override val exteriorClass: KClass<B>
-        get() = expression.exteriorClass
-    override val interiorClass: KClass<C>
-        get() = expression.interiorClass
+    override val exteriorType: KType
+        get() = expression.exteriorType
+    override val interiorType: KType
+        get() = expression.interiorType
     override val wrap: (C) -> B
         get() = expression.wrap
     override val unwrap: (B) -> C

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateBinder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateBinder.kt
@@ -1,6 +1,7 @@
 package org.komapper.core.dsl.query
 
 import org.komapper.core.Value
+import kotlin.reflect.typeOf
 
 /**
  * Represents a binder that binds given values to an SQL template.
@@ -27,6 +28,6 @@ interface TemplateBinder<BINDER : TemplateBinder<BINDER>> {
  * @return the binder
  */
 inline fun <reified T : Any, B : TemplateBinder<B>> TemplateBinder<B>.bind(name: String, value: T?, masking: Boolean = false): B {
-    val v = Value(value, T::class, masking)
+    val v = Value(value, typeOf<T>(), masking)
     return this.bindValue(name, v)
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EnumMappingException.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EnumMappingException.kt
@@ -1,13 +1,13 @@
 package org.komapper.core.dsl.runner
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 class EnumMappingException(
-    enumClass: KClass<out Enum<*>>,
+    enumType: KType,
     propertyName: String,
     value: Any,
     cause: Exception?,
 ) : RuntimeException(
-    "Failed to map the value \"$value\" to the property \"$propertyName\" of the enum class \"${enumClass.qualifiedName}\".",
+    "Failed to map the value \"$value\" to the property \"$propertyName\" of the enum class \"${enumType}\".",
     cause,
 )

--- a/komapper-core/src/main/kotlin/org/komapper/core/spi/DataTypeConverter.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/spi/DataTypeConverter.kt
@@ -1,12 +1,12 @@
 package org.komapper.core.spi
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 interface DataTypeConverter<EXTERIOR : Any, INTERIOR : Any> {
 
-    val exteriorClass: KClass<EXTERIOR>
+    val exteriorType: KType
 
-    val interiorClass: KClass<INTERIOR>
+    val interiorType: KType
 
     fun wrap(interior: INTERIOR): EXTERIOR
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/spi/DataTypeConverter.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/spi/DataTypeConverter.kt
@@ -2,13 +2,30 @@ package org.komapper.core.spi
 
 import kotlin.reflect.KType
 
+/**
+ * A converter that converts a data type between an exterior type and an interior type.
+ */
 interface DataTypeConverter<EXTERIOR : Any, INTERIOR : Any> {
 
+    /**
+     * The exterior type.
+     * [KType.isMarkedNullable] must be false.
+     */
     val exteriorType: KType
 
+    /**
+     * The interior type.
+     * [KType.isMarkedNullable] must be false.
+     */
     val interiorType: KType
 
+    /**
+     * Converts the interior type to the exterior type.
+     */
     fun wrap(interior: INTERIOR): EXTERIOR
 
+    /**
+     * Converts the exterior type to the interior type.
+     */
     fun unwrap(exterior: EXTERIOR): INTERIOR
 }

--- a/komapper-core/src/test/kotlin/org/komapper/core/CoreUtilityTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/CoreUtilityTest.kt
@@ -1,0 +1,28 @@
+package org.komapper.core
+
+import org.junit.jupiter.api.assertThrows
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CoreUtilityTest {
+    @Test
+    fun mustNotBeMarkedNullable_nonNullable() {
+        MyData.nonNullable.mustNotBeMarkedNullable(MyData::class.qualifiedName, "nonNullable")
+    }
+
+    @Test
+    fun mustNotBeMarkedNullable_nullable() {
+        val th = assertThrows<IllegalStateException> {
+            MyData.nullable.mustNotBeMarkedNullable(MyData::class.qualifiedName, "nullable")
+        }
+        val expected = "The 'nullable' property of 'org.komapper.core.MyData' must not be marked as nullable: java.lang.String? (Kotlin reflection is not available)"
+        assertEquals(expected, th.message)
+    }
+}
+
+object MyData {
+    val nonNullable: KType = typeOf<String>()
+    val nullable: KType = typeOf<String?>()
+}

--- a/komapper-core/src/test/kotlin/org/komapper/core/DryRunStatementTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/DryRunStatementTest.kt
@@ -1,5 +1,6 @@
 package org.komapper.core
 
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -11,17 +12,17 @@ class DryRunStatementTest {
             DryRunStatement(
                 sql = "select * from employee where name = ? and age = ?",
                 sqlWithArgs = "select * from employee where name = 'aaa' and age = 20",
-                args = listOf(Value("aaa"), Value(20)),
+                args = listOf(Value("aaa", typeOf<String>()), Value(20, typeOf<Int>())),
             )
         val b =
             DryRunStatement(
                 sql = "delete from employee where name = ?",
                 sqlWithArgs = "delete from employee where name = 'bbb'",
-                args = listOf(Value("bbb")),
+                args = listOf(Value("bbb", typeOf<String>())),
             )
         val c = a + b
         assertEquals("select * from employee where name = ? and age = ?;delete from employee where name = ?", c.sql)
         assertEquals("select * from employee where name = 'aaa' and age = 20;delete from employee where name = 'bbb'", c.sqlWithArgs)
-        assertEquals(c.args, listOf(Value("aaa"), Value(20), Value("bbb")))
+        assertEquals(c.args, listOf(Value("aaa", typeOf<String>()), Value(20, typeOf<Int>()), Value("bbb", typeOf<String>())))
     }
 }

--- a/komapper-core/src/test/kotlin/org/komapper/core/StatementBufferTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/StatementBufferTest.kt
@@ -1,5 +1,6 @@
 package org.komapper.core
 
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -10,15 +11,15 @@ internal class StatementBufferTest {
     fun appendAndBind() {
         val buffer = StatementBuffer()
         buffer.append("aaa")
-        buffer.bind(Value(1))
+        buffer.bind(Value(1, typeOf<Int>()))
         buffer.append("bbb")
-        buffer.bind(Value(2))
+        buffer.bind(Value(2, typeOf<Int>()))
         assertEquals(
             listOf(
                 StatementPart.Text("aaa"),
-                StatementPart.Value(Value(1)),
+                StatementPart.Value(Value(1, typeOf<Int>())),
                 StatementPart.Text("bbb"),
-                StatementPart.Value(Value(2)),
+                StatementPart.Value(Value(2, typeOf<Int>())),
             ),
             buffer.parts,
         )
@@ -28,12 +29,12 @@ internal class StatementBufferTest {
     fun appendStatement() {
         val buffer = StatementBuffer()
         buffer.append("aaa")
-        buffer.bind(Value(1))
+        buffer.bind(Value(1, typeOf<Int>()))
         buffer.append(
             Statement(
                 listOf(
                     StatementPart.Text("bbb"),
-                    StatementPart.Value(Value(2)),
+                    StatementPart.Value(Value(2, typeOf<Int>())),
                     StatementPart.Text("ccc"),
                 ),
             ),
@@ -41,9 +42,9 @@ internal class StatementBufferTest {
         assertEquals(
             listOf(
                 StatementPart.Text("aaa"),
-                StatementPart.Value(Value(1)),
+                StatementPart.Value(Value(1, typeOf<Int>())),
                 StatementPart.Text("bbb"),
-                StatementPart.Value(Value(2)),
+                StatementPart.Value(Value(2, typeOf<Int>())),
                 StatementPart.Text("ccc"),
             ),
             buffer.parts,
@@ -74,7 +75,7 @@ internal class StatementBufferTest {
     fun cutBack_error_lastElementIsPlaceHolder() {
         val buffer = StatementBuffer()
         buffer.append("abc")
-        buffer.bind(Value(1))
+        buffer.bind(Value(1, typeOf<Int>()))
         assertFailsWith<IllegalStateException> {
             buffer.cutBack(1)
         }

--- a/komapper-core/src/test/kotlin/org/komapper/core/StatementTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/StatementTest.kt
@@ -1,5 +1,6 @@
 package org.komapper.core
 
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -11,12 +12,12 @@ internal class StatementTest {
             Statement(
                 listOf(
                     StatementPart.Text("select * from employee where name = "),
-                    StatementPart.Value(Value("aaa")),
+                    StatementPart.Value(Value("aaa", typeOf<String>())),
                     StatementPart.Text(" and age = "),
-                    StatementPart.Value(Value(20)),
+                    StatementPart.Value(Value(20, typeOf<Int>())),
                 ),
             )
-        assertEquals(listOf(Value("aaa"), Value(20)), statement.args)
+        assertEquals(listOf(Value("aaa", typeOf<String>()), Value(20, typeOf<Int>())), statement.args)
     }
 
     @Test
@@ -25,9 +26,9 @@ internal class StatementTest {
             Statement(
                 listOf(
                     StatementPart.Text("select * from employee where name = "),
-                    StatementPart.Value(Value("aaa")),
+                    StatementPart.Value(Value("aaa", typeOf<String>())),
                     StatementPart.Text(" and age = "),
-                    StatementPart.Value(Value(20)),
+                    StatementPart.Value(Value(20, typeOf<Int>())),
                 ),
             )
         assertEquals("select * from employee where name = ? and age = ?", statement.toSql())

--- a/komapper-datetime-jdbc/src/main/kotlin/org/komapper/datetime/jdbc/JdbcDatetimeTypeProvider.kt
+++ b/komapper-datetime-jdbc/src/main/kotlin/org/komapper/datetime/jdbc/JdbcDatetimeTypeProvider.kt
@@ -14,28 +14,29 @@ import org.komapper.jdbc.JdbcDataType
 import org.komapper.jdbc.JdbcDataTypeProvider
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class JdbcDatetimeTypeProvider(val next: JdbcDataTypeProvider) : JdbcDataTypeProvider {
 
-    override fun <T : Any> get(klass: KClass<out T>): JdbcDataType<T>? {
-        val dataType: JdbcDataType<*>? = when (klass) {
+    override fun <T : Any> get(type: KType): JdbcDataType<T>? {
+        val dataType: JdbcDataType<*>? = when (type.classifier) {
             Instant::class -> {
-                val dataType = next.get(java.time.Instant::class)
+                val dataType = next.get<java.time.Instant>(typeOf<java.time.Instant>())
                     ?: error("The dataType is not found for java.time.Instant.")
                 JdbcKotlinInstantType(dataType)
             }
             LocalDate::class -> {
-                val dataType = next.get(java.time.LocalDate::class)
+                val dataType = next.get<java.time.LocalDate>(typeOf<java.time.LocalDate>())
                     ?: error("The dataType is not found for java.time.LocalDate.")
                 JdbcKotlinLocalDateType(dataType)
             }
             LocalDateTime::class -> {
-                val dataType = next.get(java.time.LocalDateTime::class)
+                val dataType = next.get<java.time.LocalDateTime>(typeOf<java.time.LocalDateTime>())
                     ?: error("The dataType is not found for java.time.LocalDateTime.")
                 JdbcKotlinLocalDateTimeType(dataType)
             }
-            else -> next.get(klass)
+            else -> next.get<T>(type)
         }
         @Suppress("UNCHECKED_CAST")
         return dataType as JdbcDataType<T>?
@@ -43,7 +44,7 @@ class JdbcDatetimeTypeProvider(val next: JdbcDataTypeProvider) : JdbcDataTypePro
 }
 
 internal class JdbcKotlinInstantType(private val dataType: JdbcDataType<java.time.Instant>) :
-    AbstractJdbcDataType<Instant>(Instant::class, dataType.jdbcType) {
+    AbstractJdbcDataType<Instant>(typeOf<Instant>(), dataType.jdbcType) {
     override val name: String = dataType.name
 
     override fun doGetValue(rs: ResultSet, index: Int): Instant? {
@@ -62,7 +63,7 @@ internal class JdbcKotlinInstantType(private val dataType: JdbcDataType<java.tim
 }
 
 internal class JdbcKotlinLocalDateType(private val dataType: JdbcDataType<java.time.LocalDate>) :
-    AbstractJdbcDataType<LocalDate>(LocalDate::class, dataType.jdbcType) {
+    AbstractJdbcDataType<LocalDate>(typeOf<LocalDate>(), dataType.jdbcType) {
     override val name: String = dataType.name
 
     override fun doGetValue(rs: ResultSet, index: Int): LocalDate? {
@@ -81,7 +82,7 @@ internal class JdbcKotlinLocalDateType(private val dataType: JdbcDataType<java.t
 }
 
 internal class JdbcKotlinLocalDateTimeType(private val dataType: JdbcDataType<java.time.LocalDateTime>) :
-    AbstractJdbcDataType<LocalDateTime>(LocalDateTime::class, dataType.jdbcType) {
+    AbstractJdbcDataType<LocalDateTime>(typeOf<LocalDateTime>(), dataType.jdbcType) {
     override val name: String = dataType.name
 
     override fun doGetValue(rs: ResultSet, index: Int): LocalDateTime? {

--- a/komapper-datetime-r2dbc/src/main/kotlin/org/komapper/datetime/r2dbc/R2dbcDatetimeTypeProvider.kt
+++ b/komapper-datetime-r2dbc/src/main/kotlin/org/komapper/datetime/r2dbc/R2dbcDatetimeTypeProvider.kt
@@ -15,27 +15,29 @@ import org.komapper.r2dbc.AbstractR2dbcDataType
 import org.komapper.r2dbc.R2dbcDataType
 import org.komapper.r2dbc.R2dbcDataTypeProvider
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class R2dbcDatetimeTypeProvider(val next: R2dbcDataTypeProvider) : R2dbcDataTypeProvider {
 
-    override fun <T : Any> get(klass: KClass<out T>): R2dbcDataType<T>? {
-        val dataType: R2dbcDataType<*>? = when (klass) {
+    override fun <T : Any> get(type: KType): R2dbcDataType<T>? {
+        val dataType: R2dbcDataType<*>? = when (type.classifier as KClass<*>) {
             Instant::class -> {
-                val dataType = next.get(java.time.Instant::class)
+                val dataType = next.get<java.time.Instant>(typeOf<java.time.Instant>())
                     ?: error("The dataType is not found for java.time.Instant.")
                 JdbcKotlinInstantType(dataType)
             }
             LocalDate::class -> {
-                val dataType = next.get(java.time.LocalDate::class)
+                val dataType = next.get<java.time.LocalDate>(typeOf<java.time.LocalDate>())
                     ?: error("The dataType is not found for java.time.LocalDate.")
                 JdbcKotlinLocalDateType(dataType)
             }
             LocalDateTime::class -> {
-                val dataType = next.get(java.time.LocalDateTime::class)
+                val dataType = next.get<java.time.LocalDateTime>(typeOf<java.time.LocalDateTime>())
                     ?: error("The dataType is not found for java.time.LocalDateTime.")
                 JdbcKotlinLocalDateTimeType(dataType)
             }
-            else -> next.get(klass)
+            else -> next.get<T>(type)
         }
         @Suppress("UNCHECKED_CAST")
         return dataType as R2dbcDataType<T>?
@@ -43,7 +45,7 @@ class R2dbcDatetimeTypeProvider(val next: R2dbcDataTypeProvider) : R2dbcDataType
 }
 
 internal class JdbcKotlinInstantType(private val dataType: R2dbcDataType<java.time.Instant>) :
-    AbstractR2dbcDataType<Instant>(Instant::class) {
+    AbstractR2dbcDataType<Instant>(typeOf<Instant>()) {
     override val name: String = dataType.name
 
     override fun getValue(row: Row, index: Int): Instant? {
@@ -66,7 +68,7 @@ internal class JdbcKotlinInstantType(private val dataType: R2dbcDataType<java.ti
 }
 
 internal class JdbcKotlinLocalDateType(private val dataType: R2dbcDataType<java.time.LocalDate>) :
-    AbstractR2dbcDataType<LocalDate>(LocalDate::class) {
+    AbstractR2dbcDataType<LocalDate>(typeOf<LocalDate>()) {
     override val name: String = dataType.name
 
     override fun getValue(row: Row, index: Int): LocalDate? {
@@ -89,7 +91,7 @@ internal class JdbcKotlinLocalDateType(private val dataType: R2dbcDataType<java.
 }
 
 internal class JdbcKotlinLocalDateTimeType(private val dataType: R2dbcDataType<java.time.LocalDateTime>) :
-    AbstractR2dbcDataType<LocalDateTime>(LocalDateTime::class) {
+    AbstractR2dbcDataType<LocalDateTime>(typeOf<LocalDateTime>()) {
     override val name: String = dataType.name
 
     override fun getValue(row: Row, index: Int): LocalDateTime? {

--- a/komapper-dialect-h2-jdbc/src/main/kotlin/org/komapper/dialect/h2/jdbc/H2JdbcUUIDType.kt
+++ b/komapper-dialect-h2-jdbc/src/main/kotlin/org/komapper/dialect/h2/jdbc/H2JdbcUUIDType.kt
@@ -5,8 +5,9 @@ import java.sql.JDBCType
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.util.UUID
+import kotlin.reflect.typeOf
 
-object H2JdbcUUIDType : AbstractJdbcDataType<UUID>(UUID::class, JDBCType.OTHER) {
+object H2JdbcUUIDType : AbstractJdbcDataType<UUID>(typeOf<UUID>(), JDBCType.OTHER) {
     override val name: String = "uuid"
 
     override fun doGetValue(rs: ResultSet, index: Int): UUID? {

--- a/komapper-dialect-h2-r2dbc/src/main/kotlin/org/komapper/dialect/h2/r2dbc/H2R2dbcUUIDType.kt
+++ b/komapper-dialect-h2-r2dbc/src/main/kotlin/org/komapper/dialect/h2/r2dbc/H2R2dbcUUIDType.kt
@@ -2,8 +2,9 @@ package org.komapper.dialect.h2.r2dbc
 
 import org.komapper.r2dbc.AbstractR2dbcDataType
 import java.util.UUID
+import kotlin.reflect.typeOf
 
-object H2R2dbcUUIDType : AbstractR2dbcDataType<UUID>(UUID::class) {
+object H2R2dbcUUIDType : AbstractR2dbcDataType<UUID>(typeOf<UUID>()) {
     override val name: String = "uuid"
 
     override fun convertBeforeGetting(value: Any): UUID {

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbOffsetLimitStatementBuilder.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbOffsetLimitStatementBuilder.kt
@@ -5,6 +5,7 @@ import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
 import org.komapper.core.Value
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
+import kotlin.reflect.typeOf
 
 class MariaDbOffsetLimitStatementBuilder(
     private val dialect: BuilderDialect,
@@ -20,11 +21,11 @@ class MariaDbOffsetLimitStatementBuilder(
         if (offsetRequired || limitRequired) {
             buf.append(" limit ")
             if (offsetRequired) {
-                buf.bind(Value(offset, Int::class))
+                buf.bind(Value(offset, typeOf<Int>()))
                 buf.append(", ")
             }
             if (limitRequired) {
-                buf.bind(Value(limit, Int::class))
+                buf.bind(Value(limit, typeOf<Int>()))
             } else {
                 buf.append(Long.MAX_VALUE.toString())
             }

--- a/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlOffsetLimitStatementBuilder.kt
+++ b/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlOffsetLimitStatementBuilder.kt
@@ -5,6 +5,7 @@ import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
 import org.komapper.core.Value
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
+import kotlin.reflect.typeOf
 
 class MySqlOffsetLimitStatementBuilder(
     private val dialect: BuilderDialect,
@@ -20,11 +21,11 @@ class MySqlOffsetLimitStatementBuilder(
         if (offsetRequired || limitRequired) {
             buf.append(" limit ")
             if (offsetRequired) {
-                buf.bind(Value(offset, Int::class))
+                buf.bind(Value(offset, typeOf<Int>()))
                 buf.append(", ")
             }
             if (limitRequired) {
-                buf.bind(Value(limit, Int::class))
+                buf.bind(Value(limit, typeOf<Int>()))
             } else {
                 buf.append(Long.MAX_VALUE.toString())
             }

--- a/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDataType.kt
+++ b/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcDataType.kt
@@ -6,6 +6,7 @@ import org.komapper.jdbc.JdbcDataType
 import java.sql.JDBCType
 import java.sql.PreparedStatement
 import java.sql.ResultSet
+import kotlin.reflect.typeOf
 
 class OracleJdbcDataType<T : Any>(private val jdbcDataType: JdbcDataType<T>) : JdbcDataType<T> by jdbcDataType {
     override fun registerReturnParameter(ps: PreparedStatement, index: Int) {
@@ -14,7 +15,7 @@ class OracleJdbcDataType<T : Any>(private val jdbcDataType: JdbcDataType<T>) : J
     }
 }
 
-object OracleJdbcBooleanType : AbstractJdbcDataType<Boolean>(Boolean::class, JDBCType.INTEGER) {
+object OracleJdbcBooleanType : AbstractJdbcDataType<Boolean>(typeOf<Boolean>(), JDBCType.INTEGER) {
     override val name: String = "number(1, 0)"
 
     override fun doGetValue(rs: ResultSet, index: Int): Boolean {

--- a/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcExecutor.kt
+++ b/komapper-dialect-oracle-jdbc/src/main/kotlin/org/komapper/dialect/oracle/jdbc/OracleJdbcExecutor.kt
@@ -57,8 +57,8 @@ class OracleJdbcExecutor(
 
     private fun register(ps: PreparedStatement, statement: Statement) {
         val base = statement.args.size
-        statement.returnParamTypes.forEachIndexed { index, klass ->
-            config.dataOperator.registerReturnParameter(ps, base + index + 1, klass)
+        statement.returnParamTypes.forEachIndexed { index, type ->
+            config.dataOperator.registerReturnParameter<Any>(ps, base + index + 1, type)
         }
     }
 }

--- a/komapper-dialect-oracle-r2dbc/src/main/kotlin/org/komapper/dialect/oracle/r2dbc/OracleR2dbcBooleanType.kt
+++ b/komapper-dialect-oracle-r2dbc/src/main/kotlin/org/komapper/dialect/oracle/r2dbc/OracleR2dbcBooleanType.kt
@@ -2,8 +2,9 @@ package org.komapper.dialect.oracle.r2dbc
 
 import io.r2dbc.spi.Statement
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object OracleR2dbcBooleanType : AbstractR2dbcDataType<Boolean>(Boolean::class) {
+object OracleR2dbcBooleanType : AbstractR2dbcDataType<Boolean>(typeOf<Boolean>()) {
     override val name: String = "number(1, 0)"
 
     override fun convertBeforeGetting(value: Any): Boolean {

--- a/komapper-dialect-oracle-r2dbc/src/main/kotlin/org/komapper/dialect/oracle/r2dbc/OracleR2dbcDurationType.kt
+++ b/komapper-dialect-oracle-r2dbc/src/main/kotlin/org/komapper/dialect/oracle/r2dbc/OracleR2dbcDurationType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.oracle.r2dbc
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
 import java.time.Duration
+import kotlin.reflect.typeOf
 
-object OracleR2dbcDurationType : AbstractR2dbcDataType<Duration>(Duration::class) {
+object OracleR2dbcDurationType : AbstractR2dbcDataType<Duration>(typeOf<Duration>()) {
     override val name: String = "interval day to second"
 
     override fun getValue(row: Row, index: Int): Duration? {

--- a/komapper-dialect-oracle-r2dbc/src/main/kotlin/org/komapper/dialect/oracle/r2dbc/OracleR2dbcPeriodType.kt
+++ b/komapper-dialect-oracle-r2dbc/src/main/kotlin/org/komapper/dialect/oracle/r2dbc/OracleR2dbcPeriodType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.oracle.r2dbc
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
 import java.time.Period
+import kotlin.reflect.typeOf
 
-object OracleR2dbcPeriodType : AbstractR2dbcDataType<Period>(Period::class) {
+object OracleR2dbcPeriodType : AbstractR2dbcDataType<Period>(typeOf<Period>()) {
     override val name: String = "interval year to month"
 
     override fun getValue(row: Row, index: Int): Period? {

--- a/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleStatementBuilderSupport.kt
+++ b/komapper-dialect-oracle/src/main/kotlin/org/komapper/dialect/oracle/OracleStatementBuilderSupport.kt
@@ -23,7 +23,7 @@ class OracleStatementBuilderSupport(
                 cutBack(2)
                 append(" into ")
                 for (e in expressions) {
-                    registerReturnParameter(e.interiorClass)
+                    registerReturnParameter(e.interiorType)
                     append(", ")
                 }
                 cutBack(2)

--- a/komapper-dialect-postgresql-jdbc/src/main/kotlin/org/komapper/dialect/postgresql/jdbc/PostgreSqlJdbcUUIDType.kt
+++ b/komapper-dialect-postgresql-jdbc/src/main/kotlin/org/komapper/dialect/postgresql/jdbc/PostgreSqlJdbcUUIDType.kt
@@ -5,8 +5,9 @@ import java.sql.JDBCType
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.util.UUID
+import kotlin.reflect.typeOf
 
-object PostgreSqlJdbcUUIDType : AbstractJdbcDataType<UUID>(UUID::class, JDBCType.OTHER) {
+object PostgreSqlJdbcUUIDType : AbstractJdbcDataType<UUID>(typeOf<UUID>(), JDBCType.OTHER) {
     override val name: String = "uuid"
 
     override fun doGetValue(rs: ResultSet, index: Int): UUID? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcArrayType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcArrayType.kt
@@ -3,9 +3,10 @@ package org.komapper.dialect.postgresql.r2dbc
 import org.komapper.r2dbc.AbstractR2dbcDataType
 import org.komapper.r2dbc.R2dbcDataType
 import kotlin.reflect.KClass
+import kotlin.reflect.typeOf
 
 class PostgreSqlR2dbcArrayType(arrayKlass: KClass<*>, componentDataType: R2dbcDataType<*>) :
-    AbstractR2dbcDataType<Array<*>>(Array::class, arrayKlass.java) {
+    AbstractR2dbcDataType<Array<*>>(typeOf<Array<*>>(), arrayKlass.java) {
     override val name: String = "${componentDataType.name}[]"
 
     override fun convertBeforeGetting(value: Any): Array<*> {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcBoxType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcBoxType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.postgresql.r2dbc
 import io.r2dbc.postgresql.codec.Box
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcBoxType : AbstractR2dbcDataType<Box>(Box::class) {
+object PostgreSqlR2dbcBoxType : AbstractR2dbcDataType<Box>(typeOf<Box>()) {
     override val name: String = "box"
 
     override fun getValue(row: Row, index: Int): Box? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcCircleType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcCircleType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.postgresql.r2dbc
 import io.r2dbc.postgresql.codec.Circle
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcCircleType : AbstractR2dbcDataType<Circle>(Circle::class) {
+object PostgreSqlR2dbcCircleType : AbstractR2dbcDataType<Circle>(typeOf<Circle>()) {
     override val name: String = "circle"
 
     override fun getValue(row: Row, index: Int): Circle? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcDataTypeProvider.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcDataTypeProvider.kt
@@ -71,7 +71,7 @@ class PostgreSqlR2dbcDataTypeProvider(private val next: R2dbcDataTypeProvider) :
     private val dataTypeMap: Map<KType, R2dbcDataType<*>> = DEFAULT_DATA_TYPES.associateBy { it.type }
 
     private val dataTypeMapByKClass: Map<KClass<*>, R2dbcDataType<*>> = DEFAULT_DATA_TYPES.associateBy { it.type.classifier as KClass<*> }
-    
+
     override fun <T : Any> get(type: KType): R2dbcDataType<T>? {
         return if (Array::class.java.isAssignableFrom((type.classifier as KClass<*>).java)) {
             val componentType = (type.classifier as KClass<*>).java.componentType.kotlin

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcDataTypeProvider.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcDataTypeProvider.kt
@@ -25,6 +25,7 @@ import org.komapper.r2dbc.R2dbcUByteType
 import org.komapper.r2dbc.R2dbcUIntType
 import org.komapper.r2dbc.R2dbcUShortType
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 class PostgreSqlR2dbcDataTypeProvider(private val next: R2dbcDataTypeProvider) :
     R2dbcDataTypeProvider {
@@ -67,23 +68,26 @@ class PostgreSqlR2dbcDataTypeProvider(private val next: R2dbcDataTypeProvider) :
         )
     }
 
-    private val dataTypeMap: Map<KClass<*>, R2dbcDataType<*>> = DEFAULT_DATA_TYPES.associateBy { it.klass }
+    private val dataTypeMap: Map<KType, R2dbcDataType<*>> = DEFAULT_DATA_TYPES.associateBy { it.type }
 
-    override fun <T : Any> get(klass: KClass<out T>): R2dbcDataType<T>? {
-        return if (Array::class.java.isAssignableFrom(klass.java)) {
-            val componentType = klass.java.componentType.kotlin
-            val componentDataType = getDataType(componentType)
+    private val dataTypeMapByKClass: Map<KClass<*>, R2dbcDataType<*>> = DEFAULT_DATA_TYPES.associateBy { it.type.classifier as KClass<*> }
+    
+    override fun <T : Any> get(type: KType): R2dbcDataType<T>? {
+        return if (Array::class.java.isAssignableFrom((type.classifier as KClass<*>).java)) {
+            val componentType = (type.classifier as KClass<*>).java.componentType.kotlin
+            // If the componentType can be converted to KType, the getDataType function should be called
+            val componentDataType = dataTypeMapByKClass[componentType]
             checkNotNull(componentDataType) { "The dataType is not found for the component type \"${componentType.qualifiedName}\"." }
             @Suppress("UNCHECKED_CAST")
-            PostgreSqlR2dbcArrayType(klass, componentDataType) as R2dbcDataType<T>?
+            PostgreSqlR2dbcArrayType((type.classifier as KClass<*>), componentDataType) as R2dbcDataType<T>?
         } else {
-            getDataType(klass)
+            getDataType(type)
         }
     }
 
-    private fun <T : Any> getDataType(klass: KClass<out T>): R2dbcDataType<T>? {
+    private fun <T : Any> getDataType(type: KType): R2dbcDataType<T>? {
         @Suppress("UNCHECKED_CAST")
-        val dataType = dataTypeMap[klass] as R2dbcDataType<T>?
-        return dataType ?: next.get(klass)
+        val dataType = dataTypeMap[type] as R2dbcDataType<T>?
+        return dataType ?: next.get(type)
     }
 }

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcGeometryType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcGeometryType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.postgresql.r2dbc
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
 import org.locationtech.jts.geom.Geometry
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcGeometryType : AbstractR2dbcDataType<Geometry>(Geometry::class) {
+object PostgreSqlR2dbcGeometryType : AbstractR2dbcDataType<Geometry>(typeOf<Geometry>()) {
     override val name: String = "geometry"
 
     override fun getValue(row: Row, index: Int): Geometry? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcIntervalType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcIntervalType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.postgresql.r2dbc
 import io.r2dbc.postgresql.codec.Interval
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcIntervalType : AbstractR2dbcDataType<Interval>(Interval::class) {
+object PostgreSqlR2dbcIntervalType : AbstractR2dbcDataType<Interval>(typeOf<Interval>()) {
     override val name: String = "interval"
 
     override fun getValue(row: Row, index: Int): Interval? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcJsonType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcJsonType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.postgresql.r2dbc
 import io.r2dbc.postgresql.codec.Json
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcJsonType : AbstractR2dbcDataType<Json>(Json::class) {
+object PostgreSqlR2dbcJsonType : AbstractR2dbcDataType<Json>(typeOf<Json>()) {
     override val name: String = "json"
 
     override fun getValue(row: Row, index: Int): Json? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcLineType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcLineType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.postgresql.r2dbc
 import io.r2dbc.postgresql.codec.Line
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcLineType : AbstractR2dbcDataType<Line>(Line::class) {
+object PostgreSqlR2dbcLineType : AbstractR2dbcDataType<Line>(typeOf<Line>()) {
     override val name: String = "line"
 
     override fun getValue(row: Row, index: Int): Line? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcLsegType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcLsegType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.postgresql.r2dbc
 import io.r2dbc.postgresql.codec.Lseg
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcLsegType : AbstractR2dbcDataType<Lseg>(Lseg::class) {
+object PostgreSqlR2dbcLsegType : AbstractR2dbcDataType<Lseg>(typeOf<Lseg>()) {
     override val name: String = "lseg"
 
     override fun getValue(row: Row, index: Int): Lseg? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPathType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPathType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.postgresql.r2dbc
 import io.r2dbc.postgresql.codec.Path
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcPathType : AbstractR2dbcDataType<Path>(Path::class) {
+object PostgreSqlR2dbcPathType : AbstractR2dbcDataType<Path>(typeOf<Path>()) {
     override val name: String = "path"
 
     override fun getValue(row: Row, index: Int): Path? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPointType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPointType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.postgresql.r2dbc
 import io.r2dbc.postgresql.codec.Point
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcPointType : AbstractR2dbcDataType<Point>(Point::class) {
+object PostgreSqlR2dbcPointType : AbstractR2dbcDataType<Point>(typeOf<Point>()) {
     override val name: String = "point"
 
     override fun getValue(row: Row, index: Int): Point? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPolygonType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcPolygonType.kt
@@ -3,8 +3,9 @@ package org.komapper.dialect.postgresql.r2dbc
 import io.r2dbc.postgresql.codec.Polygon
 import io.r2dbc.spi.Row
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcPolygonType : AbstractR2dbcDataType<Polygon>(Polygon::class) {
+object PostgreSqlR2dbcPolygonType : AbstractR2dbcDataType<Polygon>(typeOf<Polygon>()) {
     override val name: String = "polygon"
 
     override fun getValue(row: Row, index: Int): Polygon? {

--- a/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcUUIDType.kt
+++ b/komapper-dialect-postgresql-r2dbc/src/main/kotlin/org/komapper/dialect/postgresql/r2dbc/PostgreSqlR2dbcUUIDType.kt
@@ -2,8 +2,9 @@ package org.komapper.dialect.postgresql.r2dbc
 
 import org.komapper.r2dbc.AbstractR2dbcDataType
 import java.util.UUID
+import kotlin.reflect.typeOf
 
-object PostgreSqlR2dbcUUIDType : AbstractR2dbcDataType<UUID>(UUID::class) {
+object PostgreSqlR2dbcUUIDType : AbstractR2dbcDataType<UUID>(typeOf<UUID>()) {
     override val name: String = "uuid"
 
     override fun convertBeforeGetting(value: Any): UUID {

--- a/komapper-dialect-sqlserver-jdbc/src/main/kotlin/org/komapper/dialect/sqlserver/jdbc/SqlServerJdbcBooleanType.kt
+++ b/komapper-dialect-sqlserver-jdbc/src/main/kotlin/org/komapper/dialect/sqlserver/jdbc/SqlServerJdbcBooleanType.kt
@@ -4,8 +4,9 @@ import org.komapper.jdbc.AbstractJdbcDataType
 import java.sql.JDBCType
 import java.sql.PreparedStatement
 import java.sql.ResultSet
+import kotlin.reflect.typeOf
 
-object SqlServerJdbcBooleanType : AbstractJdbcDataType<Boolean>(Boolean::class, JDBCType.BOOLEAN) {
+object SqlServerJdbcBooleanType : AbstractJdbcDataType<Boolean>(typeOf<Boolean>(), JDBCType.BOOLEAN) {
     override val name: String = "bit"
 
     override fun doGetValue(rs: ResultSet, index: Int): Boolean {

--- a/komapper-dialect-sqlserver-r2dbc/src/main/kotlin/org/komapper/dialect/sqlserver/r2dbc/SqlServerR2dbcBooleanType.kt
+++ b/komapper-dialect-sqlserver-r2dbc/src/main/kotlin/org/komapper/dialect/sqlserver/r2dbc/SqlServerR2dbcBooleanType.kt
@@ -1,8 +1,9 @@
 package org.komapper.dialect.sqlserver.r2dbc
 
 import org.komapper.r2dbc.AbstractR2dbcDataType
+import kotlin.reflect.typeOf
 
-object SqlServerR2dbcBooleanType : AbstractR2dbcDataType<Boolean>(Boolean::class) {
+object SqlServerR2dbcBooleanType : AbstractR2dbcDataType<Boolean>(typeOf<Boolean>()) {
     override val name: String = "bit"
 
     override fun convertBeforeGetting(value: Any): Boolean {

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerOffsetLimitStatementBuilder.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerOffsetLimitStatementBuilder.kt
@@ -5,6 +5,7 @@ import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
 import org.komapper.core.Value
 import org.komapper.core.dsl.builder.OffsetLimitStatementBuilder
+import kotlin.reflect.typeOf
 
 class SqlServerOffsetLimitStatementBuilder(
     private val dialect: BuilderDialect,
@@ -19,11 +20,11 @@ class SqlServerOffsetLimitStatementBuilder(
         val fetchRequired = limit > 0
         if (offsetRequired || fetchRequired) {
             buf.append(" offset ")
-            buf.bind(Value(if (offset > 0) offset else 0, Int::class))
+            buf.bind(Value(if (offset > 0) offset else 0, typeOf<Int>()))
             buf.append(" rows")
             if (limit > 0) {
                 buf.append(" fetch first ")
-                buf.bind(Value(limit, Int::class))
+                buf.bind(Value(limit, typeOf<Int>()))
                 buf.append(" rows only")
             }
         }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataOperator.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataOperator.kt
@@ -3,7 +3,7 @@ package org.komapper.jdbc
 import org.komapper.core.DataOperator
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 interface JdbcDataOperator : DataOperator {
     /**
@@ -11,20 +11,20 @@ interface JdbcDataOperator : DataOperator {
      *
      * @param rs the result set
      * @param index the column index
-     * @param valueClass the value class
+     * @param type the value type
      * @return the value
      */
-    fun <T : Any> getValue(rs: ResultSet, index: Int, valueClass: KClass<out T>): T?
+    fun <T : Any> getValue(rs: ResultSet, index: Int, type: KType): T?
 
     /**
      * Returns the value.
      *
      * @param rs the result set
      * @param columnLabel the column label
-     * @param valueClass the value class
+     * @param type the value type
      * @return the value
      */
-    fun <T : Any> getValue(rs: ResultSet, columnLabel: String, valueClass: KClass<out T>): T?
+    fun <T : Any> getValue(rs: ResultSet, columnLabel: String, type: KType): T?
 
     /**
      * Sets the value.
@@ -32,79 +32,79 @@ interface JdbcDataOperator : DataOperator {
      * @param ps the prepared statement
      * @param index the column index
      * @param value the value
-     * @param valueClass the value class
+     * @param type the value type
      */
-    fun <T : Any> setValue(ps: PreparedStatement, index: Int, value: T?, valueClass: KClass<out T>)
+    fun <T : Any> setValue(ps: PreparedStatement, index: Int, value: T?, type: KType)
 
     /**
      * Registers the return parameter.
      *
      * @param ps the prepared statement
      * @param index the column index
-     * @param parameterClass the parameter class
+     * @param type the parameter type
      */
-    fun <T : Any> registerReturnParameter(ps: PreparedStatement, index: Int, parameterClass: KClass<out T>)
+    fun <T : Any> registerReturnParameter(ps: PreparedStatement, index: Int, type: KType)
 
     /**
      * Returns the data type.
      *
-     * @param klass the value class
+     * @param type the value type
      * @return the data type
      */
-    fun <T : Any> getDataType(klass: KClass<out T>): JdbcDataType<T>
+    fun <T : Any> getDataType(type: KType): JdbcDataType<*>
 
     /**
      * Returns the data type or null.
      *
-     * @param klass the value class
+     * @param type the value type
      * @return the data type or null
      */
-    fun <T : Any> getDataTypeOrNull(klass: KClass<out T>): JdbcDataType<T>?
+    fun <T : Any> getDataTypeOrNull(type: KType): JdbcDataType<T>?
 }
 
 class DefaultJdbcDataOperator(private val dialect: JdbcDialect, private val dataTypeProvider: JdbcDataTypeProvider) :
     JdbcDataOperator {
-    override fun <T : Any> getValue(rs: ResultSet, index: Int, valueClass: KClass<out T>): T? {
-        val dataType = getDataType(valueClass)
+    override fun <T : Any> getValue(rs: ResultSet, index: Int, type: KType): T? {
+        val dataType = getDataType<T>(type)
         return dataType.getValue(rs, index)
     }
 
-    override fun <T : Any> getValue(rs: ResultSet, columnLabel: String, valueClass: KClass<out T>): T? {
-        val dataType = getDataType(valueClass)
+    override fun <T : Any> getValue(rs: ResultSet, columnLabel: String, type: KType): T? {
+        val dataType = getDataType<T>(type)
         return dataType.getValue(rs, columnLabel)
     }
 
-    override fun <T : Any> setValue(ps: PreparedStatement, index: Int, value: T?, valueClass: KClass<out T>) {
-        val dataType = getDataType(valueClass)
+    override fun <T : Any> setValue(ps: PreparedStatement, index: Int, value: T?, type: KType) {
+        val dataType = getDataType<T>(type)
         dataType.setValue(ps, index, value)
     }
 
-    override fun <T : Any> registerReturnParameter(ps: PreparedStatement, index: Int, parameterClass: KClass<out T>) {
-        val dataType = getDataType(parameterClass)
+    override fun <T : Any> registerReturnParameter(ps: PreparedStatement, index: Int, type: KType) {
+        val dataType = getDataType<T>(type)
         dataType.registerReturnParameter(ps, index)
     }
 
-    override fun <T : Any> formatValue(value: T?, valueClass: KClass<out T>, masking: Boolean): String {
+    override fun <T : Any> formatValue(value: T?, type: KType, masking: Boolean): String {
         return if (masking) {
             dialect.mask
         } else {
-            val dataType = getDataTypeOrNull(valueClass)
+            val dataType = getDataTypeOrNull<T>(type)
             dataType?.toString(value) ?: value.toString()
         }
     }
 
-    override fun getDataTypeName(klass: KClass<*>): String {
-        val dataType = getDataType(klass)
+    override fun <T : Any> getDataTypeName(type: KType): String {
+        val dataType = getDataType<T>(type)
         return dataType.name
     }
 
-    override fun <T : Any> getDataType(klass: KClass<out T>): JdbcDataType<T> {
-        return getDataTypeOrNull(klass) ?: error(
-            "The dataType is not found for the type \"${klass.qualifiedName}\".",
+    override fun <T : Any> getDataType(type: KType): JdbcDataType<T> {
+        return getDataTypeOrNull(type) ?: error(
+            "The dataType is not found for the type \"${type}\".",
         )
     }
 
-    override fun <T : Any> getDataTypeOrNull(klass: KClass<out T>): JdbcDataType<T>? {
-        return dataTypeProvider.get(klass)
+    override fun <T : Any> getDataTypeOrNull(type: KType): JdbcDataType<T>? {
+        return dataTypeProvider.get(type)
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataType.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataType.kt
@@ -20,7 +20,8 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 /**
  * Represents a data type for JDBC access.
@@ -33,9 +34,10 @@ interface JdbcDataType<T : Any> {
     val name: String
 
     /**
-     * The corresponding class.
+     * The corresponding type.
+     * [KType.isMarkedNullable] must be false.
      */
-    val klass: KClass<T>
+    val type: KType
 
     /**
      * The JDBC type defined in the standard library.
@@ -87,7 +89,7 @@ interface JdbcDataType<T : Any> {
 }
 
 abstract class AbstractJdbcDataType<T : Any>(
-    override val klass: KClass<T>,
+    override val type: KType,
     override val jdbcType: JDBCType,
 ) : JdbcDataType<T> {
 
@@ -125,7 +127,7 @@ abstract class AbstractJdbcDataType<T : Any>(
 }
 
 class JdbcAnyType(override val name: String) :
-    AbstractJdbcDataType<Any>(Any::class, JDBCType.OTHER) {
+    AbstractJdbcDataType<Any>(typeOf<Any>(), JDBCType.OTHER) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Any? {
         return rs.getObject(index)
@@ -140,7 +142,7 @@ class JdbcAnyType(override val name: String) :
     }
 }
 
-class JdbcArrayType(override val name: String) : AbstractJdbcDataType<Array>(Array::class, JDBCType.ARRAY) {
+class JdbcArrayType(override val name: String) : AbstractJdbcDataType<Array>(typeOf<Array>(), JDBCType.ARRAY) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Array? {
         return rs.getArray(index)
@@ -156,7 +158,7 @@ class JdbcArrayType(override val name: String) : AbstractJdbcDataType<Array>(Arr
 }
 
 class JdbcBigDecimalType(override val name: String) :
-    AbstractJdbcDataType<BigDecimal>(BigDecimal::class, JDBCType.DECIMAL) {
+    AbstractJdbcDataType<BigDecimal>(typeOf<BigDecimal>(), JDBCType.DECIMAL) {
 
     override fun doGetValue(rs: ResultSet, index: Int): BigDecimal? {
         return rs.getBigDecimal(index)
@@ -173,7 +175,7 @@ class JdbcBigDecimalType(override val name: String) :
 
 class JdbcBigIntegerType(override val name: String) : JdbcDataType<BigInteger> {
     private val dataType = JdbcBigDecimalType(name)
-    override val klass: KClass<BigInteger> = BigInteger::class
+    override val type: KType = typeOf<BigInteger>()
     override val jdbcType = dataType.jdbcType
 
     override fun getValue(rs: ResultSet, index: Int): BigInteger? {
@@ -194,7 +196,7 @@ class JdbcBigIntegerType(override val name: String) : JdbcDataType<BigInteger> {
 }
 
 class JdbcBlobType(override val name: String) :
-    AbstractJdbcDataType<Blob>(Blob::class, JDBCType.BLOB) {
+    AbstractJdbcDataType<Blob>(typeOf<Blob>(), JDBCType.BLOB) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Blob? {
         return rs.getBlob(index)
@@ -210,7 +212,7 @@ class JdbcBlobType(override val name: String) :
 }
 
 class JdbcBooleanType(override val name: String) :
-    AbstractJdbcDataType<Boolean>(Boolean::class, JDBCType.BOOLEAN) {
+    AbstractJdbcDataType<Boolean>(typeOf<Boolean>(), JDBCType.BOOLEAN) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Boolean {
         return rs.getBoolean(index)
@@ -229,7 +231,7 @@ class JdbcBooleanType(override val name: String) :
     }
 }
 
-class JdbcByteType(override val name: String) : AbstractJdbcDataType<Byte>(Byte::class, JDBCType.SMALLINT) {
+class JdbcByteType(override val name: String) : AbstractJdbcDataType<Byte>(typeOf<Byte>(), JDBCType.SMALLINT) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Byte {
         return rs.getByte(index)
@@ -245,7 +247,7 @@ class JdbcByteType(override val name: String) : AbstractJdbcDataType<Byte>(Byte:
 }
 
 class JdbcByteArrayType(override val name: String) :
-    AbstractJdbcDataType<ByteArray>(ByteArray::class, JDBCType.BINARY) {
+    AbstractJdbcDataType<ByteArray>(typeOf<ByteArray>(), JDBCType.BINARY) {
 
     override fun doGetValue(rs: ResultSet, index: Int): ByteArray? {
         return rs.getBytes(index)
@@ -260,7 +262,7 @@ class JdbcByteArrayType(override val name: String) :
     }
 }
 
-class JdbcClobType(override val name: String) : AbstractJdbcDataType<Clob>(Clob::class, JDBCType.CLOB) {
+class JdbcClobType(override val name: String) : AbstractJdbcDataType<Clob>(typeOf<Clob>(), JDBCType.CLOB) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Clob? {
         return rs.getClob(index)
@@ -275,7 +277,7 @@ class JdbcClobType(override val name: String) : AbstractJdbcDataType<Clob>(Clob:
     }
 }
 
-class JdbcClobStringType(override val name: String) : AbstractJdbcDataType<ClobString>(ClobString::class, JDBCType.CLOB) {
+class JdbcClobStringType(override val name: String) : AbstractJdbcDataType<ClobString>(typeOf<ClobString>(), JDBCType.CLOB) {
 
     override fun doGetValue(rs: ResultSet, index: Int): ClobString? {
         val text = rs.getString(index)
@@ -297,7 +299,7 @@ class JdbcClobStringType(override val name: String) : AbstractJdbcDataType<ClobS
 }
 
 class JdbcDoubleType(override val name: String) :
-    AbstractJdbcDataType<Double>(Double::class, JDBCType.DOUBLE) {
+    AbstractJdbcDataType<Double>(typeOf<Double>(), JDBCType.DOUBLE) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Double {
         return rs.getDouble(index)
@@ -312,7 +314,7 @@ class JdbcDoubleType(override val name: String) :
     }
 }
 
-class JdbcFloatType(override val name: String) : AbstractJdbcDataType<Float>(Float::class, JDBCType.FLOAT) {
+class JdbcFloatType(override val name: String) : AbstractJdbcDataType<Float>(typeOf<Float>(), JDBCType.FLOAT) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Float {
         return rs.getFloat(index)
@@ -328,7 +330,7 @@ class JdbcFloatType(override val name: String) : AbstractJdbcDataType<Float>(Flo
 }
 
 class JdbcInstantType(override val name: String) :
-    AbstractJdbcDataType<Instant>(Instant::class, JDBCType.TIMESTAMP_WITH_TIMEZONE) {
+    AbstractJdbcDataType<Instant>(typeOf<Instant>(), JDBCType.TIMESTAMP_WITH_TIMEZONE) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Instant? {
         return rs.getObject(index, Instant::class.java)
@@ -344,7 +346,7 @@ class JdbcInstantType(override val name: String) :
 }
 
 class JdbcInstantAsTimestampType(override val name: String) :
-    AbstractJdbcDataType<Instant>(Instant::class, JDBCType.TIMESTAMP) {
+    AbstractJdbcDataType<Instant>(typeOf<Instant>(), JDBCType.TIMESTAMP) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Instant? {
         val dateTime: LocalDateTime? = rs.getObject(index, LocalDateTime::class.java)
@@ -367,7 +369,7 @@ class JdbcInstantAsTimestampType(override val name: String) :
 }
 
 class JdbcInstantAsTimestampWithTimezoneType(override val name: String) :
-    AbstractJdbcDataType<Instant>(Instant::class, JDBCType.TIMESTAMP_WITH_TIMEZONE) {
+    AbstractJdbcDataType<Instant>(typeOf<Instant>(), JDBCType.TIMESTAMP_WITH_TIMEZONE) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Instant? {
         val dateTime: OffsetDateTime? = rs.getObject(index, OffsetDateTime::class.java)
@@ -385,7 +387,7 @@ class JdbcInstantAsTimestampWithTimezoneType(override val name: String) :
     }
 }
 
-class JdbcIntType(override val name: String) : AbstractJdbcDataType<Int>(Int::class, JDBCType.INTEGER) {
+class JdbcIntType(override val name: String) : AbstractJdbcDataType<Int>(typeOf<Int>(), JDBCType.INTEGER) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Int {
         return rs.getInt(index)
@@ -401,7 +403,7 @@ class JdbcIntType(override val name: String) : AbstractJdbcDataType<Int>(Int::cl
 }
 
 class JdbcLocalDateTimeType(override val name: String) :
-    AbstractJdbcDataType<LocalDateTime>(LocalDateTime::class, JDBCType.TIMESTAMP) {
+    AbstractJdbcDataType<LocalDateTime>(typeOf<LocalDateTime>(), JDBCType.TIMESTAMP) {
 
     override fun doGetValue(rs: ResultSet, index: Int): LocalDateTime? {
         return rs.getObject(index, LocalDateTime::class.java)
@@ -421,7 +423,7 @@ class JdbcLocalDateTimeType(override val name: String) :
 }
 
 class JdbcLocalDateType(override val name: String) :
-    AbstractJdbcDataType<LocalDate>(LocalDate::class, JDBCType.DATE) {
+    AbstractJdbcDataType<LocalDate>(typeOf<LocalDate>(), JDBCType.DATE) {
 
     override fun doGetValue(rs: ResultSet, index: Int): LocalDate? {
         return rs.getObject(index, LocalDate::class.java)
@@ -441,7 +443,7 @@ class JdbcLocalDateType(override val name: String) :
 }
 
 class JdbcLocalTimeType(override val name: String) :
-    AbstractJdbcDataType<LocalTime>(LocalTime::class, JDBCType.TIME) {
+    AbstractJdbcDataType<LocalTime>(typeOf<LocalTime>(), JDBCType.TIME) {
 
     override fun doGetValue(rs: ResultSet, index: Int): LocalTime? {
         return rs.getObject(index, LocalTime::class.java)
@@ -460,7 +462,7 @@ class JdbcLocalTimeType(override val name: String) :
     }
 }
 
-class JdbcLongType(override val name: String) : AbstractJdbcDataType<Long>(Long::class, JDBCType.BIGINT) {
+class JdbcLongType(override val name: String) : AbstractJdbcDataType<Long>(typeOf<Long>(), JDBCType.BIGINT) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Long {
         return rs.getLong(index)
@@ -475,7 +477,7 @@ class JdbcLongType(override val name: String) : AbstractJdbcDataType<Long>(Long:
     }
 }
 
-class JdbcNClobType(override val name: String) : AbstractJdbcDataType<NClob>(NClob::class, JDBCType.NCLOB) {
+class JdbcNClobType(override val name: String) : AbstractJdbcDataType<NClob>(typeOf<NClob>(), JDBCType.NCLOB) {
 
     override fun doGetValue(rs: ResultSet, index: Int): NClob? {
         return rs.getNClob(index)
@@ -491,7 +493,7 @@ class JdbcNClobType(override val name: String) : AbstractJdbcDataType<NClob>(NCl
 }
 
 class JdbcOffsetDateTimeType(override val name: String) :
-    AbstractJdbcDataType<OffsetDateTime>(OffsetDateTime::class, JDBCType.TIMESTAMP_WITH_TIMEZONE) {
+    AbstractJdbcDataType<OffsetDateTime>(typeOf<OffsetDateTime>(), JDBCType.TIMESTAMP_WITH_TIMEZONE) {
 
     override fun doGetValue(rs: ResultSet, index: Int): OffsetDateTime? {
         return rs.getObject(index, OffsetDateTime::class.java)
@@ -511,7 +513,7 @@ class JdbcOffsetDateTimeType(override val name: String) :
 }
 
 class JdbcShortType(override val name: String) :
-    AbstractJdbcDataType<Short>(Short::class, JDBCType.SMALLINT) {
+    AbstractJdbcDataType<Short>(typeOf<Short>(), JDBCType.SMALLINT) {
 
     override fun doGetValue(rs: ResultSet, index: Int): Short {
         return rs.getShort(index)
@@ -527,7 +529,7 @@ class JdbcShortType(override val name: String) :
 }
 
 class JdbcStringType(override val name: String) :
-    AbstractJdbcDataType<String>(String::class, JDBCType.VARCHAR) {
+    AbstractJdbcDataType<String>(typeOf<String>(), JDBCType.VARCHAR) {
 
     override fun doGetValue(rs: ResultSet, index: Int): String? {
         return rs.getString(index)
@@ -547,7 +549,7 @@ class JdbcStringType(override val name: String) :
 }
 
 class JdbcSQLXMLType(override val name: String) :
-    AbstractJdbcDataType<SQLXML>(SQLXML::class, JDBCType.SQLXML) {
+    AbstractJdbcDataType<SQLXML>(typeOf<SQLXML>(), JDBCType.SQLXML) {
 
     override fun doGetValue(rs: ResultSet, index: Int): SQLXML? {
         return rs.getSQLXML(index)
@@ -562,7 +564,7 @@ class JdbcSQLXMLType(override val name: String) :
     }
 }
 
-class JdbcUByteType(override val name: String) : AbstractJdbcDataType<UByte>(UByte::class, JDBCType.SMALLINT) {
+class JdbcUByteType(override val name: String) : AbstractJdbcDataType<UByte>(typeOf<UByte>(), JDBCType.SMALLINT) {
     override fun doGetValue(rs: ResultSet, index: Int): UByte {
         val value = rs.getShort(index)
         if (value < 0) error("Negative value isn't convertible to UByte. index=$index, value=$value")
@@ -580,7 +582,7 @@ class JdbcUByteType(override val name: String) : AbstractJdbcDataType<UByte>(UBy
     }
 }
 
-class JdbcUIntType(override val name: String) : AbstractJdbcDataType<UInt>(UInt::class, JDBCType.BIGINT) {
+class JdbcUIntType(override val name: String) : AbstractJdbcDataType<UInt>(typeOf<UInt>(), JDBCType.BIGINT) {
     override fun doGetValue(rs: ResultSet, index: Int): UInt {
         val value = rs.getLong(index)
         if (value < 0L) error("Negative value isn't convertible to UInt. index=$index, value=$value")
@@ -598,7 +600,7 @@ class JdbcUIntType(override val name: String) : AbstractJdbcDataType<UInt>(UInt:
     }
 }
 
-class JdbcUShortType(override val name: String) : AbstractJdbcDataType<UShort>(UShort::class, JDBCType.INTEGER) {
+class JdbcUShortType(override val name: String) : AbstractJdbcDataType<UShort>(typeOf<UShort>(), JDBCType.INTEGER) {
     override fun doGetValue(rs: ResultSet, index: Int): UShort {
         val value = rs.getInt(index)
         if (value < 0L) error("Negative value isn't convertible to UShort. index=$index, value=$value")
@@ -623,8 +625,8 @@ class JdbcUserDefinedDataTypeAdapter<T : Any>(
     override val name: String
         get() = dataType.name
 
-    override val klass: KClass<T>
-        get() = dataType.klass
+    override val type: KType
+        get() = dataType.type
 
     override val jdbcType: JDBCType
         get() = dataType.jdbcType
@@ -659,7 +661,7 @@ class JdbcDataTypeProxy<EXTERIOR : Any, INTERIOR : Any>(
 
     override val name: String get() = dataType.name
 
-    override val klass: KClass<EXTERIOR> get() = converter.exteriorClass
+    override val type: KType get() = converter.exteriorType
 
     override val jdbcType: JDBCType get() = dataType.jdbcType
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataTypeProvider.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataTypeProvider.kt
@@ -1,11 +1,11 @@
 package org.komapper.jdbc
 
 import org.komapper.core.ThreadSafe
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 @ThreadSafe
 interface JdbcDataTypeProvider {
-    fun <T : Any> get(klass: KClass<out T>): JdbcDataType<T>?
+    fun <T : Any> get(type: KType): JdbcDataType<T>?
 }
 
 abstract class AbstractJdbcDataTypeProvider(
@@ -13,12 +13,12 @@ abstract class AbstractJdbcDataTypeProvider(
     dataTypes: List<JdbcDataType<*>>,
 ) : JdbcDataTypeProvider {
 
-    private val dataTypeMap: Map<KClass<*>, JdbcDataType<*>> = dataTypes.associateBy { it.klass }
+    private val dataTypeMap: Map<KType, JdbcDataType<*>> = dataTypes.associateBy { it.type }
 
-    override fun <T : Any> get(klass: KClass<out T>): JdbcDataType<T>? {
+    override fun <T : Any> get(type: KType): JdbcDataType<T>? {
         @Suppress("UNCHECKED_CAST")
-        val dataType = dataTypeMap[klass] as JdbcDataType<T>?
-        return dataType ?: next.get(klass)
+        val dataType = dataTypeMap[type] as JdbcDataType<T>?
+        return dataType ?: next.get(type)
     }
 }
 
@@ -32,5 +32,5 @@ fun JdbcDataTypeProvider(vararg dataTypes: JdbcDataType<*>): JdbcDataTypeProvide
 }
 
 internal object EmptyJdbcDataTypeProvider : JdbcDataTypeProvider {
-    override fun <T : Any> get(klass: KClass<out T>): JdbcDataType<T>? = null
+    override fun <T : Any> get(type: KType): JdbcDataType<T>? = null
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcExecutor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcExecutor.kt
@@ -228,7 +228,7 @@ class DefaultJdbcExecutor(
 
     fun bind(ps: PreparedStatement, statement: Statement) {
         statement.args.forEachIndexed { index, value ->
-            config.dataOperator.setValue(ps, index + 1, value.any, value.klass)
+            config.dataOperator.setValue(ps, index + 1, value.any, value.type)
         }
     }
 

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcUserDefinedDataTypes.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcUserDefinedDataTypes.kt
@@ -1,12 +1,15 @@
 package org.komapper.jdbc
 
+import org.komapper.core.mustNotBeMarkedNullable
 import org.komapper.jdbc.spi.JdbcUserDefinedDataType
-import java.util.ServiceLoader
+import java.util.*
 
 object JdbcUserDefinedDataTypes {
 
     fun get(): List<JdbcUserDefinedDataType<*>> {
         val loader = ServiceLoader.load(JdbcUserDefinedDataType::class.java)
-        return loader.toList()
+        return loader.toList().onEach {
+            it.type.mustNotBeMarkedNullable(it::class.qualifiedName, "type")
+        }
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcResultSetWrapper.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcResultSetWrapper.kt
@@ -3,19 +3,18 @@ package org.komapper.jdbc.dsl.runner
 import org.komapper.core.dsl.query.Row
 import org.komapper.jdbc.JdbcDataOperator
 import java.sql.ResultSet
-import kotlin.reflect.KClass
-import kotlin.reflect.cast
+import kotlin.reflect.KType
 
 internal class JdbcResultSetWrapper(
     private val dataOperator: JdbcDataOperator,
     private val rs: ResultSet,
 ) : Row {
 
-    override fun <T : Any> get(index: Int, klass: KClass<T>): T? {
-        return dataOperator.getValue(rs, index + 1, klass)?.let { klass.cast(it) }
+    override fun <T : Any> get(index: Int, type: KType): T? {
+        return dataOperator.getValue(rs, index + 1, type)
     }
 
-    override fun <T : Any> get(columnLabel: String, klass: KClass<T>): T? {
-        return dataOperator.getValue(rs, columnLabel, klass)?.let { klass.cast(it) }
+    override fun <T : Any> get(columnLabel: String, type: KType): T? {
+        return dataOperator.getValue(rs, columnLabel, type)
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcValueExtractor.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcValueExtractor.kt
@@ -14,7 +14,7 @@ internal class JdbcIndexedValueExtractor(private val dataOperator: JdbcDataOpera
 
     override fun <EXTERIOR : Any, INTERIOR : Any> execute(expression: ColumnExpression<EXTERIOR, INTERIOR>): EXTERIOR? {
         return ValueExtractor.getByIndex(expression, index) {
-            dataOperator.getValue(resultSet, ++index, expression.interiorClass)
+            dataOperator.getValue(resultSet, ++index, expression.interiorType)
         }
     }
 }
@@ -23,7 +23,7 @@ internal class JdbcNamedValueExtractor(private val dataOperator: JdbcDataOperato
 
     override fun <EXTERIOR : Any, INTERIOR : Any> execute(expression: ColumnExpression<EXTERIOR, INTERIOR>): EXTERIOR? {
         return ValueExtractor.getByName(expression) {
-            dataOperator.getValue(resultSet, expression.columnName, expression.interiorClass)
+            dataOperator.getValue(resultSet, expression.columnName, expression.interiorType)
         }
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/spi/JdbcUserDefinedDataType.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/spi/JdbcUserDefinedDataType.kt
@@ -4,7 +4,7 @@ import org.komapper.core.ThreadSafe
 import java.sql.JDBCType
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * Represents a user-defined data type for JDBC access.
@@ -17,9 +17,10 @@ interface JdbcUserDefinedDataType<T : Any> {
     val name: String
 
     /**
-     * The user-defined class.
+     * The user-defined type.
+     * [KType.isMarkedNullable] must be false.
      */
-    val klass: KClass<T>
+    val type: KType
 
     /**
      * The JDBC type defined in the standard library.

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityFactory.kt
@@ -334,12 +334,6 @@ internal class EntityFactory(
     }
 
     private fun validatePlainClassProperty(property: LeafProperty, plainClass: PlainClass) {
-        if (!plainClass.isArray && plainClass.declaration.typeParameters.isNotEmpty()) {
-            report(
-                "The property \"${property.path}\" must not be a generic type \"${plainClass.type}\".",
-                property.node,
-            )
-        }
         if (plainClass.alternateType != null) {
             if (plainClass.declaration != plainClass.alternateType.property.type.declaration) {
                 report(

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -177,15 +177,15 @@ internal class EntityMetamodelGenerator(
         fun leafPropertyDescriptor(p: LeafProperty, getter: String, setter: String, nullability: Nullability): String {
             val exteriorTypeName = p.exteriorTypeName
             val interiorTypeName = p.interiorTypeName
-            val exteriorClass = "$exteriorTypeName::class"
-            val interiorClass = "$interiorTypeName::class"
+            val exteriorType = "kotlin.reflect.typeOf<$exteriorTypeName>()"
+            val interiorType = "kotlin.reflect.typeOf<$interiorTypeName>()"
             val columnName = "\"${p.column.name}\""
             val alwaysQuote = "${p.column.alwaysQuote}"
             val masking = "${p.column.masking}"
             val wrap = when (p.kotlinClass) {
                 is EnumClass -> {
                     fun throwException(value: String, propertyName: String, cause: String) =
-                        "throw $EnumMappingException($exteriorClass, $propertyName, $value, $cause)"
+                        "throw $EnumMappingException($exteriorType, $propertyName, $value, $cause)"
                     when (val strategy = p.kotlinClass.strategy) {
                         is EnumStrategy.Name ->
                             "{ try { $exteriorTypeName.valueOf(it) } catch (e: IllegalArgumentException) { ${
@@ -268,7 +268,7 @@ internal class EntityMetamodelGenerator(
             val nullable = if (nullability == Nullability.NULLABLE) "true" else "false"
             val propertyDescriptor =
                 "$PropertyDescriptor<$entityTypeName, $exteriorTypeName, $interiorTypeName>"
-            return "$propertyDescriptor($exteriorClass, $interiorClass, \"$p\", $columnName, $alwaysQuote, $masking, $getter, $setter, $wrap, $unwrap, $nullable)"
+            return "$propertyDescriptor($exteriorType, $interiorType, \"$p\", $columnName, $alwaysQuote, $masking, $getter, $setter, $wrap, $unwrap, $nullable)"
         }
 
         w.println("    private object $EntityDescriptor {")

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorErrorTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorErrorTest.kt
@@ -843,40 +843,6 @@ class EntityProcessorErrorTest : AbstractKspTest(EntityProcessorProvider()) {
     }
 
     @Test
-    fun `The property must not be a generic type`() {
-        val result = compile(
-            """
-            package test
-            import org.komapper.annotation.*
-            @KomapperEntity
-            data class Dept(
-                @KomapperId val id: Int,
-                val names: List<String>,
-            )
-            """,
-        )
-        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("The property \"names\" must not be a generic type \"List<String>\"."))
-    }
-
-    @Test
-    fun `The property must not be a generic type, @KomapperEmbedded`() {
-        val result = compile(
-            """
-            package test
-            import org.komapper.annotation.*
-            @KomapperEntity
-            data class Dept(
-                @KomapperId val id: Int,
-                @KomapperEmbedded val info: Pair<String, List<Int>>,
-            )
-            """,
-        )
-        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("The property \"info.second\" must not be a generic type \"List<Int>\"."))
-    }
-
-    @Test
     fun `The property is not found in the class, @KomapperColumnOverride`() {
         val result = compile(
             """

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorOkTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/EntityProcessorOkTest.kt
@@ -319,4 +319,36 @@ class EntityProcessorOkTest : AbstractKspTest(EntityProcessorProvider()) {
         )
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
     }
+
+    @Test
+    fun `Allow generic property types`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            @KomapperEntity
+            data class Dept(
+                @KomapperId val id: Int,
+                val names: List<String>,
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `Allow generic property types, @KomapperEmbedded`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            @KomapperEntity
+            data class Dept(
+                @KomapperId val id: Int,
+                @KomapperEmbedded val info: Pair<String, List<Int>>,
+            )
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataTypeProvider.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataTypeProvider.kt
@@ -1,11 +1,11 @@
 package org.komapper.r2dbc
 
 import org.komapper.core.ThreadSafe
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 @ThreadSafe
 interface R2dbcDataTypeProvider {
-    fun <T : Any> get(klass: KClass<out T>): R2dbcDataType<T>?
+    fun <T : Any> get(type: KType): R2dbcDataType<T>?
 }
 
 abstract class AbstractR2dbcDataTypeProvider(
@@ -13,12 +13,12 @@ abstract class AbstractR2dbcDataTypeProvider(
     dataTypes: List<R2dbcDataType<*>>,
 ) : R2dbcDataTypeProvider {
 
-    private val dataTypeMap: Map<KClass<*>, R2dbcDataType<*>> = dataTypes.associateBy { it.klass }
+    private val dataTypeMap: Map<KType, R2dbcDataType<*>> = dataTypes.associateBy { it.type }
 
-    override fun <T : Any> get(klass: KClass<out T>): R2dbcDataType<T>? {
+    override fun <T : Any> get(type: KType): R2dbcDataType<T>? {
         @Suppress("UNCHECKED_CAST")
-        val dataType = dataTypeMap[klass] as R2dbcDataType<T>?
-        return dataType ?: next.get(klass)
+        val dataType = dataTypeMap[type] as R2dbcDataType<T>?
+        return dataType ?: next.get(type)
     }
 }
 
@@ -32,5 +32,5 @@ fun R2dbcDataTypeProvider(vararg dataTypes: R2dbcDataType<*>): R2dbcDataTypeProv
 }
 
 internal object R2dbcEmptyDataTypeProvider : R2dbcDataTypeProvider {
-    override fun <T : Any> get(klass: KClass<out T>): R2dbcDataType<T>? = null
+    override fun <T : Any> get(type: KType): R2dbcDataType<T>? = null
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataTypeProviders.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDataTypeProviders.kt
@@ -5,7 +5,7 @@ import org.komapper.core.spi.DataTypeConverter
 import org.komapper.r2dbc.spi.R2dbcDataTypeProviderFactory
 import org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
 import java.util.ServiceLoader
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 object R2dbcDataTypeProviders {
 
@@ -19,33 +19,33 @@ object R2dbcDataTypeProviders {
         val lastProvider: R2dbcDataTypeProvider = R2dbcEmptyDataTypeProvider
         val chainedProviders = factories.fold(lastProvider) { acc, factory -> factory.create(acc) }
         val secondProvider = R2dbcUserDefinedDataTypeProvider
-        val converters = DataTypeConverters.get().associateBy { it.exteriorClass }
+        val converters = DataTypeConverters.get().associateBy { it.exteriorType }
         return object : R2dbcDataTypeProvider {
 
-            override fun <T : Any> get(klass: KClass<out T>): R2dbcDataType<T>? {
+            override fun <T : Any> get(type: KType): R2dbcDataType<T>? {
                 @Suppress("UNCHECKED_CAST")
-                val converter = converters[klass] as DataTypeConverter<T, Any>?
+                val converter = converters[type] as DataTypeConverter<T, Any>?
                 return if (converter == null) {
-                    find(klass)
+                    find(type)
                 } else {
-                    val dataType = find(converter.interiorClass)
-                        ?: error("The dataType is not found for the type \"${converter.interiorClass.qualifiedName}\".")
+                    val dataType = find<Any>(converter.interiorType)
+                        ?: error("The dataType is not found for the type \"${converter.interiorType}\".")
                     R2dbcDataTypeProxy(converter, dataType)
                 }
             }
 
-            private fun <T : Any> find(klass: KClass<out T>): R2dbcDataType<T>? {
-                return firstProvider?.get(klass) ?: secondProvider.get(klass) ?: chainedProviders.get(klass)
+            private fun <T : Any> find(type: KType): R2dbcDataType<T>? {
+                return firstProvider?.get(type) ?: secondProvider.get(type) ?: chainedProviders.get(type)
             }
         }
     }
 }
 
 private object R2dbcUserDefinedDataTypeProvider : R2dbcDataTypeProvider {
-    val dataTypes = R2dbcUserDefinedDataTypes.get().associateBy { it.klass }
-    override fun <T : Any> get(klass: KClass<out T>): R2dbcDataType<T>? {
+    val dataTypes = R2dbcUserDefinedDataTypes.get().associateBy { it.type }
+    override fun <T : Any> get(type: KType): R2dbcDataType<T>? {
         @Suppress("UNCHECKED_CAST")
-        val dataType = dataTypes[klass] as R2dbcUserDefinedDataType<T>?
+        val dataType = dataTypes[type] as R2dbcUserDefinedDataType<T>?
         return if (dataType == null) null else R2dbcUserDefinedDataTypeAdapter(dataType)
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcExecutor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcExecutor.kt
@@ -193,7 +193,7 @@ internal class R2dbcExecutor(
 
     private fun bind(r2dbcStmt: io.r2dbc.spi.Statement, statement: Statement) {
         statement.args.forEachIndexed { index, value ->
-            config.dataOperator.setValue(r2dbcStmt, index, value.any, value.klass)
+            config.dataOperator.setValue(r2dbcStmt, index, value.any, value.type)
         }
     }
 

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcUserDefinedDataTypes.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcUserDefinedDataTypes.kt
@@ -1,5 +1,6 @@
 package org.komapper.r2dbc
 
+import org.komapper.core.mustNotBeMarkedNullable
 import org.komapper.r2dbc.spi.R2dbcUserDefinedDataType
 import java.util.ServiceLoader
 
@@ -7,6 +8,8 @@ object R2dbcUserDefinedDataTypes {
 
     fun get(): List<R2dbcUserDefinedDataType<*>> {
         val loader = ServiceLoader.load(R2dbcUserDefinedDataType::class.java)
-        return loader.toList()
+        return loader.toList().onEach {
+            it.type.mustNotBeMarkedNullable(it::class.qualifiedName, "type")
+        }
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRowWrapper.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcRowWrapper.kt
@@ -2,19 +2,18 @@ package org.komapper.r2dbc.dsl.runner
 
 import org.komapper.core.dsl.query.Row
 import org.komapper.r2dbc.R2dbcDataOperator
-import kotlin.reflect.KClass
-import kotlin.reflect.cast
+import kotlin.reflect.KType
 
 internal class R2dbcRowWrapper(
     private val dataOperator: R2dbcDataOperator,
     private val row: io.r2dbc.spi.Row,
 ) : Row {
 
-    override fun <T : Any> get(index: Int, klass: KClass<T>): T? {
-        return dataOperator.getValue(row, index, klass)?.let { klass.cast(it) }
+    override fun <T : Any> get(index: Int, type: KType): T? {
+        return dataOperator.getValue(row, index, type)
     }
 
-    override fun <T : Any> get(columnLabel: String, klass: KClass<T>): T? {
-        return dataOperator.getValue(row, columnLabel, klass)?.let { klass.cast(it) }
+    override fun <T : Any> get(columnLabel: String, type: KType): T? {
+        return dataOperator.getValue(row, columnLabel, type)
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcValueExtractor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcValueExtractor.kt
@@ -14,7 +14,7 @@ internal class R2dbcIndexedValueExtractor(private val dataOperator: R2dbcDataOpe
 
     override fun <EXTERIOR : Any, INTERIOR : Any> execute(expression: ColumnExpression<EXTERIOR, INTERIOR>): EXTERIOR? {
         return ValueExtractor.getByIndex(expression, index) {
-            dataOperator.getValue(row, index++, expression.interiorClass)
+            dataOperator.getValue(row, index++, expression.interiorType)
         }
     }
 }
@@ -23,7 +23,7 @@ internal class R2dbcNamedValueExtractor(private val dataOperator: R2dbcDataOpera
 
     override fun <EXTERIOR : Any, INTERIOR : Any> execute(expression: ColumnExpression<EXTERIOR, INTERIOR>): EXTERIOR? {
         return ValueExtractor.getByName(expression) {
-            dataOperator.getValue(row, expression.columnName, expression.interiorClass)
+            dataOperator.getValue(row, expression.columnName, expression.interiorType)
         }
     }
 }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/spi/R2dbcUserDefinedDataType.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/spi/R2dbcUserDefinedDataType.kt
@@ -3,7 +3,7 @@ package org.komapper.r2dbc.spi
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
 import org.komapper.core.ThreadSafe
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * Represents a user-defined data type for R2DBC access.
@@ -16,9 +16,10 @@ interface R2dbcUserDefinedDataType<T : Any> {
     val name: String
 
     /**
-     * The user-defined class.
+     * The user-defined type.
+     * [KType.isMarkedNullable] must be false.
      */
-    val klass: KClass<T>
+    val type: KType
 
     /**
      * The R2DBC codec type.

--- a/komapper-spring-boot-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfigurationTest.kt
+++ b/komapper-spring-boot-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfigurationTest.kt
@@ -20,7 +20,8 @@ import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -61,7 +62,7 @@ class KomapperJdbcAutoConfigurationTest {
 
         val database = context.getBean(JdbcDatabase::class.java)
         assertNotNull(database)
-        val dataType = database.config.dataOperator.getDataType(String::class)
+        val dataType = database.config.dataOperator.getDataType<String>(typeOf<String>())
         assertEquals("abc", dataType.name)
         val clock = database.config.clockProvider.now()
         val timestamp = LocalDateTime.now(clock)
@@ -95,11 +96,11 @@ class KomapperJdbcAutoConfigurationTest {
         @Bean
         open fun dataTypeProvider(): JdbcDataTypeProvider {
             return object : JdbcDataTypeProvider {
-                private val map: Map<KClass<*>, JdbcDataType<*>> =
-                    listOf(JdbcStringType("abc")).associateBy { it.klass }
+                private val map: Map<KType, JdbcDataType<*>> =
+                    listOf(JdbcStringType("abc")).associateBy { it.type }
 
-                override fun <T : Any> get(klass: KClass<out T>): JdbcDataType<T>? {
-                    return map[klass] as JdbcDataType<T>?
+                override fun <T : Any> get(type: KType): JdbcDataType<T>? {
+                    return map[type] as JdbcDataType<T>?
                 }
             }
         }

--- a/komapper-template/src/main/kotlin/org/komapper/template/expression/ExprNode.kt
+++ b/komapper-template/src/main/kotlin/org/komapper/template/expression/ExprNode.kt
@@ -1,6 +1,6 @@
 package org.komapper.template.expression
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 import org.komapper.template.expression.ExprLocation as Loc
 
 internal sealed class ExprNode {
@@ -18,7 +18,7 @@ internal sealed class ExprNode {
     data class Comma(override val location: Loc, val nodeList: List<ExprNode>) : ExprNode()
     data class ClassRef(override val location: Loc, val name: String) : ExprNode()
     data class Value(override val location: Loc, val name: String) : ExprNode()
-    data class Literal(override val location: Loc, val value: Any?, val klass: KClass<out Any>) : ExprNode()
+    data class Literal(override val location: Loc, val value: Any?, val type: KType) : ExprNode()
     data class Empty(override val location: Loc) : ExprNode()
 
     data class Property(

--- a/komapper-template/src/main/kotlin/org/komapper/template/expression/ExprParser.kt
+++ b/komapper-template/src/main/kotlin/org/komapper/template/expression/ExprParser.kt
@@ -35,6 +35,7 @@ import org.komapper.template.expression.ExprTokenType.WHITESPACE
 import java.math.BigDecimal
 import java.util.Deque
 import java.util.LinkedList
+import kotlin.reflect.typeOf
 
 internal class ExprParser(
     private val expression: String,
@@ -119,13 +120,13 @@ internal class ExprParser(
 
     private fun parseStringLiteral() {
         val value = token.substring(1, token.length - 1)
-        val node = ExprNode.Literal(location, value, String::class)
+        val node = ExprNode.Literal(location, value, typeOf<String>())
         nodes.push(node)
     }
 
     private fun parseCharLiteral() {
         val value = token[1]
-        val node = ExprNode.Literal(location, value, Char::class)
+        val node = ExprNode.Literal(location, value, typeOf<Char>())
         nodes.push(node)
     }
 
@@ -133,7 +134,7 @@ internal class ExprParser(
         val start = if (token[0] == '+') 1 else 0
         val end = token.length
         val value = Integer.valueOf(token.substring(start, end))
-        val node = ExprNode.Literal(location, value, Int::class)
+        val node = ExprNode.Literal(location, value, typeOf<Int>())
         nodes.push(node)
     }
 
@@ -141,7 +142,7 @@ internal class ExprParser(
         val start = if (token[0] == '+') 1 else 0
         val end = token.length - 1
         val value = java.lang.Long.valueOf(token.substring(start, end))
-        val node = ExprNode.Literal(location, value, Long::class)
+        val node = ExprNode.Literal(location, value, typeOf<Long>())
         nodes.push(node)
     }
 
@@ -149,7 +150,7 @@ internal class ExprParser(
         val start = if (token[0] == '+') 1 else 0
         val end = token.length - 1
         val value = java.lang.Float.valueOf(token.substring(start, end))
-        val node = ExprNode.Literal(location, value, Float::class)
+        val node = ExprNode.Literal(location, value, typeOf<Float>())
         nodes.push(node)
     }
 
@@ -157,7 +158,7 @@ internal class ExprParser(
         val start = if (token[0] == '+') 1 else 0
         val end = token.length - 1
         val value = java.lang.Double.valueOf(token.substring(start, end))
-        val node = ExprNode.Literal(location, value, Double::class)
+        val node = ExprNode.Literal(location, value, typeOf<Double>())
         nodes.push(node)
     }
 
@@ -165,22 +166,22 @@ internal class ExprParser(
         val start = 0
         val end = token.length - 1
         val value = BigDecimal(token.substring(start, end))
-        val node = ExprNode.Literal(location, value, BigDecimal::class)
+        val node = ExprNode.Literal(location, value, typeOf<BigDecimal>())
         nodes.push(node)
     }
 
     private fun parseTrueLiteral() {
-        val node = ExprNode.Literal(location, true, Boolean::class)
+        val node = ExprNode.Literal(location, true, typeOf<Boolean>())
         nodes.push(node)
     }
 
     private fun parseFalseLiteral() {
-        val node = ExprNode.Literal(location, false, Boolean::class)
+        val node = ExprNode.Literal(location, false, typeOf<Boolean>())
         nodes.push(node)
     }
 
     private fun parseNullLiteral() {
-        val node = ExprNode.Literal(location, null, Any::class)
+        val node = ExprNode.Literal(location, null, typeOf<Any>())
         nodes.push(node)
     }
 

--- a/komapper-template/src/test/kotlin/org/komapper/template/expression/ExprEvaluatorTest.kt
+++ b/komapper-template/src/test/kotlin/org/komapper/template/expression/ExprEvaluatorTest.kt
@@ -3,6 +3,7 @@ package org.komapper.template.expression
 import org.junit.jupiter.api.Nested
 import org.komapper.core.TemplateBuiltinExtensions
 import org.komapper.core.Value
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -14,7 +15,7 @@ class ExprEvaluatorTest {
 
     private val evaluator = DefaultExprEvaluator(
         NoCacheExprNodeFactory(),
-        DefaultExprEnvironment(mapOf("global" to Value("hello"))),
+        DefaultExprEnvironment(mapOf("global" to Value("hello", typeOf<String>()))),
     )
 
     data class Person(val id: Int, val name: String, val age: Int?)
@@ -59,30 +60,30 @@ class ExprEvaluatorTest {
     inner class LiteralTest {
         @Test
         fun nullLiteral() {
-            val ctx = ExprContext(mapOf("a" to Value(null, Any::class)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(null, typeOf<Any>())), extensions)
             val result = evaluator.eval("a", ctx)
-            assertEquals(Value(null, Any::class), result)
+            assertEquals(Value(null, typeOf<Any>()), result)
         }
 
         @Test
         fun trueLiteral() {
-            val ctx = ExprContext(mapOf("a" to Value(true)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(true, typeOf<Boolean>())), extensions)
             val result = evaluator.eval("a", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun falseLiteral() {
-            val ctx = ExprContext(mapOf("a" to Value(false)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(false, typeOf<Boolean>())), extensions)
             val result = evaluator.eval("a", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun stringLiteral() {
-            val ctx = ExprContext(mapOf("a" to Value("abc")), extensions)
+            val ctx = ExprContext(mapOf("a" to Value("abc", typeOf<String>())), extensions)
             val result = evaluator.eval("a", ctx)
-            assertEquals(Value("abc"), result)
+            assertEquals(Value("abc", typeOf<String>()), result)
         }
     }
 
@@ -91,119 +92,119 @@ class ExprEvaluatorTest {
 
         @Test
         fun eq1() {
-            val ctx = ExprContext(mapOf("a" to Value(1)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(1, typeOf<Int>())), extensions)
             val result = evaluator.eval("a == 1", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun eq2() {
-            val ctx = ExprContext(mapOf("a" to Value(2)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(2, typeOf<Int>())), extensions)
             val result = evaluator.eval("a == 1", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun ne1() {
-            val ctx = ExprContext(mapOf("a" to Value(0)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(0, typeOf<Int>())), extensions)
             val result = evaluator.eval("a != 1", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun ne2() {
-            val ctx = ExprContext(mapOf("a" to Value(1)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(1, typeOf<Int>())), extensions)
             val result = evaluator.eval("a != 1", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun ge1() {
-            val ctx = ExprContext(mapOf("a" to Value(2)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(2, typeOf<Int>())), extensions)
             val result = evaluator.eval("a >= 1", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun ge2() {
-            val ctx = ExprContext(mapOf("a" to Value(2)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(2, typeOf<Int>())), extensions)
             val result = evaluator.eval("a >= 1", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun ge3() {
-            val ctx = ExprContext(mapOf("a" to Value(0)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(0, typeOf<Int>())), extensions)
             val result = evaluator.eval("a >= 1", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun gt1() {
-            val ctx = ExprContext(mapOf("a" to Value(2)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(2, typeOf<Int>())), extensions)
             val result = evaluator.eval("a > 1", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun gt2() {
-            val ctx = ExprContext(mapOf("a" to Value(1)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(1, typeOf<Int>())), extensions)
             val result = evaluator.eval("a > 1", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun gt3() {
-            val ctx = ExprContext(mapOf("a" to Value(0)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(0, typeOf<Int>())), extensions)
             val result = evaluator.eval("a > 1", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun le1() {
-            val ctx = ExprContext(mapOf("a" to Value(2)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(2, typeOf<Int>())), extensions)
             val result = evaluator.eval("a <= 1", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun le2() {
-            val ctx = ExprContext(mapOf("a" to Value(1)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(1, typeOf<Int>())), extensions)
             val result = evaluator.eval("a <= 1", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun le3() {
-            val ctx = ExprContext(mapOf("a" to Value(0)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(0, typeOf<Int>())), extensions)
             val result = evaluator.eval("a <= 1", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun lt1() {
-            val ctx = ExprContext(mapOf("a" to Value(2)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(2, typeOf<Int>())), extensions)
             val result = evaluator.eval("a < 1", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun lt2() {
-            val ctx = ExprContext(mapOf("a" to Value(1)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(1, typeOf<Int>())), extensions)
             val result = evaluator.eval("a < 1", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun lt3() {
-            val ctx = ExprContext(mapOf("a" to Value(0)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(0, typeOf<Int>())), extensions)
             val result = evaluator.eval("a < 1", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun `Cannot compare because the left operand is null`() {
-            val ctx = ExprContext(mapOf("a" to Value(null, Any::class)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(null, typeOf<Any>())), extensions)
             val exception = assertFailsWith<ExprException> {
                 evaluator
                     .eval("a > 1", ctx)
@@ -214,7 +215,7 @@ class ExprEvaluatorTest {
         @Test
         fun `Cannot compare because the right operand is null`() {
             val ctx = ExprContext(
-                mapOf("a" to Value(null, Any::class)),
+                mapOf("a" to Value(null, typeOf<Any>())),
                 extensions,
             )
             val exception = assertFailsWith<ExprException> {
@@ -226,7 +227,7 @@ class ExprEvaluatorTest {
 
         @Test
         fun `Cannot compare because the operands are not comparable to each other`() {
-            val ctx = ExprContext(mapOf("a" to Value("string")), extensions)
+            val ctx = ExprContext(mapOf("a" to Value("string", typeOf<String>())), extensions)
             val exception = assertFailsWith<ExprException> {
                 evaluator
                     .eval("a > 1", ctx)
@@ -239,49 +240,49 @@ class ExprEvaluatorTest {
     inner class LogicalOperatorTest {
         @Test
         fun not_true() {
-            val ctx = ExprContext(mapOf("a" to Value(false)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(false, typeOf<Boolean>())), extensions)
             val result = evaluator.eval("!a", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun not_false() {
-            val ctx = ExprContext(mapOf("a" to Value(true)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(true, typeOf<Boolean>())), extensions)
             val result = evaluator.eval("!a", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun and_true() {
-            val ctx = ExprContext(mapOf("a" to Value(true)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(true, typeOf<Boolean>())), extensions)
             val result = evaluator.eval("a && true", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun and_false() {
-            val ctx = ExprContext(mapOf("a" to Value(false)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(false, typeOf<Boolean>())), extensions)
             val result = evaluator.eval("a && true", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun or_true() {
-            val ctx = ExprContext(mapOf("a" to Value(true)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(true, typeOf<Boolean>())), extensions)
             val result = evaluator.eval("a || false", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun or_false() {
-            val ctx = ExprContext(mapOf("a" to Value(false)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(false, typeOf<Boolean>())), extensions)
             val result = evaluator.eval("a || false", ctx)
-            assertEquals(Value(false), result)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
         }
 
         @Test
         fun `Cannot perform the logical operator because the left operand is null`() {
-            val ctx = ExprContext(mapOf("a" to Value(null, Any::class)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(null, typeOf<Any>())), extensions)
             val exception = assertFailsWith<ExprException> {
                 evaluator
                     .eval("a && true", ctx)
@@ -291,7 +292,7 @@ class ExprEvaluatorTest {
 
         @Test
         fun `Cannot perform the logical operator because the right operand is null`() {
-            val ctx = ExprContext(mapOf("a" to Value(null, Any::class)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(null, typeOf<Any>())), extensions)
             val exception = assertFailsWith<ExprException> {
                 evaluator
                     .eval("true && a", ctx)
@@ -301,7 +302,7 @@ class ExprEvaluatorTest {
 
         @Test
         fun `Cannot perform the logical operator because either operand is not boolean`() {
-            val ctx = ExprContext(mapOf("a" to Value("string")), extensions)
+            val ctx = ExprContext(mapOf("a" to Value("string", typeOf<String>())), extensions)
             val exception = assertFailsWith<ExprException> {
                 evaluator
                     .eval("true && a", ctx)
@@ -311,7 +312,7 @@ class ExprEvaluatorTest {
 
         @Test
         fun `Cannot perform the logical operator because the operand is null`() {
-            val ctx = ExprContext(mapOf("a" to Value(null, Any::class)), extensions)
+            val ctx = ExprContext(mapOf("a" to Value(null, typeOf<Any>())), extensions)
             val exception = assertFailsWith<ExprException> {
                 evaluator
                     .eval("!a", ctx)
@@ -321,7 +322,7 @@ class ExprEvaluatorTest {
 
         @Test
         fun `Cannot perform the logical operator because the operand is not Boolean`() {
-            val ctx = ExprContext(mapOf("a" to Value("string")), extensions)
+            val ctx = ExprContext(mapOf("a" to Value("string", typeOf<String>())), extensions)
             val exception = assertFailsWith<ExprException> {
                 evaluator
                     .eval("!a", ctx)
@@ -336,63 +337,63 @@ class ExprEvaluatorTest {
         fun companionObject() {
             val ctx = ExprContext(emptyMap(), extensions)
             val result = evaluator.eval("@${Hello::class.java.name}@", ctx)
-            assertEquals(Value(Hello), result)
+            assertEquals(Value(Hello, typeOf<Hello.Companion>()), result)
         }
 
         @Test
         fun companionObject_property() {
             val ctx = ExprContext(emptyMap(), extensions)
             val result = evaluator.eval("@${Hello::class.java.name}@.name", ctx)
-            assertEquals(Value(Hello.name), result)
+            assertEquals(Value(Hello.name, typeOf<String>()), result)
         }
 
         @Test
         fun companionObject_constProperty() {
             val ctx = ExprContext(emptyMap(), extensions)
             val result = evaluator.eval("@${Hello::class.java.name}@.constName", ctx)
-            assertEquals(Value(Hello.constName), result)
+            assertEquals(Value(Hello.constName, typeOf<String>()), result)
         }
 
         @Test
         fun companionObject_function() {
             val ctx = ExprContext(emptyMap(), extensions)
             val result = evaluator.eval("@${Hello::class.java.name}@.greet(\"abc\")", ctx)
-            assertEquals(Value("hello abc!"), result)
+            assertEquals(Value("hello abc!", typeOf<String>()), result)
         }
 
         @Test
         fun `object`() {
             val ctx = ExprContext(emptyMap(), extensions)
             val result = evaluator.eval("@${Hi::class.java.name}@", ctx)
-            assertEquals(Value(Hi), result)
+            assertEquals(Value(Hi, typeOf<Hi>()), result)
         }
 
         @Test
         fun object_property() {
             val ctx = ExprContext(emptyMap(), extensions)
             val result = evaluator.eval("@${Hi::class.java.name}@.name", ctx)
-            assertEquals(Value(Hi.name), result)
+            assertEquals(Value(Hi.name, typeOf<String>()), result)
         }
 
         @Test
         fun object_constProperty() {
             val ctx = ExprContext(emptyMap(), extensions)
             val result = evaluator.eval("@${Hi::class.java.name}@.constName", ctx)
-            assertEquals(Value(Hi.constName), result)
+            assertEquals(Value(Hi.constName, typeOf<String>()), result)
         }
 
         @Test
         fun object_function() {
             val ctx = ExprContext(emptyMap(), extensions)
             val result = evaluator.eval("@${Hi::class.java.name}@.greet(\"abc\")", ctx)
-            assertEquals(Value("hi abc!"), result)
+            assertEquals(Value("hi abc!", typeOf<String>()), result)
         }
 
         @Test
         fun enum_element() {
             val ctx = ExprContext(emptyMap(), extensions)
             val result = evaluator.eval("@${Direction::class.java.name}@.WEST", ctx)
-            assertEquals(Value(Direction.WEST), result)
+            assertEquals(Value(Direction.WEST, typeOf<Direction>()), result)
         }
 
         @Suppress("UNCHECKED_CAST")
@@ -410,7 +411,7 @@ class ExprEvaluatorTest {
         fun global() {
             val ctx = ExprContext(emptyMap(), extensions)
             val result = evaluator.eval("global", ctx)
-            assertEquals(Value("hello"), result)
+            assertEquals(Value("hello", typeOf<String>()), result)
         }
 
         @Test
@@ -431,50 +432,54 @@ class ExprEvaluatorTest {
                 mapOf(
                     "p" to Value(
                         Person(1, "aaa", 20),
+                        typeOf<Person>(),
                     ),
                 ),
                 extensions,
             )
             val result = evaluator.eval("p.name", ctx)
-            assertEquals(Value("aaa"), result)
+            assertEquals(Value("aaa", typeOf<String>()), result)
         }
 
         @Test
         fun property_nullable() {
             val ctx = ExprContext(
                 mapOf(
-                    "p" to Value(Person(1, "aaa", null)),
+                    "p" to Value(
+                        Person(1, "aaa", null),
+                        typeOf<Person>(),
+                    ),
                 ),
                 extensions,
             )
             val result = evaluator.eval("p.age", ctx)
-            assertEquals(Value(null, Int::class), result)
+            assertEquals(Value(null, typeOf<Int>()), result)
         }
 
         @Test
         fun safeCall() {
             val ctx = ExprContext(
-                mapOf("a" to Value(null, String::class)),
+                mapOf("a" to Value(null, typeOf<String>())),
                 extensions,
             )
             val result = evaluator.eval("a?.length", ctx)
-            assertEquals(Value(null, Int::class), result)
+            assertEquals(Value(null, typeOf<Int>()), result)
         }
 
         @Test
         fun extensionProperty() {
             val ctx = ExprContext(
-                mapOf("a" to Value("abc")),
+                mapOf("a" to Value("abc", typeOf<String>())),
                 extensions,
             )
             val result = evaluator.eval("a.lastIndex", ctx)
-            assertEquals(Value(2), result)
+            assertEquals(Value(2, typeOf<Int>()), result)
         }
 
         @Test
         fun `Failed to call the property`() {
             val ctx = ExprContext(
-                mapOf("a" to Value(null, String::class)),
+                mapOf("a" to Value(null, typeOf<String>())),
                 extensions,
             )
             val exception = assertFailsWith<ExprException> {
@@ -486,7 +491,7 @@ class ExprEvaluatorTest {
         @Test
         fun `The property is not found`() {
             val ctx = ExprContext(
-                mapOf("a" to Value("string")),
+                mapOf("a" to Value("string", typeOf<String>())),
                 extensions,
             )
             val exception = assertFailsWith<ExprException> {
@@ -501,71 +506,71 @@ class ExprEvaluatorTest {
         @Test
         fun function_1parameter() {
             val ctx = ExprContext(
-                mapOf("h" to Value(Hello()), "w" to Value("world")),
+                mapOf("h" to Value(Hello(), typeOf<Hello>()), "w" to Value("world", typeOf<String>())),
                 extensions,
             )
             val result = evaluator.eval("h.say(w)", ctx)
-            assertEquals(Value("hello world"), result)
+            assertEquals(Value("hello world", typeOf<String>()), result)
         }
 
         @Test
         fun function_2parameter() {
             val ctx = ExprContext(
                 mapOf(
-                    "h" to Value(Hello(), Hello::class),
-                    "w" to Value("world", String::class),
-                    "m" to Value("good luck", String::class),
+                    "h" to Value(Hello(), typeOf<Hello>()),
+                    "w" to Value("world", typeOf<String>()),
+                    "m" to Value("good luck", typeOf<String>()),
                 ),
                 extensions,
             )
             val result = evaluator.eval("h.say(w, m)", ctx)
-            assertEquals(Value("hello world, good luck"), result)
+            assertEquals(Value("hello world, good luck", typeOf<String>()), result)
         }
 
         @Test
         fun safeCall() {
             val ctx = ExprContext(
-                mapOf("a" to Value(null, String::class)),
+                mapOf("a" to Value(null, typeOf<String>())),
                 extensions,
             )
             val result = evaluator.eval("a?.subSequence(0, 1)", ctx)
-            assertEquals(Value(null, CharSequence::class), result)
+            assertEquals(Value(null, typeOf<CharSequence>()), result)
         }
 
         @Test
         fun extensionFunction() {
             val ctx = ExprContext(
-                mapOf("s" to Value("")),
+                mapOf("s" to Value("", typeOf<String>())),
                 extensions,
             )
             val result = evaluator.eval("s.isBlank()", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun memberExtensionFunction() {
             val ctx = ExprContext(
-                mapOf("s" to Value("abc")),
+                mapOf("s" to Value("abc", typeOf<String>())),
                 extensions,
             )
             val result = evaluator.eval("s.asPrefix()", ctx)
-            assertEquals(Value("abc%", String::class), result)
+            assertEquals(Value("abc%", typeOf<String>()), result)
         }
 
         @Test
         fun `Call an extension function when the receiver is null`() {
             val ctx = ExprContext(
-                mapOf("s" to Value(null, Any::class)),
+                mapOf("s" to Value(null, typeOf<Any>())),
                 extensions,
             )
             val result = evaluator.eval("s.isNullOrEmpty()", ctx)
-            assertEquals(Value(true), result)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test
         fun `Failed to call the function`() {
             val ctx = ExprContext(
-                mapOf("a" to Value(null, String::class)),
+                mapOf("a" to Value(null, typeOf<String>())),
                 extensions,
             )
             val exception = assertFailsWith<ExprException> {
@@ -578,7 +583,7 @@ class ExprEvaluatorTest {
         @Test
         fun `The function is not found`() {
             val ctx = ExprContext(
-                mapOf("a" to Value("string")),
+                mapOf("a" to Value("string", typeOf<String>())),
                 extensions,
             )
             val exception = assertFailsWith<ExprException> {
@@ -594,11 +599,11 @@ class ExprEvaluatorTest {
         @Test
         fun test() {
             val ctx = ExprContext(
-                mapOf("uInt" to Value(1u)),
+                mapOf("uInt" to Value(1u, typeOf<UInt>())),
                 extensions,
             )
             val result = evaluator.eval("uInt", ctx)
-            assertEquals(Value(1u), result)
+            assertEquals(Value(1u, typeOf<UInt>()), result)
         }
     }
 }


### PR DESCRIPTION
This pull request is experimental and includes breaking changes.

## Description

Previously, we supported mapping database data types for each `KClass`, but this pull request supports mapping for each `KType`.

## Example

In the following example, mappings are defined for two generic types using the `Pair` class.

**Entity**
```kotlin
@KomapperEntity
data class SampleEntity(
  @KomapperId
  val id: Int,
  val pairOfString: Pair<String, String>?,
  val pairOfInt: Pair<Int, Int>?,
)
```

**User-defined data type for Pair<String, String>**
```kotlin
package example

class PairOfStringType : JdbcUserDefinedDataType<Pair<String, String>> {

    override val name: String = "varchar(500)"
    override val type: KType = typeOf<Pair<String, String>>()
    override val jdbcType: JDBCType = JDBCType.VARCHAR

    override fun getValue(rs: ResultSet, index: Int): Pair<String, String>? {
        return rs.getString(index)?.let {
            val values = it.split(",")
            return Pair(values[0], values[1])
        }
    }

    override fun getValue(rs: ResultSet, columnLabel: String): Pair<String, String>? {
        return rs.getString(columnLabel)?.let {
            val values = it.split(",")
            return Pair(values[0], values[1])
        }
    }

    override fun setValue(ps: PreparedStatement, index: Int, value: Pair<String, String>) {
        return ps.setString(index, "${value.first},${value.second}")
    }

    override fun toString(value: Pair<String, String>): String {
        return "'${value.first},${value.second}'"
    }
}
```

**User-defined data type for Pair<Int, Int>**
```kotlin
package example

class PairOfIntType : JdbcUserDefinedDataType<Pair<Int, Int>> {

    override val name: String = "varchar(500)"
    override val type: KType = typeOf<Pair<Int, Int>>()
    override val jdbcType: JDBCType = JDBCType.VARCHAR

    override fun getValue(rs: ResultSet, index: Int): Pair<Int, Int>? {
        return rs.getString(index)?.let {
            val values = it.split(",")
            return Pair(values[0].toInt(), values[1].toInt())
        }
    }

    override fun getValue(rs: ResultSet, columnLabel: String): Pair<Int, Int>? {
        return rs.getString(columnLabel)?.let {
            val values = it.split(",")
            return Pair(values[0].toInt(), values[1].toInt())
        }
    }

    override fun setValue(ps: PreparedStatement, index: Int, value: Pair<Int, Int>) {
        return ps.setString(index, "${value.first},${value.second}")
    }

    override fun toString(value: Pair<Int, Int>): String {
        return "'${value.first},${value.second}'"
    }
}
```

**META-INF/services/org.komapper.jdbc.spi.JdbcUserDefinedDataType**
```
example.PairOfIntType
example.PairOfStringType
```