### PR TITLE
Support explicit API in the code generated by KSP

### DIFF
--- a/integration-test-core/build.gradle.kts
+++ b/integration-test-core/build.gradle.kts
@@ -19,6 +19,10 @@ ksp {
     arg("komapper.enableEntityStoreContext", "true")
 }
 
+kotlin {
+    explicitApi()
+}
+
 tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         kotlinOptions.freeCompilerArgs += listOf(

--- a/integration-test-core/src/main/kotlin/integration/core/Dbms.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Dbms.kt
@@ -1,5 +1,5 @@
 package integration.core
 
-enum class Dbms {
+public enum class Dbms {
     H2, MARIADB, MYSQL_5, MYSQL, ORACLE, POSTGRESQL, SQLSERVER
 }

--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -29,7 +29,7 @@ import java.time.OffsetDateTime
 
 @KomapperEntity
 @KomapperProjection
-data class Address(
+public data class Address(
     @KomapperId
     @KomapperColumn(name = "address_id")
     val addressId: Int,
@@ -39,7 +39,7 @@ data class Address(
 
 @KomapperEntity
 @KomapperTable(name = "address")
-data class IdColumnOnlyAddress(
+public data class IdColumnOnlyAddress(
     @KomapperId
     @KomapperColumn(name = "address_id")
     val addressId: Int,
@@ -49,21 +49,21 @@ data class IdColumnOnlyAddress(
 
 @KomapperEntity
 @KomapperTable(name = "comp_key_address")
-data class CompositeKeyAddress(
+public data class CompositeKeyAddress(
     @KomapperId val addressId1: Int,
     @KomapperId val addressId2: Int,
     val street: String,
     val version: Int,
 )
 
-data class AddressId(
+public data class AddressId(
     val addressId1: Int,
     val addressId2: Int,
 )
 
 @KomapperEntity
 @KomapperTable(name = "comp_key_address")
-data class EmbeddedIdAddress(
+public data class EmbeddedIdAddress(
     @KomapperEmbeddedId
     val id: AddressId,
     val street: String,
@@ -72,7 +72,7 @@ data class EmbeddedIdAddress(
 
 @KomapperEntity
 @KomapperTable(name = "comp_key_address")
-data class GenericEmbeddedIdAddress(
+public data class GenericEmbeddedIdAddress(
     @KomapperEmbeddedId
     @KomapperColumnOverride("first", KomapperColumn("address_id1"))
     @KomapperColumnOverride("second", KomapperColumn("address_id2"))
@@ -83,7 +83,7 @@ data class GenericEmbeddedIdAddress(
 
 @KomapperEntity
 @KomapperTable("identity_strategy")
-data class IdentityStrategy(
+public data class IdentityStrategy(
     @KomapperId @KomapperAutoIncrement
     val id: Int?,
     @KomapperColumn(alwaysQuote = true) val value: String,
@@ -91,7 +91,7 @@ data class IdentityStrategy(
 
 @KomapperEntity
 @KomapperTable("sequence_strategy")
-data class SequenceStrategy(
+public data class SequenceStrategy(
     @KomapperId
     @KomapperSequence(name = "sequence_strategy_id", incrementBy = 100)
     val id: Int,
@@ -100,7 +100,7 @@ data class SequenceStrategy(
 
 @KomapperEntity
 @KomapperTable("human")
-data class Man(
+public data class Man(
     @KomapperId
     @KomapperColumn("human_id")
     val manId: Int,
@@ -114,7 +114,7 @@ data class Man(
 )
 
 @KomapperEntity
-data class Person(
+public data class Person(
     @KomapperId
     @KomapperColumn("person_id")
     val personId: Int,
@@ -129,7 +129,7 @@ data class Person(
 
 @KomapperEntity
 @KomapperTable("human")
-data class Human(
+public data class Human(
     @KomapperId
     @KomapperColumn("human_id")
     val humanId: Int,
@@ -147,7 +147,7 @@ data class Human(
     link = KomapperLink(source = "manager", target = "employee"),
 )
 @KomapperEntity(["employee", "manager"])
-data class Employee(
+public data class Employee(
     @KomapperId
     @KomapperColumn("employee_id")
     val employeeId: Int,
@@ -161,12 +161,12 @@ data class Employee(
     @KomapperVersion val version: Int,
 )
 
-data class RobotInfo1(
+public data class RobotInfo1(
     @KomapperColumn("employee_no") val employeeNo: Int,
     @KomapperColumn("employee_name") val employeeName: String,
 )
 
-data class RobotInfo2(
+public data class RobotInfo2(
     val hiredate: LocalDate? = null,
     val salary: BigDecimal? = null,
 )
@@ -174,7 +174,7 @@ data class RobotInfo2(
 @KomapperEntity
 @KomapperProjection
 @KomapperTable("employee")
-data class Robot(
+public data class Robot(
     @KomapperId
     @KomapperColumn("employee_id")
     val employeeId: Int,
@@ -192,7 +192,7 @@ data class Robot(
 
 @KomapperEntity
 @KomapperTable("employee")
-data class Android(
+public data class Android(
     @KomapperId
     @KomapperColumn("employee_id")
     val employeeId: Int,
@@ -210,10 +210,10 @@ data class Android(
     @KomapperVersion val version: Int,
 )
 
-typealias CyborgInfo1 = Pair<Int, String>
-typealias CyborgInfo2 = Pair<LocalDate?, BigDecimal?>
+public typealias CyborgInfo1 = Pair<Int, String>
+public typealias CyborgInfo2 = Pair<LocalDate?, BigDecimal?>
 
-data class Cyborg(
+public data class Cyborg(
     val employeeId: Int,
     val info1: CyborgInfo1,
     val info2: CyborgInfo2?,
@@ -225,7 +225,7 @@ data class Cyborg(
 
 @KomapperEntityDef(Cyborg::class)
 @KomapperTable("employee")
-data class CyborgDef(
+public data class CyborgDef(
     @KomapperId
     @KomapperColumn("employee_id")
     val employeeId: Nothing,
@@ -243,19 +243,19 @@ data class CyborgDef(
     @KomapperVersion val version: Nothing,
 )
 
-data class MachineInfo1(
+public data class MachineInfo1(
     val employeeNo: Int,
     val employeeName: String,
 )
 
-data class MachineInfo2(
+public data class MachineInfo2(
     val hiredate: LocalDate? = null,
     val salary: BigDecimal? = null,
 )
 
 @KomapperEntity
 @KomapperTable("employee")
-data class Machine(
+public data class Machine(
     @KomapperId
     @KomapperColumn("employee_id")
     val employeeId: Int,
@@ -274,7 +274,7 @@ data class Machine(
 @KomapperAggregateRoot("departments")
 @KomapperOneToMany(Employee::class, navigator = "employees")
 @KomapperEntity
-data class Department(
+public data class Department(
     @KomapperId
     @KomapperColumn("department_id")
     val departmentId: Int,
@@ -286,7 +286,7 @@ data class Department(
 
 @KomapperEntity
 @KomapperTable("department")
-data class NoVersionDepartment(
+public data class NoVersionDepartment(
     @KomapperId
     @KomapperColumn("department_id")
     val departmentId: Int,
@@ -296,18 +296,18 @@ data class NoVersionDepartment(
     val version: Int,
 )
 
-data class Place(
+public data class Place(
     val id: Int,
     val street: String,
     val version: Int,
 )
 
-typealias LocationInt = Int
-typealias LocationString = String
+public typealias LocationInt = Int
+public typealias LocationString = String
 
 @KomapperEntity
 @KomapperTable("address")
-data class Location(
+public data class Location(
     @KomapperId
     @KomapperColumn(name = "address_id")
     val id: LocationInt?,
@@ -317,13 +317,13 @@ data class Location(
 )
 
 @KomapperEntity
-data class T(
+public data class T(
     @KomapperId(virtual = true)
     val n: Int,
 )
 
 @KomapperEntity
-data class IntPair(
+public data class IntPair(
     @KomapperId(virtual = true)
     val first: Int,
     @KomapperId(virtual = true)
@@ -331,7 +331,7 @@ data class IntPair(
 )
 
 @KomapperEntity
-data class NameAndAmount(
+public data class NameAndAmount(
     @KomapperId(virtual = true)
     val name: String,
     val amount: BigDecimal,
@@ -356,7 +356,7 @@ data class NameAndAmount(
 }
 
 @KomapperEntity
-data class EmployeeSalary(
+public data class EmployeeSalary(
     @KomapperId(virtual = true)
     val departmentId: Int,
     @KomapperId(virtual = true)
@@ -367,15 +367,15 @@ data class EmployeeSalary(
 )
 
 @KomapperProjection
-data class AddressDto(
+public data class AddressDto(
     @KomapperColumn("address_id") val idValue: Int,
     @KomapperColumn("street") val streetValue: String?,
 )
 
-data class DepartmentDto(
+public data class DepartmentDto(
     val department: String,
     val memberCount: Long,
 )
 
 @KomapperProjectionDef(DepartmentDto::class)
-object DepartmentDtoDef
+public object DepartmentDtoDef

--- a/integration-test-core/src/main/kotlin/integration/core/EntitiesDataType.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/EntitiesDataType.kt
@@ -29,48 +29,48 @@ import java.util.UUID
 
 @KomapperEntity
 @KomapperTable("any_person")
-data class AnyPerson(@KomapperId val name: String) : Serializable
+public data class AnyPerson(@KomapperId val name: String) : Serializable
 
 @KomapperEntity
 @KomapperTable("any_data")
-data class AnyData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Any?)
+public data class AnyData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Any?)
 
 @KomapperEntity
 @KomapperTable("big_decimal_data")
-data class BigDecimalData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: BigDecimal?)
+public data class BigDecimalData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: BigDecimal?)
 
 @KomapperEntity
 @KomapperTable("big_integer_data")
-data class BigIntegerData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: BigInteger?)
+public data class BigIntegerData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: BigInteger?)
 
 @KomapperEntity
 @KomapperTable("boolean_data")
-data class BooleanData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Boolean?)
+public data class BooleanData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Boolean?)
 
 @KomapperEntity
 @KomapperTable("byte_data")
-data class ByteData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Byte?)
+public data class ByteData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Byte?)
 
 @KomapperEntity
 @KomapperTable("byte_array_data")
 @Suppress("ArrayInDataClass")
-data class ByteArrayData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: ByteArray?)
+public data class ByteArrayData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: ByteArray?)
 
 @KomapperEntity
 @KomapperTable("double_data")
-data class DoubleData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Double?)
+public data class DoubleData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Double?)
 
 @KomapperEntity
 @KomapperTable("duration_data")
-data class DurationData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Duration?)
+public data class DurationData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Duration?)
 
 @KomapperEntity
 @KomapperTable("enum_data")
-data class EnumData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Direction?)
+public data class EnumData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Direction?)
 
 @KomapperEntity
 @KomapperTable("enum_ordinal_data")
-data class EnumOrdinalData(
+public data class EnumOrdinalData(
     @KomapperId val id: Int,
     @KomapperColumn(alwaysQuote = true)
     @KomapperEnum(EnumType.ORDINAL)
@@ -79,7 +79,7 @@ data class EnumOrdinalData(
 
 @KomapperEntity
 @KomapperTable("enum_property_data")
-data class EnumPropertyData(
+public data class EnumPropertyData(
     @KomapperId val id: Int,
     @KomapperColumn(alwaysQuote = true)
     @KomapperEnum(EnumType.PROPERTY, hint = "value")
@@ -88,24 +88,24 @@ data class EnumPropertyData(
 
 @KomapperEntity
 @KomapperTable("enum_udt_data")
-data class EnumUdtData(
+public data class EnumUdtData(
     @KomapperId val id: Int,
     @KomapperColumn(alwaysQuote = true)
     @KomapperEnum(EnumType.TYPE)
     val value: Mood?,
 )
 
-data class DirectionInfo(
+public data class DirectionInfo(
     val direction: Direction,
 )
 
-data class ColorInfo(
+public data class ColorInfo(
     val color: Color,
 )
 
 @KomapperEntity
 @KomapperTable("enum_ordinal_data")
-data class EmbeddedEnumOrdinalData(
+public data class EmbeddedEnumOrdinalData(
     @KomapperId val id: Int,
     @KomapperEmbedded
     @KomapperColumnOverride(name = "direction", KomapperColumn(name = "value", alwaysQuote = true))
@@ -115,7 +115,7 @@ data class EmbeddedEnumOrdinalData(
 
 @KomapperEntity
 @KomapperTable("enum_property_data")
-data class EmbeddedEnumPropertyData(
+public data class EmbeddedEnumPropertyData(
     @KomapperId val id: Int,
     @KomapperEmbedded
     @KomapperColumnOverride(name = "color", KomapperColumn(name = "value", alwaysQuote = true))
@@ -125,75 +125,75 @@ data class EmbeddedEnumPropertyData(
 
 @KomapperEntity
 @KomapperTable("float_data")
-data class FloatData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Float?)
+public data class FloatData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Float?)
 
 @KomapperEntity
 @KomapperTable("instant_data")
-data class InstantData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Instant?)
+public data class InstantData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Instant?)
 
 @KomapperEntity
 @KomapperTable("int_data")
-data class IntData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Int?)
+public data class IntData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Int?)
 
 @KomapperEntity
 @KomapperTable("local_date_time_data")
-data class LocalDateTimeData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: LocalDateTime?)
+public data class LocalDateTimeData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: LocalDateTime?)
 
 @KomapperEntity
 @KomapperTable("local_date_data")
-data class LocalDateData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: LocalDate?)
+public data class LocalDateData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: LocalDate?)
 
 @KomapperEntity
 @KomapperTable("local_time_data")
-data class LocalTimeData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: LocalTime?)
+public data class LocalTimeData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: LocalTime?)
 
 @KomapperEntity
 @KomapperTable("long_data")
-data class LongData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Long?)
+public data class LongData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Long?)
 
 @KomapperEntity
 @KomapperTable("offset_date_time_data")
-data class OffsetDateTimeData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: OffsetDateTime?)
+public data class OffsetDateTimeData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: OffsetDateTime?)
 
 @KomapperEntity
 @KomapperTable("string_data")
-data class PairOfStringData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Pair<String, String>?)
+public data class PairOfStringData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Pair<String, String>?)
 
 @KomapperEntity
 @KomapperTable("string_data")
-data class PairOfIntData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Pair<Int, Int>?)
+public data class PairOfIntData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Pair<Int, Int>?)
 
 @KomapperEntity
 @KomapperTable("period_data")
-data class PeriodData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Period?)
+public data class PeriodData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Period?)
 
 @KomapperEntity
 @KomapperTable("short_data")
-data class ShortData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Short?)
+public data class ShortData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Short?)
 
 @KomapperEntity
 @KomapperTable("string_data")
-data class StringData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: String?)
+public data class StringData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: String?)
 
 @KomapperEntity
 @KomapperTable("short_data")
-data class UByteData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UByte?)
+public data class UByteData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UByte?)
 
 @KomapperEntity
 @KomapperTable("long_data")
-data class UIntData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UInt?)
+public data class UIntData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UInt?)
 
 @KomapperEntity
 @KomapperTable("int_data")
-data class UShortData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UShort?)
+public data class UShortData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UShort?)
 
 @KomapperEntity
 @KomapperTable("uuid_data")
-data class UUIDData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UUID?)
+public data class UUIDData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UUID?)
 
 @KomapperEntity
 @KomapperTable("address")
-data class UnsignedAddress(
+public data class UnsignedAddress(
     @KomapperId
     @KomapperColumn(name = "address_id")
     val addressId: UInt,
@@ -202,11 +202,11 @@ data class UnsignedAddress(
 )
 
 @JvmInline
-value class UIntVersion(@KomapperColumn(alwaysQuote = true) val value: UInt)
+public value class UIntVersion(@KomapperColumn(alwaysQuote = true) public val value: UInt)
 
 @KomapperEntity
 @KomapperTable("address")
-data class UnsignedAddress2(
+public data class UnsignedAddress2(
     @KomapperId
     @KomapperColumn(name = "address_id")
     val addressId: UInt,
@@ -216,7 +216,7 @@ data class UnsignedAddress2(
 
 @KomapperEntity
 @KomapperTable("identity_strategy")
-data class UnsignedIdentityStrategy(
+public data class UnsignedIdentityStrategy(
     @KomapperId @KomapperAutoIncrement
     val id: UInt?,
     @KomapperColumn(alwaysQuote = true) val value: String,
@@ -224,7 +224,7 @@ data class UnsignedIdentityStrategy(
 
 @KomapperEntity
 @KomapperTable("sequence_strategy")
-data class UnsignedSequenceStrategy(
+public data class UnsignedSequenceStrategy(
     @KomapperId
     @KomapperSequence(name = "sequence_strategy_id", incrementBy = 100)
     val id: UInt,
@@ -233,21 +233,21 @@ data class UnsignedSequenceStrategy(
 
 @KomapperEntity
 @KomapperTable("int_data")
-data class UserDefinedIntData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UserDefinedInt?)
+public data class UserDefinedIntData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: UserDefinedInt?)
 
-data class UserDefinedInt(val value: Int)
+public data class UserDefinedInt(val value: Int)
 
 @KomapperEntity
 @KomapperTable("string_data")
-data class UserDefinedStringData(
+public data class UserDefinedStringData(
     @KomapperId val id: Int,
     @KomapperColumn(alwaysQuote = true) val value: UserDefinedString?,
 )
 
-data class UserDefinedString(val value: String)
+public data class UserDefinedString(val value: String)
 
 @KomapperEntity
 @KomapperTable("string_data")
-data class WrappedStringData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: WrappedString?)
+public data class WrappedStringData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: WrappedString?)
 
-data class WrappedString(val value: String)
+public data class WrappedString(val value: String)

--- a/integration-test-core/src/main/kotlin/integration/core/EntitiesKeyword.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/EntitiesKeyword.kt
@@ -10,7 +10,7 @@ import org.komapper.annotation.KomapperVersion
 import java.time.LocalDateTime
 
 @KomapperEntity
-data class Keywords(
+public data class Keywords(
     @KomapperId val `as`: Int,
     val `break`: String,
     @KomapperCreatedAt
@@ -22,27 +22,27 @@ data class Keywords(
 )
 
 @KomapperEntity
-data class KeywordsSingleId(
+public data class KeywordsSingleId(
     @KomapperId val `fun`: Int,
     val `class`: String,
 )
 
 @KomapperEntity
-data class KeywordsMultipleId(
+public data class KeywordsMultipleId(
     @KomapperId val `fun`: Int,
     @KomapperId val `this`: Int,
     val `class`: String,
 )
 
 @KomapperEntity
-data class KeywordsAutoIncrementId(
+public data class KeywordsAutoIncrementId(
     @KomapperId @KomapperAutoIncrement
     val `fun`: Int,
     val `class`: String,
 )
 
 @KomapperEntity
-data class KeywordsSequenceId(
+public data class KeywordsSequenceId(
     @KomapperId
     @KomapperSequence(name = "SEQ")
     val `fun`: Int,

--- a/integration-test-core/src/main/kotlin/integration/core/EntitiesKotlinDatetime.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/EntitiesKotlinDatetime.kt
@@ -12,22 +12,22 @@ import org.komapper.annotation.KomapperUpdatedAt
 
 @KomapperEntity
 @KomapperTable("instant_data")
-data class KotlinInstantData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Instant)
+public data class KotlinInstantData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: Instant)
 
 @KomapperEntity
 @KomapperTable("local_date_data")
-data class KotlinLocalDateData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: LocalDate)
+public data class KotlinLocalDateData(@KomapperId val id: Int, @KomapperColumn(alwaysQuote = true) val value: LocalDate)
 
 @KomapperEntity
 @KomapperTable("local_date_time_data")
-data class KotlinLocalDateTimeData(
+public data class KotlinLocalDateTimeData(
     @KomapperId val id: Int,
     @KomapperColumn(alwaysQuote = true) val value: LocalDateTime,
 )
 
 @KomapperEntity
 @KomapperTable("human")
-data class KotlinInstantPerson(
+public data class KotlinInstantPerson(
     @KomapperId
     @KomapperColumn("human_id")
     val humanId: Int,
@@ -42,7 +42,7 @@ data class KotlinInstantPerson(
 
 @KomapperEntity
 @KomapperTable("person")
-data class KotlinDatetimePerson(
+public data class KotlinDatetimePerson(
     @KomapperId
     @KomapperColumn("person_id")
     val personId: Int,

--- a/integration-test-core/src/main/kotlin/integration/core/EntitiesQuote.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/EntitiesQuote.kt
@@ -8,7 +8,7 @@ import org.komapper.annotation.KomapperVersion
 
 @KomapperEntity
 @KomapperTable(catalog = "catalog", schema = "schema", alwaysQuote = true)
-data class CatalogAndSchema(
+public data class CatalogAndSchema(
     @KomapperId
     @KomapperColumn(name = "address_id")
     val addressId: Int,
@@ -18,19 +18,19 @@ data class CatalogAndSchema(
 
 @KomapperEntity
 @KomapperTable(catalog = "catalog", alwaysQuote = true)
-data class CatalogOnly(
+public data class CatalogOnly(
     @KomapperId val id: Int,
 )
 
 @KomapperEntity
 @KomapperTable(schema = "schema", alwaysQuote = true)
-data class SchemaOnly(
+public data class SchemaOnly(
     @KomapperId val id: Int,
 )
 
 @KomapperEntity
 @KomapperTable("    ", alwaysQuote = true)
-data class BlankName(
+public data class BlankName(
     @KomapperId
     @KomapperColumn("    ", alwaysQuote = true)
     val id: Int,
@@ -38,7 +38,7 @@ data class BlankName(
 
 @KomapperEntity
 @KomapperTable(alwaysQuote = true)
-data class Order(
+public data class Order(
     @KomapperId
     @KomapperColumn(alwaysQuote = true)
     val orderId: Int,

--- a/integration-test-core/src/main/kotlin/integration/core/EntitiesSchema.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/EntitiesSchema.kt
@@ -7,7 +7,7 @@ import org.komapper.annotation.KomapperId
 import org.komapper.annotation.KomapperSequence
 
 @KomapperEntity
-data class Aaa(
+public data class Aaa(
     @KomapperId
     @KomapperColumn(alwaysQuote = true)
     val id: Int,
@@ -15,14 +15,14 @@ data class Aaa(
 )
 
 @KomapperEntity
-data class Bbb(
+public data class Bbb(
     @KomapperId @KomapperAutoIncrement
     val id: Int,
     val name: String?,
 )
 
 @KomapperEntity
-data class Ccc(
+public data class Ccc(
     @KomapperId
     @KomapperSequence("ccc_seq", incrementBy = 50)
     val id: Int,
@@ -30,7 +30,7 @@ data class Ccc(
 )
 
 @KomapperEntity
-data class CompositeKey(
+public data class CompositeKey(
     @KomapperId val addressId1: Int,
     @KomapperId val addressId2: Int,
     val street: String,
@@ -38,14 +38,14 @@ data class CompositeKey(
 )
 
 @KomapperEntity
-data class AutoIncrementTable(
+public data class AutoIncrementTable(
     @KomapperId @KomapperAutoIncrement
     val id: Int?,
     @KomapperColumn(alwaysQuote = true) val value: String,
 )
 
 @KomapperEntity
-data class SequenceTable(
+public data class SequenceTable(
     @KomapperId
     @KomapperSequence(name = "sequence_table_id", incrementBy = 100)
     val id: Int,

--- a/integration-test-core/src/main/kotlin/integration/core/EntitiesUnit.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/EntitiesUnit.kt
@@ -10,11 +10,11 @@ import org.komapper.annotation.KomapperUpdatedAt
 import org.komapper.annotation.KomapperVersion
 import java.time.LocalDateTime
 
-object MyMeta
+public object MyMeta
 
 @KomapperEntity(unit = MyMeta::class)
 @KomapperTable("address")
-data class MyAddress(
+public data class MyAddress(
     @KomapperId
     @KomapperColumn(name = "address_id")
     val addressId: Int,
@@ -22,7 +22,7 @@ data class MyAddress(
     @KomapperVersion val version: Int,
 )
 
-data class MyPerson(
+public data class MyPerson(
     val personId: Int,
     val name: String,
     val createdAt: LocalDateTime? = null,
@@ -31,7 +31,7 @@ data class MyPerson(
 
 @KomapperEntityDef(entity = MyPerson::class, unit = MyMeta::class)
 @KomapperTable("person")
-data class MyPersonDef(
+public data class MyPersonDef(
     @KomapperId
     @KomapperColumn("person_id")
     val personId: Nothing,

--- a/integration-test-core/src/main/kotlin/integration/core/EntitiesValueClass.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/EntitiesValueClass.kt
@@ -12,24 +12,24 @@ import org.komapper.annotation.KomapperVersion
 import java.time.LocalDateTime
 
 @JvmInline
-value class IntId(val value: Int) : Comparable<IntId> {
+public value class IntId(public val value: Int) : Comparable<IntId> {
     override fun compareTo(other: IntId): Int {
         return value.compareTo(other.value)
     }
 }
 
 @JvmInline
-value class Street(val value: String)
+public value class Street(public val value: String)
 
 @JvmInline
-value class Version(val value: Int)
+public value class Version(public val value: Int)
 
 @JvmInline
-value class Timestamp(val value: LocalDateTime)
+public value class Timestamp(public val value: LocalDateTime)
 
 @KomapperEntity
 @KomapperTable("address")
-data class VAddress(
+public data class VAddress(
     @KomapperId val addressId: IntId,
     val street: Street,
     @KomapperVersion val version: Version,
@@ -37,7 +37,7 @@ data class VAddress(
 
 @KomapperEntity
 @KomapperTable("person")
-data class VPerson(
+public data class VPerson(
     @KomapperId
     @KomapperColumn("person_id")
     val personId: IntId,
@@ -52,7 +52,7 @@ data class VPerson(
 
 @KomapperEntity
 @KomapperTable("identity_strategy")
-data class VIdentityStrategy(
+public data class VIdentityStrategy(
     @KomapperId @KomapperAutoIncrement
     val id: IntId?,
     @KomapperColumn(alwaysQuote = true)val value: String,
@@ -60,7 +60,7 @@ data class VIdentityStrategy(
 
 @KomapperEntity
 @KomapperTable("sequence_strategy")
-data class VSequenceStrategy(
+public data class VSequenceStrategy(
     @KomapperId
     @KomapperSequence(name = "sequence_strategy_id", incrementBy = 100)
     val id: IntId,

--- a/integration-test-core/src/main/kotlin/integration/core/EntitiesVirtual.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/EntitiesVirtual.kt
@@ -5,17 +5,17 @@ import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperId
 
 @KomapperEntity
-data class Belonging(
+public data class Belonging(
     @KomapperId(virtual = true) val employeeId: Int,
     @KomapperId(virtual = true) val departmentId: Int,
 )
 
 @KomapperEntity
-data class Assignment(
+public data class Assignment(
     @KomapperEmbeddedId(virtual = true) val id: AssignmentId,
 )
 
-data class AssignmentId(
+public data class AssignmentId(
     val employeeId: Int,
     val taskId: Int,
 )

--- a/integration-test-core/src/main/kotlin/integration/core/H2Setting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/H2Setting.kt
@@ -2,7 +2,7 @@ package integration.core
 
 import org.komapper.core.Database
 
-interface H2Setting<DATABASE : Database> : Setting<DATABASE> {
+public interface H2Setting<DATABASE : Database> : Setting<DATABASE> {
     override val dbms: Dbms get() = Dbms.H2
     override val createSql: String
         get() = """

--- a/integration-test-core/src/main/kotlin/integration/core/LogConfigurator.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/LogConfigurator.kt
@@ -7,7 +7,7 @@ import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.spi.Configurator
 import org.komapper.core.LogCategory
 
-class LogConfigurator : BasicConfigurator() {
+public class LogConfigurator : BasicConfigurator() {
     override fun configure(lc: LoggerContext): Configurator.ExecutionStatus {
         val status = super.configure(lc)
         val sqlLogger: Logger = lc.getLogger(LogCategory.SQL_WITH_ARGS)

--- a/integration-test-core/src/main/kotlin/integration/core/MariaDbSetting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/MariaDbSetting.kt
@@ -2,7 +2,7 @@ package integration.core
 
 import org.komapper.core.Database
 
-interface MariaDbSetting<DATABASE : Database> : Setting<DATABASE> {
+public interface MariaDbSetting<DATABASE : Database> : Setting<DATABASE> {
     override val dbms: Dbms get() = Dbms.MARIADB
     override val createSql: String
         get() = """

--- a/integration-test-core/src/main/kotlin/integration/core/MySql5Setting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/MySql5Setting.kt
@@ -2,7 +2,7 @@ package integration.core
 
 import org.komapper.core.Database
 
-interface MySql5Setting<DATABASE : Database> : Setting<DATABASE> {
+public interface MySql5Setting<DATABASE : Database> : Setting<DATABASE> {
     override val dbms: Dbms get() = Dbms.MYSQL_5
     override val createSql: String
         get() = """

--- a/integration-test-core/src/main/kotlin/integration/core/MySqlSetting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/MySqlSetting.kt
@@ -2,7 +2,7 @@ package integration.core
 
 import org.komapper.core.Database
 
-interface MySqlSetting<DATABASE : Database> : Setting<DATABASE> {
+public interface MySqlSetting<DATABASE : Database> : Setting<DATABASE> {
     override val dbms: Dbms get() = Dbms.MYSQL
     override val createSql: String
         get() = """

--- a/integration-test-core/src/main/kotlin/integration/core/OracleSetting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/OracleSetting.kt
@@ -2,7 +2,7 @@ package integration.core
 
 import org.komapper.core.Database
 
-interface OracleSetting<DATABASE : Database> : Setting<DATABASE> {
+public interface OracleSetting<DATABASE : Database> : Setting<DATABASE> {
     override val dbms: Dbms get() = Dbms.ORACLE
     override val createSql: String
         get() = """

--- a/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
@@ -2,7 +2,7 @@ package integration.core
 
 import org.komapper.core.Database
 
-interface PostgreSqlSetting<DATABASE : Database> : Setting<DATABASE> {
+public interface PostgreSqlSetting<DATABASE : Database> : Setting<DATABASE> {
     override val dbms: Dbms get() = Dbms.POSTGRESQL
     override val createSql: String
         get() = """

--- a/integration-test-core/src/main/kotlin/integration/core/Run.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Run.kt
@@ -2,9 +2,9 @@ package integration.core
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Run(val onlyIf: Array<Dbms> = [], val unless: Array<Dbms> = []) {
-    companion object {
-        fun isRunnable(run: Run, dbms: Dbms): Boolean {
+public annotation class Run(val onlyIf: Array<Dbms> = [], val unless: Array<Dbms> = []) {
+    public companion object {
+        public fun isRunnable(run: Run, dbms: Dbms): Boolean {
             with(run) {
                 if (onlyIf.isNotEmpty()) {
                     return dbms in onlyIf

--- a/integration-test-core/src/main/kotlin/integration/core/Setting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Setting.kt
@@ -2,9 +2,9 @@ package integration.core
 
 import org.komapper.core.Database
 
-interface Setting<DATABASE : Database> {
-    val database: DATABASE
-    val dbms: Dbms
-    val createSql: String
-    val resetSql: String?
+public interface Setting<DATABASE : Database> {
+    public val database: DATABASE
+    public val dbms: Dbms
+    public val createSql: String
+    public val resetSql: String?
 }

--- a/integration-test-core/src/main/kotlin/integration/core/SqlServerSetting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/SqlServerSetting.kt
@@ -2,7 +2,7 @@ package integration.core
 
 import org.komapper.core.Database
 
-interface SqlServerSetting<DATABASE : Database> : Setting<DATABASE> {
+public interface SqlServerSetting<DATABASE : Database> : Setting<DATABASE> {
     override val dbms: Dbms get() = Dbms.SQLSERVER
     override val createSql: String
         get() = """

--- a/integration-test-core/src/main/kotlin/integration/core/WrappedStringTypeConverter.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/WrappedStringTypeConverter.kt
@@ -4,7 +4,7 @@ import org.komapper.core.spi.DataTypeConverter
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-class WrappedStringTypeConverter : DataTypeConverter<WrappedString, String> {
+public class WrappedStringTypeConverter : DataTypeConverter<WrappedString, String> {
     override val exteriorType: KType = typeOf<WrappedString>()
     override val interiorType: KType = typeOf<String>()
 

--- a/integration-test-core/src/main/kotlin/integration/core/enumclass/Color.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/enumclass/Color.kt
@@ -1,5 +1,5 @@
 package integration.core.enumclass
 
-enum class Color(val value: Int) {
+public enum class Color(public val value: Int) {
     RED(10), BLUE(20), YELLOW(30)
 }

--- a/integration-test-core/src/main/kotlin/integration/core/enumclass/Direction.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/enumclass/Direction.kt
@@ -1,5 +1,5 @@
 package integration.core.enumclass
 
-enum class Direction {
+public enum class Direction {
     NORTH, SOUTH, EAST, WEST
 }

--- a/integration-test-core/src/main/kotlin/integration/core/enumclass/Mood.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/enumclass/Mood.kt
@@ -1,5 +1,5 @@
 package integration.core.enumclass
 
-enum class Mood(val abbr: String) {
+public enum class Mood(public val abbr: String) {
     SAD("S"), OK("O"), HAPPY("H")
 }

--- a/integration-test-core/src/main/kotlin/integration/core/one/MyTestModel.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/one/MyTestModel.kt
@@ -4,7 +4,7 @@ import org.komapper.annotation.KomapperEntity
 import org.komapper.annotation.KomapperId
 
 @KomapperEntity
-data class MyTestModel(
+public data class MyTestModel(
     @KomapperId
     val id: Long,
 )

--- a/integration-test-core/src/main/kotlin/integration/core/two/AnotherModel.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/two/AnotherModel.kt
@@ -7,7 +7,7 @@ import org.komapper.annotation.KomapperOneToMany
 
 @KomapperOneToMany(MyTestModel::class, "mymodel")
 @KomapperEntity
-data class AnotherModel(
+public data class AnotherModel(
     @KomapperId
     val id: Long,
     val myModelId: Long,

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/BackquotedSymbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/BackquotedSymbols.kt
@@ -22,6 +22,7 @@ internal object BackquotedSymbols {
     const val IdContext = "`org.komapper.core.dsl.metamodel`.IdContext"
     const val IdGenerator = "`org.komapper.core.dsl.metamodel`.IdGenerator"
     const val Instant = "`java.time`.Instant"
+    const val KClass = "`kotlin.reflect`.KClass"
     const val KomapperExperimentalAssociation = "`org.komapper.annotation`.KomapperExperimentalAssociation"
     const val LocalDateTime = "`java.time`.LocalDateTime"
     const val Operand = "`org.komapper.core.dsl.expression`.Operand"

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelStubGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelStubGenerator.kt
@@ -38,24 +38,24 @@ internal class EntityMetamodelStubGenerator(
         }
         w.println("// generated at ${ZonedDateTime.now()}")
         w.println("@$EntityMetamodelImplementor($entityTypeName::class)")
-        w.println("class $simpleName : $EntityMetamodelStub<$entityTypeName, $simpleName>() {")
+        w.println("public class $simpleName : $EntityMetamodelStub<$entityTypeName, $simpleName>() {")
         val parameters = declaration.primaryConstructor?.parameters
         if (parameters != null) {
             for (p in parameters) {
                 val typeName = p.type.resolve().declaration.qualifiedName?.asString()
-                w.println("    val `$p`: $PropertyMetamodel<$entityTypeName, $typeName, $typeName> = $PropertyMetamodelStub<$entityTypeName, $typeName>()")
+                w.println("    public val `$p`: $PropertyMetamodel<$entityTypeName, $typeName, $typeName> = $PropertyMetamodelStub<$entityTypeName, $typeName>()")
             }
         }
-        w.println("    fun clone($constructorParamList) = $simpleName()")
-        w.println("    companion object {")
+        w.println("    public fun clone($constructorParamList): $simpleName = $simpleName()")
+        w.println("    public companion object {")
         for (alias in aliases) {
-            w.println("        val `$alias` = $simpleName()")
+            w.println("        public val `$alias` = $simpleName()")
         }
         w.println("    }")
         w.println("}")
         w.println("")
         for (alias in aliases) {
-            w.println("val $unitTypeName.`$alias` get() = $simpleName.`$alias`")
+            w.println("val $unitTypeName.`$alias`: $simpleName get() = $simpleName.`$alias`")
         }
     }
 }


### PR DESCRIPTION
We have decided to make visibility and return types explicit in the code generated by KSP.
The integration-test-core module is used to test whether the code is generated correctly.