### PR TITLE
Add location information to the output of KSPLogger

### DIFF
--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Context.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Context.kt
@@ -4,10 +4,10 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 
 internal data class Context(
-    val environment: SymbolProcessorEnvironment,
+    private val environment: SymbolProcessorEnvironment,
     val config: Config,
     val resolver: Resolver,
 ) {
-    val logger get() = environment.logger
+    val logger = KomapperKSPLogger(environment.logger)
     val codeGenerator get() = environment.codeGenerator
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/KomapperKSPLogger.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/KomapperKSPLogger.kt
@@ -1,0 +1,36 @@
+package org.komapper.processor
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.FileLocation
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.NonExistLocation
+
+class KomapperKSPLogger(private val logger: KSPLogger) : KSPLogger {
+
+    override fun logging(message: String, symbol: KSNode?) {
+        logger.logging(convertMessage(message, symbol))
+    }
+
+    override fun info(message: String, symbol: KSNode?) {
+        logger.info(convertMessage(message, symbol))
+    }
+
+    override fun warn(message: String, symbol: KSNode?) {
+        logger.warn(convertMessage(message, symbol))
+    }
+
+    override fun error(message: String, symbol: KSNode?) {
+        logger.error(convertMessage(message, symbol))
+    }
+
+    override fun exception(e: Throwable) {
+        logger.exception(e)
+    }
+
+    private fun convertMessage(message: String, symbol: KSNode?): String {
+        return when (val location = symbol?.location) {
+            is FileLocation -> "$message file:///${location.filePath}:${location.lineNumber}"
+            is NonExistLocation, null -> message
+        }
+    }
+}

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/KomapperKSPLogger.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/KomapperKSPLogger.kt
@@ -29,7 +29,7 @@ class KomapperKSPLogger(private val logger: KSPLogger) : KSPLogger {
 
     private fun convertMessage(message: String, symbol: KSNode?): String {
         return when (val location = symbol?.location) {
-            is FileLocation -> "$message file:///${location.filePath}:${location.lineNumber}"
+            is FileLocation -> "$message file://${location.filePath}:${location.lineNumber}"
             is NonExistLocation, null -> message
         }
     }


### PR DESCRIPTION
The output example is as follows:

> [ksp] The entity class must have at least one id property. file:///Users/nakamura/src/github.com/komapper/komapper-quickstart/src/main/kotlin/org/komapper/quickstart/Employee.kt:7