### PR TITLE
Use the compilerOptions property

### DIFF
--- a/integration-test-core/build.gradle.kts
+++ b/integration-test-core/build.gradle.kts
@@ -25,9 +25,9 @@ kotlin {
 
 tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        kotlinOptions.freeCompilerArgs += listOf(
-            "-opt-in=org.komapper.annotation.KomapperExperimentalAssociation",
-            "-Xcontext-receivers",
-        )
+        compilerOptions {
+            freeCompilerArgs.add("-opt-in=org.komapper.annotation.KomapperExperimentalAssociation")
+            freeCompilerArgs.add("-Xcontext-receivers")
+        }
     }
 }

--- a/integration-test-jdbc/build.gradle.kts
+++ b/integration-test-jdbc/build.gradle.kts
@@ -39,10 +39,10 @@ tasks {
         )
     }
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        kotlinOptions.freeCompilerArgs += listOf(
-            "-opt-in=org.komapper.annotation.KomapperExperimentalAssociation",
-            "-Xcontext-receivers",
-        )
+        compilerOptions {
+            freeCompilerArgs.add("-opt-in=org.komapper.annotation.KomapperExperimentalAssociation")
+            freeCompilerArgs.add("-Xcontext-receivers")
+        }
     }
 }
 

--- a/komapper-tx-context-jdbc/build.gradle.kts
+++ b/komapper-tx-context-jdbc/build.gradle.kts
@@ -14,8 +14,8 @@ dependencies {
 
 tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        kotlinOptions {
-            freeCompilerArgs = freeCompilerArgs + "-Xcontext-receivers"
+        compilerOptions {
+            freeCompilerArgs.add("-Xcontext-receivers")
         }
     }
 }

--- a/komapper-tx-context-r2dbc/build.gradle.kts
+++ b/komapper-tx-context-r2dbc/build.gradle.kts
@@ -14,8 +14,8 @@ dependencies {
 
 tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        kotlinOptions {
-            freeCompilerArgs = freeCompilerArgs + "-Xcontext-receivers"
+        compilerOptions {
+            freeCompilerArgs.add("-Xcontext-receivers")
         }
     }
 }


### PR DESCRIPTION
Based on the Gradle warning messages, we will set the compilation options using the suggested approach.