### PR TITLE
Extract the driver even if "pool" is included in the R2DBC connection URL

### DIFF
--- a/example-spring-boot-r2dbc/src/main/resources/application.properties
+++ b/example-spring-boot-r2dbc/src/main/resources/application.properties
@@ -1,3 +1,3 @@
-spring.r2dbc.url=r2dbc:h2:mem:///example;DB_CLOSE_DELAY=-1
+spring.r2dbc.url=r2dbc:pool:h2:mem:///example;DB_CLOSE_DELAY=-1
 logging.level.org.komapper.Sql=DEBUG
 logging.level.org.springframework.transaction.interceptor=TRACE

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDialects.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcDialects.kt
@@ -10,7 +10,7 @@ import java.util.regex.Pattern
  * The provider of [R2dbcDialect]
  */
 object R2dbcDialects {
-    private val r2dbcUrlPattern = Pattern.compile("^r2dbc[s]?:(tc:)?([^:]*):.*")
+    private val r2dbcUrlPattern = Pattern.compile("^r2dbc[s]?:(tc:)?(pool:)?([^:]*):.*")
 
     /**
      * @param driver the R2DBC driver name
@@ -60,7 +60,7 @@ object R2dbcDialects {
     fun extractR2dbcDriver(url: String): String {
         val matcher = r2dbcUrlPattern.matcher(url)
         if (matcher.matches()) {
-            return matcher.group(2).lowercase()
+            return matcher.group(3).lowercase()
         }
         error("The driver is not found in the R2DBC URL. url=$url")
     }

--- a/komapper-r2dbc/src/test/kotlin/org/komapper/r2dbc/R2dbcDialectsTest.kt
+++ b/komapper-r2dbc/src/test/kotlin/org/komapper/r2dbc/R2dbcDialectsTest.kt
@@ -33,6 +33,18 @@ class R2dbcDialectsTest {
     }
 
     @Test
+    fun extractR2dbcDriver_testcontainers_pool() {
+        val driver = R2dbcDialects.extractR2dbcDriver("r2dbc:tc:pool:h2:mem:///testdb")
+        assertEquals("h2", driver)
+    }
+
+    @Test
+    fun extractR2dbcDriver_pool() {
+        val driver = R2dbcDialects.extractR2dbcDriver("r2dbc:pool:h2:mem:///testdb")
+        assertEquals("h2", driver)
+    }
+
+    @Test
     fun extractR2dbcDriver_error() {
         assertFailsWith<IllegalStateException> {
             R2dbcDialects.extractR2dbcDriver("jdbc:h2:mem:///testdb")


### PR DESCRIPTION
For example, this PR can extract the string "h2" from the following connection URL:

- r2dbc:pool:h2:mem:///testdb