### PR TITLE
Make QueryDsl instantiable and carry over query options settings

### DIFF
--- a/integration-test-core/src/test/kotlin/integration/core/QueryDslTest.kt
+++ b/integration-test-core/src/test/kotlin/integration/core/QueryDslTest.kt
@@ -120,6 +120,20 @@ class QueryDslTest {
     }
 
     @Test
+    fun selectOptions_setOperation() {
+        val a = Meta.address
+
+        val expected = SelectOptions(fetchSize = 10, queryTimeoutSeconds = 20, suppressLogging = true)
+        var actual: SelectOptions? = null
+        QueryDsl(selectOptions = expected).from(a).union(QueryDsl.from(a)).options {
+            actual = it
+            it
+        }
+        assertNotNull(actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun templateSelectOptions() {
         val expected = TemplateSelectOptions(fetchSize = 10, queryTimeoutSeconds = 20, suppressLogging = true)
         var actual: TemplateSelectOptions? = null

--- a/integration-test-core/src/test/kotlin/integration/core/QueryDslTest.kt
+++ b/integration-test-core/src/test/kotlin/integration/core/QueryDslTest.kt
@@ -1,0 +1,162 @@
+package integration.core
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.options.DeleteOptions
+import org.komapper.core.dsl.options.InsertOptions
+import org.komapper.core.dsl.options.SchemaOptions
+import org.komapper.core.dsl.options.ScriptOptions
+import org.komapper.core.dsl.options.SelectOptions
+import org.komapper.core.dsl.options.TemplateExecuteOptions
+import org.komapper.core.dsl.options.TemplateSelectOptions
+import org.komapper.core.dsl.options.UpdateOptions
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class QueryDslTest {
+
+    @Test
+    fun objectReference() {
+        val dsl1 = QueryDsl
+        val dsl2 = QueryDsl
+        assertEquals(dsl1, dsl2)
+    }
+
+    @Test
+    fun instantiation() {
+        val dsl1 = QueryDsl()
+        val dsl2 = QueryDsl
+        assertNotEquals(dsl1, dsl2)
+    }
+
+    @Test
+    fun deleteOptions() {
+        val a = Meta.address
+
+        val expected = DeleteOptions(queryTimeoutSeconds = 20, suppressLogging = true)
+        var actual: DeleteOptions? = null
+        QueryDsl(deleteOptions = expected)
+            .delete(a)
+            .single(Address(1, "", 1))
+            .options {
+                actual = it
+                it
+            }
+        assertNotNull(actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun insertOptions() {
+        val a = Meta.address
+
+        val expected = InsertOptions(queryTimeoutSeconds = 20, suppressLogging = true)
+        var actual: InsertOptions? = null
+        QueryDsl(insertOptions = expected)
+            .insert(a)
+            .single(Address(1, "", 1))
+            .options {
+                actual = it
+                it
+            }
+        assertNotNull(actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun schemaOptions_create() {
+        val a = Meta.address
+
+        val expected = SchemaOptions(queryTimeoutSeconds = 20, suppressLogging = true)
+        var actual: SchemaOptions? = null
+        QueryDsl(schemaOptions = expected).create(a).options {
+            actual = it
+            it
+        }
+        assertNotNull(actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun schemaOptions_drop() {
+        val a = Meta.address
+
+        val expected = SchemaOptions(queryTimeoutSeconds = 20, suppressLogging = true)
+        var actual: SchemaOptions? = null
+        QueryDsl(schemaOptions = expected).drop(a).options {
+            actual = it
+            it
+        }
+        assertNotNull(actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun scripOptions() {
+        val expected = ScriptOptions(queryTimeoutSeconds = 20, suppressLogging = true)
+        var actual: ScriptOptions? = null
+        QueryDsl(scriptOptions = expected).executeScript("").options {
+            actual = it
+            it
+        }
+        assertNotNull(actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun selectOptions() {
+        val a = Meta.address
+
+        val expected = SelectOptions(fetchSize = 10, queryTimeoutSeconds = 20, suppressLogging = true)
+        var actual: SelectOptions? = null
+        QueryDsl(selectOptions = expected).from(a).options {
+            actual = it
+            it
+        }
+        assertNotNull(actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun templateSelectOptions() {
+        val expected = TemplateSelectOptions(fetchSize = 10, queryTimeoutSeconds = 20, suppressLogging = true)
+        var actual: TemplateSelectOptions? = null
+        QueryDsl(templateSelectOptions = expected).fromTemplate("").options {
+            actual = it
+            it
+        }
+        assertNotNull(actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun templateExecuteOptions() {
+        val expected = TemplateExecuteOptions(queryTimeoutSeconds = 20, suppressLogging = true)
+        var actual: TemplateExecuteOptions? = null
+        QueryDsl(templateExecuteOptions = expected).executeTemplate("").options {
+            actual = it
+            it
+        }
+        assertNotNull(actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun updateOptions() {
+        val a = Meta.address
+
+        val expected = UpdateOptions(queryTimeoutSeconds = 20, suppressLogging = true)
+        var actual: UpdateOptions? = null
+        QueryDsl(updateOptions = expected)
+            .update(a)
+            .single(Address(1, "", 1))
+            .options {
+                actual = it
+                it
+            }
+        assertNotNull(actual)
+        assertEquals(expected, actual)
+    }
+}

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
@@ -27,6 +27,7 @@ import org.komapper.core.dsl.operator.columnExpression
 import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.operator.desc
 import org.komapper.core.dsl.operator.literal
+import org.komapper.core.dsl.options.SelectOptions
 import org.komapper.core.dsl.query.first
 import org.komapper.core.dsl.query.firstOrNull
 import org.komapper.core.dsl.query.single
@@ -346,5 +347,17 @@ class JdbcSelectTest(private val db: JdbcDatabase) {
             visit(o1)
             append(")")
         }
+    }
+
+    @Test
+    fun options() {
+        val myDsl = QueryDsl(selectOptions = SelectOptions(allowMissingWhereClause = false))
+        val e = assertThrows<IllegalStateException> {
+            db.runQuery {
+                myDsl.select(literal("hello")).single()
+            }
+            Unit
+        }
+        println(e)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
@@ -15,6 +15,14 @@ import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.metamodel.EmptyMetamodel
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.options.DeleteOptions
+import org.komapper.core.dsl.options.InsertOptions
+import org.komapper.core.dsl.options.SchemaOptions
+import org.komapper.core.dsl.options.ScriptOptions
+import org.komapper.core.dsl.options.SelectOptions
+import org.komapper.core.dsl.options.TemplateExecuteOptions
+import org.komapper.core.dsl.options.TemplateSelectOptions
+import org.komapper.core.dsl.options.UpdateOptions
 import org.komapper.core.dsl.query.DeleteQueryBuilder
 import org.komapper.core.dsl.query.DeleteQueryBuilderImpl
 import org.komapper.core.dsl.query.FlowSubquery
@@ -39,37 +47,25 @@ import org.komapper.core.dsl.query.UpdateQueryBuilderImpl
  * The entry point for constructing queries.
  */
 @ThreadSafe
-object QueryDsl {
+interface QueryDsl {
 
     fun with(
         metamodel: EntityMetamodel<*, *, *>,
         subquery: SubqueryExpression<*>,
-    ): WithQueryDsl {
-        val with = With(false, listOf(metamodel to subquery))
-        return WithQueryDslImpl(with)
-    }
+    ): WithQueryDsl
 
     fun with(
         vararg pairs: Pair<EntityMetamodel<*, *, *>, SubqueryExpression<*>>,
-    ): WithQueryDsl {
-        val with = With(false, pairs.toList())
-        return WithQueryDslImpl(with)
-    }
+    ): WithQueryDsl
 
     fun withRecursive(
         metamodel: EntityMetamodel<*, *, *>,
         subquery: SubqueryExpression<*>,
-    ): WithQueryDsl {
-        val with = With(true, listOf(metamodel to subquery))
-        return WithQueryDslImpl(with)
-    }
+    ): WithQueryDsl
 
     fun withRecursive(
         vararg pairs: Pair<EntityMetamodel<*, *, *>, SubqueryExpression<*>>,
-    ): WithQueryDsl {
-        val with = With(true, pairs.toList())
-        return WithQueryDslImpl(with)
-    }
+    ): WithQueryDsl
 
     /**
      * Creates a SELECT query builder.
@@ -82,9 +78,7 @@ object QueryDsl {
      */
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> from(
         metamodel: META,
-    ): SelectQueryBuilder<ENTITY, ID, META> {
-        return SelectQueryBuilderImpl(SelectContext(metamodel))
-    }
+    ): SelectQueryBuilder<ENTITY, ID, META>
 
     /**
      * Creates a SELECT query builder which uses a derived table.
@@ -99,28 +93,20 @@ object QueryDsl {
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> from(
         metamodel: META,
         subquery: SubqueryExpression<*>,
-    ): SelectQueryBuilder<ENTITY, ID, META> {
-        return SelectQueryBuilderImpl(SelectContext(metamodel, subquery))
-    }
+    ): SelectQueryBuilder<ENTITY, ID, META>
 
-    fun <A : Any> select(expression: ColumnExpression<A, *>): FlowSubquery<A?> {
-        return from(EmptyMetamodel).select(expression)
-    }
+    fun <A : Any> select(expression: ColumnExpression<A, *>): FlowSubquery<A?>
 
     fun <A : Any, B : Any> select(
         expression1: ColumnExpression<A, *>,
         expression2: ColumnExpression<B, *>,
-    ): FlowSubquery<Pair<A?, B?>> {
-        return from(EmptyMetamodel).select(expression1, expression2)
-    }
+    ): FlowSubquery<Pair<A?, B?>>
 
     fun <A : Any, B : Any, C : Any> select(
         expression1: ColumnExpression<A, *>,
         expression2: ColumnExpression<B, *>,
         expression3: ColumnExpression<C, *>,
-    ): FlowSubquery<Triple<A?, B?, C?>> {
-        return from(EmptyMetamodel).select(expression1, expression2, expression3)
-    }
+    ): FlowSubquery<Triple<A?, B?, C?>>
 
     /**
      * Creates a INSERT query builder.
@@ -133,9 +119,7 @@ object QueryDsl {
      */
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> insert(
         metamodel: META,
-    ): InsertQueryBuilder<ENTITY, ID, META> {
-        return InsertQueryBuilderImpl(EntityInsertContext(metamodel))
-    }
+    ): InsertQueryBuilder<ENTITY, ID, META>
 
     /**
      * Creates a UPDATE query builder.
@@ -148,9 +132,7 @@ object QueryDsl {
      */
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> update(
         metamodel: META,
-    ): UpdateQueryBuilder<ENTITY, ID, META> {
-        return UpdateQueryBuilderImpl(EntityUpdateContext(metamodel))
-    }
+    ): UpdateQueryBuilder<ENTITY, ID, META>
 
     /**
      * Creates a DELETE query builder.
@@ -163,9 +145,7 @@ object QueryDsl {
      */
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> delete(
         metamodel: META,
-    ): DeleteQueryBuilder<ENTITY> {
-        return DeleteQueryBuilderImpl(EntityDeleteContext(metamodel))
-    }
+    ): DeleteQueryBuilder<ENTITY>
 
     /**
      * Creates a builder for constructing a SELECT query.
@@ -173,9 +153,7 @@ object QueryDsl {
      * @param sql the sql template
      * @return the builder
      */
-    fun fromTemplate(@Language("sql") sql: String): TemplateSelectQueryBuilder {
-        return TemplateSelectQueryBuilderImpl(TemplateSelectContext(sql))
-    }
+    fun fromTemplate(@Language("sql") sql: String): TemplateSelectQueryBuilder
 
     /**
      * Creates a query for executing an arbitrary command.
@@ -183,52 +161,162 @@ object QueryDsl {
      * @param sql the sql template
      * @return the query
      */
-    fun executeTemplate(@Language("sql") sql: String): TemplateExecuteQuery {
-        return TemplateExecuteQueryImpl(TemplateExecuteContext(sql))
-    }
+    fun executeTemplate(@Language("sql") sql: String): TemplateExecuteQuery
 
     /**
      * Creates a query for executing a script.
      *
      * @param sql the script to execute
      */
-    fun executeScript(@Language("sql") sql: String): ScriptExecuteQuery {
-        return ScriptExecuteQueryImpl(ScriptContext(sql))
-    }
+    fun executeScript(@Language("sql") sql: String): ScriptExecuteQuery
 
     /**
      * Creates a query for creating tables and their associated constraints.
      *
      * @param metamodels the entity metamodels
      */
-    fun create(metamodels: List<EntityMetamodel<*, *, *>>): SchemaCreateQuery {
-        return SchemaCreateQueryImpl(SchemaContext(metamodels))
-    }
+    fun create(metamodels: List<EntityMetamodel<*, *, *>>): SchemaCreateQuery
 
     /**
      * Creates a query for creating tables and their associated constraints.
      *
      * @param metamodels the entity metamodels
      */
-    fun create(vararg metamodels: EntityMetamodel<*, *, *>): SchemaCreateQuery {
+    fun create(vararg metamodels: EntityMetamodel<*, *, *>): SchemaCreateQuery
+
+    /**
+     * Creates a query for dropping tables and their associated constraints.
+     *
+     * @param metamodels the entity metamodels
+     */
+    fun drop(metamodels: List<EntityMetamodel<*, *, *>>): SchemaDropQuery
+
+    /**
+     * Creates a query for dropping tables and their associated constraints.
+     *
+     * @param metamodels the entity metamodels
+     */
+    fun drop(vararg metamodels: EntityMetamodel<*, *, *>): SchemaDropQuery
+
+    companion object : QueryDsl by QueryDsl()
+}
+
+internal class QueryDslImpl(
+    private val deleteOptions: DeleteOptions,
+    private val insertOptions: InsertOptions,
+    private val schemaOptions: SchemaOptions,
+    private val scriptOptions: ScriptOptions,
+    private val selectOptions: SelectOptions,
+    private val templateExecuteOptions: TemplateExecuteOptions,
+    private val templateSelectOptions: TemplateSelectOptions,
+    private val updateOptions: UpdateOptions,
+) : QueryDsl {
+
+    override fun with(
+        metamodel: EntityMetamodel<*, *, *>,
+        subquery: SubqueryExpression<*>,
+    ): WithQueryDsl {
+        val with = With(false, listOf(metamodel to subquery))
+        return WithQueryDslImpl(with, selectOptions)
+    }
+
+    override fun with(
+        vararg pairs: Pair<EntityMetamodel<*, *, *>, SubqueryExpression<*>>,
+    ): WithQueryDsl {
+        val with = With(false, pairs.toList())
+        return WithQueryDslImpl(with, selectOptions)
+    }
+
+    override fun withRecursive(
+        metamodel: EntityMetamodel<*, *, *>,
+        subquery: SubqueryExpression<*>,
+    ): WithQueryDsl {
+        val with = With(true, listOf(metamodel to subquery))
+        return WithQueryDslImpl(with, selectOptions)
+    }
+
+    override fun withRecursive(
+        vararg pairs: Pair<EntityMetamodel<*, *, *>, SubqueryExpression<*>>,
+    ): WithQueryDsl {
+        val with = With(true, pairs.toList())
+        return WithQueryDslImpl(with, selectOptions)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> from(
+        metamodel: META,
+    ): SelectQueryBuilder<ENTITY, ID, META> {
+        return SelectQueryBuilderImpl(SelectContext(metamodel, options = selectOptions))
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> from(
+        metamodel: META,
+        subquery: SubqueryExpression<*>,
+    ): SelectQueryBuilder<ENTITY, ID, META> {
+        return SelectQueryBuilderImpl(SelectContext(metamodel, subquery, options = selectOptions))
+    }
+
+    override fun <A : Any> select(expression: ColumnExpression<A, *>): FlowSubquery<A?> {
+        return from(EmptyMetamodel).select(expression)
+    }
+
+    override fun <A : Any, B : Any> select(
+        expression1: ColumnExpression<A, *>,
+        expression2: ColumnExpression<B, *>,
+    ): FlowSubquery<Pair<A?, B?>> {
+        return from(EmptyMetamodel).select(expression1, expression2)
+    }
+
+    override fun <A : Any, B : Any, C : Any> select(
+        expression1: ColumnExpression<A, *>,
+        expression2: ColumnExpression<B, *>,
+        expression3: ColumnExpression<C, *>,
+    ): FlowSubquery<Triple<A?, B?, C?>> {
+        return from(EmptyMetamodel).select(expression1, expression2, expression3)
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> insert(
+        metamodel: META,
+    ): InsertQueryBuilder<ENTITY, ID, META> {
+        return InsertQueryBuilderImpl(EntityInsertContext(metamodel, options = insertOptions))
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> update(
+        metamodel: META,
+    ): UpdateQueryBuilder<ENTITY, ID, META> {
+        return UpdateQueryBuilderImpl(EntityUpdateContext(metamodel, options = updateOptions))
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> delete(
+        metamodel: META,
+    ): DeleteQueryBuilder<ENTITY> {
+        return DeleteQueryBuilderImpl(EntityDeleteContext(metamodel, options = deleteOptions))
+    }
+
+    override fun fromTemplate(@Language("sql") sql: String): TemplateSelectQueryBuilder {
+        return TemplateSelectQueryBuilderImpl(TemplateSelectContext(sql, options = templateSelectOptions))
+    }
+
+    override fun executeTemplate(@Language("sql") sql: String): TemplateExecuteQuery {
+        return TemplateExecuteQueryImpl(TemplateExecuteContext(sql, options = templateExecuteOptions))
+    }
+
+    override fun executeScript(@Language("sql") sql: String): ScriptExecuteQuery {
+        return ScriptExecuteQueryImpl(ScriptContext(sql, options = scriptOptions))
+    }
+
+    override fun create(metamodels: List<EntityMetamodel<*, *, *>>): SchemaCreateQuery {
+        return SchemaCreateQueryImpl(SchemaContext(metamodels, options = schemaOptions))
+    }
+
+    override fun create(vararg metamodels: EntityMetamodel<*, *, *>): SchemaCreateQuery {
         return create(metamodels.toList())
     }
 
-    /**
-     * Creates a query for dropping tables and their associated constraints.
-     *
-     * @param metamodels the entity metamodels
-     */
-    fun drop(metamodels: List<EntityMetamodel<*, *, *>>): SchemaDropQuery {
-        return SchemaDropQueryImpl(SchemaContext(metamodels))
+    override fun drop(metamodels: List<EntityMetamodel<*, *, *>>): SchemaDropQuery {
+        return SchemaDropQueryImpl(SchemaContext(metamodels, options = schemaOptions))
     }
 
-    /**
-     * Creates a query for dropping tables and their associated constraints.
-     *
-     * @param metamodels the entity metamodels
-     */
-    fun drop(vararg metamodels: EntityMetamodel<*, *, *>): SchemaDropQuery {
+    override fun drop(vararg metamodels: EntityMetamodel<*, *, *>): SchemaDropQuery {
         return drop(metamodels.toList())
     }
 }
@@ -248,10 +336,44 @@ interface WithQueryDsl {
     ): SelectQueryBuilder<ENTITY, ID, META>
 }
 
-internal data class WithQueryDslImpl(private val with: With) : WithQueryDsl {
+internal data class WithQueryDslImpl(private val with: With, private val options: SelectOptions) : WithQueryDsl {
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> from(
         metamodel: META,
     ): SelectQueryBuilder<ENTITY, ID, META> {
-        return SelectQueryBuilderImpl(SelectContext(metamodel, with = with))
+        return SelectQueryBuilderImpl(SelectContext(metamodel, with = with, options = options))
     }
+}
+
+/**
+ * Creates a new instance of [QueryDsl].
+ *
+ * @param deleteOptions the options for DELETE queries
+ * @param insertOptions the options for INSERT queries
+ * @param schemaOptions the options for schema operations
+ * @param scriptOptions the options for script operations
+ * @param selectOptions the options for SELECT queries
+ * @param templateExecuteOptions the options for template execute operations
+ * @param templateSelectOptions the options for template select operations
+ * @param updateOptions the options for UPDATE queries
+ */
+fun QueryDsl(
+    deleteOptions: DeleteOptions = DeleteOptions.DEFAULT,
+    insertOptions: InsertOptions = InsertOptions.DEFAULT,
+    schemaOptions: SchemaOptions = SchemaOptions.DEFAULT,
+    scriptOptions: ScriptOptions = ScriptOptions.DEFAULT,
+    selectOptions: SelectOptions = SelectOptions.DEFAULT,
+    templateExecuteOptions: TemplateExecuteOptions = TemplateExecuteOptions.DEFAULT,
+    templateSelectOptions: TemplateSelectOptions = TemplateSelectOptions.DEFAULT,
+    updateOptions: UpdateOptions = UpdateOptions.DEFAULT,
+): QueryDsl {
+    return QueryDslImpl(
+        deleteOptions,
+        insertOptions,
+        schemaOptions,
+        scriptOptions,
+        selectOptions,
+        templateExecuteOptions,
+        templateSelectOptions,
+        updateOptions,
+    )
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityDeleteContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityDeleteContext.kt
@@ -12,7 +12,7 @@ import org.komapper.core.dsl.options.DeleteOptions
 data class EntityDeleteContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
     override val returning: Returning = Returning.Expressions(emptyList()),
-    override val options: DeleteOptions = DeleteOptions.DEFAULT,
+    override val options: DeleteOptions,
 ) : TablesProvider, WhereProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {
@@ -24,6 +24,6 @@ data class EntityDeleteContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     }
 
     fun asRelationDeleteContext(): RelationDeleteContext<ENTITY, ID, META> {
-        return RelationDeleteContext(target)
+        return RelationDeleteContext(target, options = options)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
@@ -13,7 +13,7 @@ import org.komapper.core.dsl.options.InsertOptions
 data class EntityInsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     val target: META,
     override val returning: Returning = Returning.Expressions(emptyList()),
-    val options: InsertOptions = InsertOptions.DEFAULT,
+    val options: InsertOptions,
 ) : TablesProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpdateContext.kt
@@ -16,7 +16,7 @@ data class EntityUpdateContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     val includedProperties: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
     val excludedProperties: List<PropertyMetamodel<ENTITY, *, *>> = emptyList(),
     override val returning: Returning = Returning.Expressions(emptyList()),
-    override val options: UpdateOptions = UpdateOptions.DEFAULT,
+    override val options: UpdateOptions,
 ) : TablesProvider, WhereProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {
@@ -41,6 +41,6 @@ data class EntityUpdateContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     }
 
     fun asRelationUpdateContext(declaration: AssignmentDeclaration<ENTITY, META>): RelationUpdateContext<ENTITY, ID, META> {
-        return RelationUpdateContext(target, declaration)
+        return RelationUpdateContext(target, declaration, options = options)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationDeleteContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationDeleteContext.kt
@@ -14,7 +14,7 @@ data class RelationDeleteContext<ENTITY : Any, ID : Any, META : EntityMetamodel<
     val target: META,
     val where: WhereDeclaration = {},
     override val returning: Returning = Returning.Expressions(emptyList()),
-    override val options: DeleteOptions = DeleteOptions.DEFAULT,
+    override val options: DeleteOptions,
 ) : TablesProvider, WhereProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationUpdateContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/RelationUpdateContext.kt
@@ -16,7 +16,7 @@ data class RelationUpdateContext<ENTITY : Any, ID : Any, META : EntityMetamodel<
     val set: AssignmentDeclaration<ENTITY, META> = {},
     val where: WhereDeclaration = { },
     override val returning: Returning = Returning.Expressions(emptyList()),
-    override val options: UpdateOptions = UpdateOptions.DEFAULT,
+    override val options: UpdateOptions,
 ) : TablesProvider, WhereProvider, ReturningProvider {
 
     override fun getTables(): Set<TableExpression<*>> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SchemaContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SchemaContext.kt
@@ -7,5 +7,5 @@ import org.komapper.core.dsl.options.SchemaOptions
 @ThreadSafe
 data class SchemaContext(
     val metamodels: List<EntityMetamodel<*, *, *>> = emptyList(),
-    val options: SchemaOptions = SchemaOptions.DEFAULT,
+    val options: SchemaOptions,
 )

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/ScriptContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/ScriptContext.kt
@@ -6,5 +6,5 @@ import org.komapper.core.dsl.options.ScriptOptions
 @ThreadSafe
 data class ScriptContext(
     val sql: String = "",
-    val options: ScriptOptions = ScriptOptions.DEFAULT,
+    val options: ScriptOptions,
 )

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SelectContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SelectContext.kt
@@ -33,7 +33,7 @@ data class SelectContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, 
     val having: HavingDeclaration = {},
     val include: List<EntityMetamodel<*, *, *>> = listOf(),
     val includeAll: Boolean = false,
-    override val options: SelectOptions = SelectOptions.DEFAULT,
+    override val options: SelectOptions,
 ) : TablesProvider, WhereProvider, SubqueryContext {
 
     fun getProjection(): Projection {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SetOperationContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SetOperationContext.kt
@@ -12,7 +12,7 @@ data class SetOperationContext(
     val left: SubqueryContext,
     val right: SubqueryContext,
     val orderBy: List<SortItem> = listOf(),
-    val options: SelectOptions = SelectOptions.DEFAULT,
+    override val options: SelectOptions,
 ) : TablesProvider, SubqueryContext {
 
     fun getProjection(): Projection {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SubqueryContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SubqueryContext.kt
@@ -1,6 +1,9 @@
 package org.komapper.core.dsl.context
 
 import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.options.SelectOptions
 
 @ThreadSafe
-sealed interface SubqueryContext
+sealed interface SubqueryContext {
+    val options: SelectOptions
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/DeleteOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/DeleteOptions.kt
@@ -1,13 +1,13 @@
 package org.komapper.core.dsl.options
 
 data class DeleteOptions(
-    override val allowMissingWhereClause: Boolean,
-    override val batchSize: Int? = null,
-    override val escapeSequence: String?,
-    override val disableOptimisticLock: Boolean,
-    override val queryTimeoutSeconds: Int?,
-    override val suppressLogging: Boolean,
-    override val suppressOptimisticLockException: Boolean,
+    override val allowMissingWhereClause: Boolean = DEFAULT.allowMissingWhereClause,
+    override val batchSize: Int? = DEFAULT.batchSize,
+    override val escapeSequence: String? = DEFAULT.escapeSequence,
+    override val disableOptimisticLock: Boolean = DEFAULT.disableOptimisticLock,
+    override val queryTimeoutSeconds: Int? = DEFAULT.queryTimeoutSeconds,
+    override val suppressLogging: Boolean = DEFAULT.suppressLogging,
+    override val suppressOptimisticLockException: Boolean = DEFAULT.suppressOptimisticLockException,
 ) : BatchOptions, OptimisticLockOptions, WhereOptions {
 
     companion object {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/InsertOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/InsertOptions.kt
@@ -1,16 +1,16 @@
 package org.komapper.core.dsl.options
 
 data class InsertOptions(
-    override val batchSize: Int?,
+    override val batchSize: Int? = DEFAULT.batchSize,
     /**
      * Whether to disable assigning sequence-numbered values to primary keys.
      */
-    val disableSequenceAssignment: Boolean,
-    val returnGeneratedKeys: Boolean,
-    override val queryTimeoutSeconds: Int?,
-    override val suppressLogging: Boolean,
-    override val allowMissingWhereClause: Boolean,
-    override val escapeSequence: String?,
+    val disableSequenceAssignment: Boolean = DEFAULT.disableSequenceAssignment,
+    val returnGeneratedKeys: Boolean = DEFAULT.returnGeneratedKeys,
+    override val queryTimeoutSeconds: Int? = DEFAULT.queryTimeoutSeconds,
+    override val suppressLogging: Boolean = DEFAULT.suppressLogging,
+    override val allowMissingWhereClause: Boolean = DEFAULT.allowMissingWhereClause,
+    override val escapeSequence: String? = DEFAULT.escapeSequence,
 ) : WhereOptions, BatchOptions, QueryOptions {
 
     companion object {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/SchemaOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/SchemaOptions.kt
@@ -1,8 +1,8 @@
 package org.komapper.core.dsl.options
 
 data class SchemaOptions(
-    override val queryTimeoutSeconds: Int?,
-    override val suppressLogging: Boolean,
+    override val queryTimeoutSeconds: Int? = DEFAULT.queryTimeoutSeconds,
+    override val suppressLogging: Boolean = DEFAULT.suppressLogging,
 ) : QueryOptions {
 
     companion object {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/ScriptOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/ScriptOptions.kt
@@ -1,9 +1,9 @@
 package org.komapper.core.dsl.options
 
 data class ScriptOptions(
-    val separator: String,
-    override val queryTimeoutSeconds: Int?,
-    override val suppressLogging: Boolean,
+    val separator: String = DEFAULT.separator,
+    override val queryTimeoutSeconds: Int? = DEFAULT.queryTimeoutSeconds,
+    override val suppressLogging: Boolean = DEFAULT.suppressLogging,
 ) : QueryOptions {
 
     companion object {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/SelectOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/SelectOptions.kt
@@ -1,12 +1,12 @@
 package org.komapper.core.dsl.options
 
 data class SelectOptions(
-    override val allowMissingWhereClause: Boolean,
-    override val escapeSequence: String?,
-    override val fetchSize: Int?,
-    override val maxRows: Int?,
-    override val queryTimeoutSeconds: Int?,
-    override val suppressLogging: Boolean,
+    override val allowMissingWhereClause: Boolean = DEFAULT.allowMissingWhereClause,
+    override val escapeSequence: String? = DEFAULT.escapeSequence,
+    override val fetchSize: Int? = DEFAULT.fetchSize,
+    override val maxRows: Int? = DEFAULT.maxRows,
+    override val queryTimeoutSeconds: Int? = DEFAULT.queryTimeoutSeconds,
+    override val suppressLogging: Boolean = DEFAULT.suppressLogging,
 ) : FetchOptions, WhereOptions {
 
     companion object {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/TemplateExecuteOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/TemplateExecuteOptions.kt
@@ -7,9 +7,9 @@ data class TemplateExecuteOptions(
      * The escape sequence to be used in the LIKE predicate.
      * If null is returned, the value of [Dialect.escapeSequence] will be used.
      */
-    val escapeSequence: String?,
-    override val queryTimeoutSeconds: Int?,
-    override val suppressLogging: Boolean,
+    val escapeSequence: String? = DEFAULT.escapeSequence,
+    override val queryTimeoutSeconds: Int? = DEFAULT.queryTimeoutSeconds,
+    override val suppressLogging: Boolean = DEFAULT.suppressLogging,
 ) : QueryOptions {
 
     companion object {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/TemplateSelectOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/TemplateSelectOptions.kt
@@ -7,11 +7,11 @@ data class TemplateSelectOptions(
      * The escape sequence to be used in the LIKE predicate.
      * If null is returned, the value of [Dialect.escapeSequence] will be used.
      */
-    val escapeSequence: String?,
-    override val fetchSize: Int?,
-    override val maxRows: Int?,
-    override val queryTimeoutSeconds: Int?,
-    override val suppressLogging: Boolean,
+    val escapeSequence: String? = DEFAULT.escapeSequence,
+    override val fetchSize: Int? = DEFAULT.fetchSize,
+    override val maxRows: Int? = DEFAULT.maxRows,
+    override val queryTimeoutSeconds: Int? = DEFAULT.queryTimeoutSeconds,
+    override val suppressLogging: Boolean = DEFAULT.suppressLogging,
 ) : FetchOptions {
 
     companion object {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/UpdateOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/UpdateOptions.kt
@@ -1,13 +1,13 @@
 package org.komapper.core.dsl.options
 
 data class UpdateOptions(
-    override val allowMissingWhereClause: Boolean,
-    override val batchSize: Int?,
-    override val escapeSequence: String?,
-    override val disableOptimisticLock: Boolean,
-    override val queryTimeoutSeconds: Int?,
-    override val suppressLogging: Boolean,
-    override val suppressOptimisticLockException: Boolean,
+    override val allowMissingWhereClause: Boolean = DEFAULT.allowMissingWhereClause,
+    override val batchSize: Int? = DEFAULT.batchSize,
+    override val escapeSequence: String? = DEFAULT.escapeSequence,
+    override val disableOptimisticLock: Boolean = DEFAULT.disableOptimisticLock,
+    override val queryTimeoutSeconds: Int? = DEFAULT.queryTimeoutSeconds,
+    override val suppressLogging: Boolean = DEFAULT.suppressLogging,
+    override val suppressOptimisticLockException: Boolean = DEFAULT.suppressOptimisticLockException,
 ) : BatchOptions, OptimisticLockOptions, WhereOptions {
 
     companion object {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/FlowSubquerySupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/FlowSubquerySupport.kt
@@ -30,7 +30,7 @@ internal class FlowSubquerySupport<T>(
         kind: SetOperationKind,
         other: SubqueryExpression<T>,
     ): FlowSetOperationQuery<T> {
-        val setOperatorContext = SetOperationContext(kind, context, other.context)
+        val setOperatorContext = SetOperationContext(kind, context, other.context, options = context.options)
         return transform(setOperatorContext)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SelectQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/SelectQueryBuilder.kt
@@ -119,7 +119,7 @@ internal data class SelectQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
         left: SubqueryExpression<ENTITY>,
         right: SubqueryExpression<ENTITY>,
     ): FlowSetOperationQuery<ENTITY> {
-        val setOperatorContext = SetOperationContext(kind, left.context, right.context)
+        val setOperatorContext = SetOperationContext(kind, left.context, right.context, options = left.context.options)
         return RelationSetOperationQueryImpl(setOperatorContext, metamodel = context.target)
     }
 


### PR DESCRIPTION
Previously, it was necessary to set query options for each query.

```kotlin
val a = Meta.address

val query1 = QueryDsl.from(a)
    .options {
        it.copy(
            queryTimeoutSeconds = 10,
        )
    }
val list1 = db.runQuery(query1)

val query2 = QueryDsl.from(a)
    .where { a.addressId greater 10 }
    .options {
        it.copy(
            queryTimeoutSeconds = 10,
        )
    }
val list2 = db.runQuery(query2)
```

From now on, you will only need to configure the query options once for each instantiated QueryDsl. The query options will be shared across the same instance.

```kotlin
val myDsl = QueryDsl(selectOptions = SelectOptions(queryTimeoutSeconds = 10))    
val a = Meta.address

val query1 = myDsl.from(a)
val list1 = db.runQuery(query1)

val query2 = myDsl.from(a).where { a.addressId greater 10 }
val list2 = db.runQuery(query2)
```

Of course, the previous notation will continue to be supported.