### PR TITLE
Simplify the definition of custom column expressions

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcOperatorTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcOperatorTest.kt
@@ -262,7 +262,7 @@ class JdbcOperatorTest(private val db: JdbcDatabase) {
         assertEquals("St. 1", result)
     }
 
-    private fun <T : Any> replace(
+    private inline fun <reified T : Any> replace(
         expression: ColumnExpression<T, String>,
         from: T,
         to: T,

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
@@ -34,7 +34,6 @@ import org.komapper.core.dsl.query.singleOrNull
 import org.komapper.jdbc.JdbcDatabase
 import java.math.BigDecimal
 import java.time.LocalDateTime
-import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -341,8 +340,8 @@ class JdbcSelectTest(private val db: JdbcDatabase) {
 
     private fun fromUnixTime(value: Long): ColumnExpression<LocalDateTime, LocalDateTime> {
         val name = "fromUnixTime"
-        val o1 = Operand.SimpleArgument(typeOf<Long>(), value)
-        return columnExpression(typeOf<LocalDateTime>(), name, listOf(o1)) {
+        val o1 = Operand.simpleArgument(value)
+        return columnExpression(name, listOf(o1)) {
             append("FROM_UNIXTIME(")
             visit(o1)
             append(")")

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/Operand.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/Operand.kt
@@ -3,6 +3,7 @@ package org.komapper.core.dsl.expression
 import org.komapper.core.ThreadSafe
 import org.komapper.core.Value
 import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 /**
  * Represents operands in Komapper Query DSL.
@@ -73,5 +74,15 @@ sealed class Operand {
      */
     data class Subquery(val subqueryExpression: SubqueryExpression<*>) : Operand() {
         override val masking: Boolean = false
+    }
+
+    companion object {
+        /**
+         * Creates an [Operand.SimpleArgument].
+         *
+         * @param S the interior type
+         * @param interior the argument value
+         */
+        inline fun <reified S : Any> simpleArgument(interior: S?) = SimpleArgument(typeOf<S>(), interior)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/OperatorUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/OperatorUtility.kt
@@ -5,7 +5,6 @@ import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.ReadOnlyColumnExpression
 import org.komapper.core.dsl.expression.SqlBuilderScope
 import org.komapper.core.dsl.expression.UserDefinedExpression
-import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
 /**
@@ -21,15 +20,13 @@ import kotlin.reflect.typeOf
  * @param build the SQL builder
  * @return column expression
  */
-fun <T : Any, S : Any> columnExpression(
+inline fun <reified T : Any, reified S : Any> columnExpression(
     baseExpression: ColumnExpression<T, S>,
     name: String,
     operands: List<Operand>,
-    build: SqlBuilderScope.() -> Unit,
+    noinline build: SqlBuilderScope.() -> Unit,
 ): ColumnExpression<T, S> {
     return columnExpression(
-        baseExpression.exteriorType,
-        baseExpression.interiorType,
         baseExpression.wrap,
         name,
         operands,
@@ -43,19 +40,17 @@ fun <T : Any, S : Any> columnExpression(
  * The [name] and [operands] are used to determine identity of the expression.
  *
  * @param T the exterior type and interior type of expression evaluation
- * @param type the type of [T]
  * @param name the name that must be unique among user-defined column expressions
  * @param operands the operand list used in the expression
  * @param build the SQL builder
  * @return column expression
  */
-fun <T : Any> columnExpression(
-    type: KType,
+inline fun <reified T : Any> columnExpression(
     name: String,
     operands: List<Operand>,
-    build: SqlBuilderScope.() -> Unit,
+    noinline build: SqlBuilderScope.() -> Unit,
 ): ColumnExpression<T, T> {
-    return columnExpression(type, type, { it }, name, operands, build)
+    return columnExpression({ it }, name, operands, build)
 }
 
 /**
@@ -65,23 +60,19 @@ fun <T : Any> columnExpression(
  *
  * @param EXTERIOR the exterior type of expression evaluation
  * @param INTERIOR the interior type of expression evaluation
- * @param exteriorType the type of [EXTERIOR]
- * @param interiorType the type of [INTERIOR]
  * @param wrap the function to convert an interior value to an exterior value
  * @param name the name that must be unique among user-defined column expressions
  * @param operands the operand list used in the expression
  * @param build the SQL builder
  * @return column expression
  */
-fun <EXTERIOR : Any, INTERIOR : Any> columnExpression(
-    exteriorType: KType,
-    interiorType: KType,
-    wrap: (INTERIOR) -> EXTERIOR,
+inline fun <reified EXTERIOR : Any, reified INTERIOR : Any> columnExpression(
+    noinline wrap: (INTERIOR) -> EXTERIOR,
     name: String,
     operands: List<Operand>,
-    build: SqlBuilderScope.() -> Unit,
+    noinline build: SqlBuilderScope.() -> Unit,
 ): ColumnExpression<EXTERIOR, INTERIOR> {
-    return UserDefinedExpression(exteriorType, interiorType, wrap, name, operands, build)
+    return UserDefinedExpression(typeOf<EXTERIOR>(), typeOf<INTERIOR>(), wrap, name, operands, build)
 }
 
 /**


### PR DESCRIPTION
To simplify the definition, use type parameters instead of KType parameters.

This change is related to #1303.