### PR TITLE
Prevent elements from being used across rounds

### DIFF
--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelFactoryProcessor.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelFactoryProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.KSAnnotated
-import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFile
 import org.komapper.processor.Symbols.EntityMetamodelFactory
 import org.komapper.processor.Symbols.EntityMetamodelFactorySpi
 import java.io.PrintWriter
@@ -15,18 +15,20 @@ internal class EntityMetamodelFactoryProcessor(
 ) :
     SymbolProcessor {
 
-    private val classDeclarations: MutableList<KSClassDeclaration> = mutableListOf()
+    private val fileMap: MutableMap<String, KSFile> = mutableMapOf()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val symbols = resolver.getSymbolsWithAnnotation(EntityMetamodelFactory)
         val declarations = symbols.map { it.accept(ClassDeclarationVisitor(), Unit) }.filterNotNull().toList()
-        classDeclarations.addAll(declarations)
+        declarations
+            .map { it.qualifiedName to it.containingFile }
+            .filter { it.first != null && it.second != null }
+            .associateTo(fileMap) { it.first!!.asString() to it.second!! }
         return emptyList()
     }
 
     override fun finish() {
-        val files = classDeclarations.mapNotNull { it.containingFile }
-        val dependencies = Dependencies(true, *files.toTypedArray())
+        val dependencies = Dependencies(true, *fileMap.values.toTypedArray())
         environment.codeGenerator.createNewFile(
             dependencies,
             "META-INF/services",
@@ -34,11 +36,8 @@ internal class EntityMetamodelFactoryProcessor(
             "",
         ).use { out ->
             PrintWriter(out).use { writer ->
-                for (classDeclaration in classDeclarations) {
-                    val name = classDeclaration.qualifiedName?.asString()
-                    if (name != null) {
-                        writer.println(name)
-                    }
+                for (name in fileMap.keys) {
+                    writer.println(name)
                 }
             }
         }


### PR DESCRIPTION
This PR avoids KtInvalidLifetimeOwnerAccessException in KSP 2.0.0-1.0.24.

For more details: https://github.com/google/ksp/issues/1854