### PR TITLE
Add get operator to EntityMetamodel

### DIFF
--- a/integration-test-core/src/test/kotlin/integration/core/EntityMetamodelTest.kt
+++ b/integration-test-core/src/test/kotlin/integration/core/EntityMetamodelTest.kt
@@ -1,0 +1,40 @@
+package integration.core
+
+import org.junit.jupiter.api.Assertions.assertNull
+import org.komapper.core.dsl.Meta
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class EntityMetamodelTest {
+
+    @Test
+    fun get() {
+        val a = Meta.address
+        assertEquals(a.addressId, a["addressId"])
+        assertEquals(a.street, a["street"])
+        assertNull(a["unknown"])
+
+        val b = Meta.address.clone()
+        assertEquals(b.addressId, b["addressId"])
+        assertEquals(b.street, b["street"])
+        assertNull(b["unknown"])
+
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun properties() {
+        val a = Meta.address
+        assertEquals(a.addressId, a.properties().find { it.name == "addressId" })
+        assertEquals(a.street, a.properties().find { it.name == "street" })
+        assertNull(a.properties().find { it.name == "unknown" })
+
+        val b = Meta.address.clone()
+        assertEquals(b.addressId, b.properties().find { it.name == "addressId" })
+        assertEquals(b.street, b.properties().find { it.name == "street" })
+        assertNull(b.properties().find { it.name == "unknown" })
+
+        assertNotEquals(a, b)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ColumnExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ColumnExpression.kt
@@ -5,21 +5,59 @@ import kotlin.reflect.KType
 sealed interface InteriorExpression<out INTERIOR>
 
 /**
- * The column expression.
+ * Represents a column expression in the DSL.
+ * This interface provides methods to access various properties of the column.
  *
  * @param EXTERIOR the exterior type of expression evaluation
  * @param INTERIOR the interior type of expression evaluation
  */
 sealed interface ColumnExpression<EXTERIOR : Any, INTERIOR : Any> : SortExpression, InteriorExpression<INTERIOR> {
+    /**
+     * The owner table expression.
+     */
     val owner: TableExpression<*>
+
+    /**
+     * The exterior type of the column.
+     */
     val exteriorType: KType
+
+    /**
+     * The interior type of the column.
+     */
     val interiorType: KType
+
+    /**
+     * A function that wraps an interior type value to an exterior type value.
+     */
     val wrap: (INTERIOR) -> EXTERIOR
+
+    /**
+     * A function that unwraps an exterior type value to an interior type value.
+     */
     val unwrap: (EXTERIOR) -> INTERIOR
+
+    /**
+     * The name of the column.
+     */
     val columnName: String
+
+    /**
+     * Indicates whether the column name should always be quoted.
+     */
     val alwaysQuote: Boolean
+
+    /**
+     * Indicates whether the column should be masked.
+     */
     val masking: Boolean
 
+    /**
+     * Returns the canonical name of the column, optionally quoting it.
+     *
+     * @param enquote a function that quotes a string
+     * @return the canonical name of the column
+     */
     fun getCanonicalColumnName(enquote: (String) -> String): String {
         val transform = if (alwaysQuote) {
             enquote

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/PropertyExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/PropertyExpression.kt
@@ -1,3 +1,9 @@
 package org.komapper.core.dsl.expression
 
+/**
+ * Represents a property expression that maps an exterior type to an interior type.
+ *
+ * @param EXTERIOR the exterior type
+ * @param INTERIOR the interior type
+ */
 interface PropertyExpression<EXTERIOR : Any, INTERIOR : Any> : ColumnExpression<EXTERIOR, INTERIOR>

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/TableExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/TableExpression.kt
@@ -3,15 +3,69 @@ package org.komapper.core.dsl.expression
 import org.komapper.core.ThreadSafe
 import kotlin.reflect.KClass
 
+/**
+ * Represents a table expression in the DSL.
+ * This interface provides methods to access various properties of the table.
+ *
+ * @param T The type of the entity associated with the table.
+ */
 @ThreadSafe
 interface TableExpression<T : Any> {
+    /**
+     * Returns the KClass of the entity.
+     *
+     * @return The KClass of the entity.
+     */
     fun klass(): KClass<T>
+
+    /**
+     * Returns the name of the table.
+     *
+     * @return The name of the table.
+     */
     fun tableName(): String
+
+    /**
+     * Returns the name of the catalog.
+     *
+     * @return The name of the catalog.
+     */
     fun catalogName(): String
+
+    /**
+     * Returns the name of the schema.
+     *
+     * @return The name of the schema.
+     */
     fun schemaName(): String
+
+    /**
+     * Returns whether the table name should be quoted.
+     *
+     * @return `true` if the table name should be quoted, `false` otherwise.
+     */
     fun alwaysQuote(): Boolean
+
+    /**
+     * Returns whether the sequence assignment is disabled.
+     *
+     * @return `true` if the sequence assignment is disabled, `false` otherwise.
+     */
     fun disableSequenceAssignment(): Boolean
+
+    /**
+     * Returns whether the auto increment is disabled.
+     *
+     * @return `true` if the auto increment is disabled, `false` otherwise.
+     */
     fun disableAutoIncrement(): Boolean = false
+
+    /**
+     * Returns the canonical table name.
+     *
+     * @param enquote The function to quote the table name.
+     * @return The canonical table name.
+     */
     fun getCanonicalTableName(enquote: (String) -> String): String {
         val transform = if (alwaysQuote()) {
             enquote

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
@@ -6,6 +6,14 @@ import org.komapper.core.dsl.expression.TableExpression
 import java.time.Clock
 import kotlin.reflect.KClass
 
+/**
+ * This interface represents the metamodel of an entity.
+ * It provides methods to access and manipulate the properties of the entity.
+ *
+ * @param ENTITY The type of the entity.
+ * @param ID The type of the entity's identifier.
+ * @param META The type of the metamodel.
+ */
 @ThreadSafe
 interface EntityMetamodel<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> : TableExpression<ENTITY> {
     companion object {
@@ -15,29 +23,178 @@ interface EntityMetamodel<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY,
          */
         const val METAMODEL_VERSION: Int = 2
     }
+
+    /**
+     * Returns the declaration of the metamodel.
+     *
+     * @return The declaration of the metamodel.
+     */
     fun declaration(): EntityMetamodelDeclaration<META>
+
+    /**
+     * Returns the ID generator of the entity.
+     * The ID generator is responsible for generating unique identifiers for each entity instance.
+     * This method may return null if the entity does not have an ID generator.
+     *
+     * @return The ID generator of the entity, or null if none exists.
+     */
     fun idGenerator(): IdGenerator<ENTITY, ID>?
+
+    /**
+     * Returns the ID properties of the entity.
+     * The ID properties are the properties that uniquely identify an entity.
+     *
+     * @return A list of PropertyMetamodel objects representing the ID properties of the entity.
+     */
     fun idProperties(): List<PropertyMetamodel<ENTITY, *, *>>
+
+    /**
+     * Returns the virtual ID properties of the entity.
+     * Virtual ID properties are additional properties that can be used to identify an entity.
+     * By default, this method returns an empty list.
+     *
+     * @return A list of PropertyMetamodel objects representing the virtual ID properties of the entity.
+     */
     fun virtualIdProperties(): List<PropertyMetamodel<ENTITY, *, *>> = emptyList()
+
+    /**
+     * Returns the version property of the entity.
+     * The version property is used to implement optimistic locking.
+     *
+     * @return The PropertyMetamodel object representing the version property of the entity, or null if none exists.
+     */
     fun versionProperty(): PropertyMetamodel<ENTITY, *, *>?
+
+    /**
+     * Returns the created-at property of the entity.
+     * The created-at property is used to store the timestamp when the entity was created.
+     *
+     * @return The PropertyMetamodel object representing the created-at property of the entity, or null if none exists.
+     */
     fun createdAtProperty(): PropertyMetamodel<ENTITY, *, *>?
+
+    /**
+     * Returns the updated-at property of the entity.
+     * The updated-at property is used to store the timestamp when the entity was last updated.
+     *
+     * @return The PropertyMetamodel object representing the updated-at property of the entity, or null if none exists.
+     */
     fun updatedAtProperty(): PropertyMetamodel<ENTITY, *, *>?
+
+    /**
+     * Returns the properties of the entity.
+     * The properties are the fields or columns of the entity.
+     *
+     * @return A list of PropertyMetamodel objects representing the properties of the entity.
+     */
     fun properties(): List<PropertyMetamodel<ENTITY, *, *>>
+
+    /**
+     * Extracts the ID from the given entity.
+     * This method retrieves the identifier of the entity.
+     *
+     * @param e The entity from which to extract the ID.
+     * @return The ID of the entity.
+     */
     fun extractId(e: ENTITY): ID
+
+    /**
+     * Converts the generated key to the entity's ID.
+     * This method is used to convert a generated key (e.g., from a database auto-incremented value) to the entity's identifier type.
+     *
+     * @param generatedKey The generated key to convert.
+     * @return The converted ID, or null if the conversion is not possible.
+     */
     fun convertToId(generatedKey: Long): ID?
+
+    /**
+     * Returns the version assignment for the entity.
+     * The version assignment is used to implement optimistic locking by assigning a version value to the entity.
+     *
+     * @return A pair containing the version property and the operand representing the version value, or null if no version property exists.
+     */
     fun versionAssignment(): Pair<PropertyMetamodel<ENTITY, *, *>, Operand>?
+
+    /**
+     * Returns the created-at assignment for the entity.
+     * The created-at assignment is used to set the timestamp when the entity was created.
+     *
+     * @param c The clock used to generate the timestamp.
+     * @return A pair containing the created-at property and the operand representing the timestamp, or null if no created-at property exists.
+     */
     fun createdAtAssignment(c: Clock): Pair<PropertyMetamodel<ENTITY, *, *>, Operand>?
+
+    /**
+     * Returns the updated-at assignment for the entity.
+     * The updated-at assignment is used to set the timestamp when the entity was last updated.
+     *
+     * @param c The clock used to generate the timestamp.
+     * @return A pair containing the updated-at property and the operand representing the timestamp, or null if no updated-at property exists.
+     */
     fun updatedAtAssignment(c: Clock): Pair<PropertyMetamodel<ENTITY, *, *>, Operand>?
+
+    /**
+     * Pre-insert hook for the entity.
+     * This method is called before the entity is inserted into the database.
+     *
+     * @param e The entity to be inserted.
+     * @param c The clock used to generate the timestamp.
+     * @return The entity to be inserted, possibly modified.
+     */
     fun preInsert(e: ENTITY, c: Clock): ENTITY
+
+    /**
+     * Pre-update hook for the entity.
+     * This method is called before the entity is updated in the database.
+     *
+     * @param e The entity to be updated.
+     * @param c The clock used to generate the timestamp.
+     * @return The entity to be updated, possibly modified.
+     */
     fun preUpdate(e: ENTITY, c: Clock): ENTITY
+
+    /**
+     * Post-update hook for the entity.
+     * This method is called after the entity is updated in the database.
+     *
+     * @param e The entity that was updated.
+     * @return The updated entity, possibly modified.
+     */
     fun postUpdate(e: ENTITY): ENTITY
 
+    /**
+     * Retrieves a property metamodel by its name.
+     * This method searches for a property metamodel with the specified name among the entity's properties.
+     *
+     * @param name The name of the property to retrieve.
+     * @return The PropertyMetamodel object representing the property, or null if no property with the specified name exists.
+     */
     operator fun get(name: String): PropertyMetamodel<ENTITY, *, *>? {
         return properties().find { it.name == name }
     }
 
+    /**
+     * Creates a new entity instance from the given property values.
+     * This method constructs a new entity using the provided map of property metamodels and their corresponding values.
+     *
+     * @param m A map where the keys are PropertyMetamodel objects and the values are the property values.
+     * @return A new instance of the entity.
+     */
     fun newEntity(m: Map<PropertyMetamodel<*, *, *>, Any?>): ENTITY
 
+    /**
+     * Creates a new metamodel instance with the specified parameters.
+     * This method constructs a new metamodel using the provided table, catalog, schema, and other settings.
+     *
+     * @param table The name of the table.
+     * @param catalog The name of the catalog.
+     * @param schema The name of the schema.
+     * @param alwaysQuote Whether to always quote identifiers.
+     * @param disableSequenceAssignment Whether to disable sequence assignment.
+     * @param declaration The declaration of the metamodel.
+     * @param disableAutoIncrement Whether to disable auto-increment (default is false).
+     * @return A new instance of the metamodel.
+     */
     fun newMetamodel(
         table: String,
         catalog: String,
@@ -49,6 +206,14 @@ interface EntityMetamodel<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY,
     ): META
 }
 
+/**
+ * Abstract class representing a stub implementation of the EntityMetamodel interface.
+ * This class provides default implementations for the methods in the EntityMetamodel interface,
+ * which throw an error indicating that the method needs to be implemented.
+ *
+ * @param ENTITY The type of the entity.
+ * @param META The type of the metamodel.
+ */
 @Suppress("unused")
 abstract class EntityMetamodelStub<ENTITY : Any, META : EntityMetamodelStub<ENTITY, META>> :
     EntityMetamodel<ENTITY, Any, META> {
@@ -90,6 +255,11 @@ abstract class EntityMetamodelStub<ENTITY : Any, META : EntityMetamodelStub<ENTI
     }
 }
 
+/**
+ * An internal object representing an empty metamodel.
+ * This object provides default implementations for the methods in the EntityMetamodel interface,
+ * which throw an UnsupportedOperationException.
+ */
 internal object EmptyMetamodel : EntityMetamodel<Nothing, Nothing, EmptyMetamodel> {
     override fun declaration(): EntityMetamodelDeclaration<EmptyMetamodel> {
         return {}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodel.kt
@@ -31,6 +31,11 @@ interface EntityMetamodel<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY,
     fun preInsert(e: ENTITY, c: Clock): ENTITY
     fun preUpdate(e: ENTITY, c: Clock): ENTITY
     fun postUpdate(e: ENTITY): ENTITY
+
+    operator fun get(name: String): PropertyMetamodel<ENTITY, *, *>? {
+        return properties().find { it.name == name }
+    }
+
     fun newEntity(m: Map<PropertyMetamodel<*, *, *>, Any?>): ENTITY
 
     fun newMetamodel(

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodelDeclaration.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodelDeclaration.kt
@@ -1,7 +1,22 @@
 package org.komapper.core.dsl.metamodel
 
+/**
+ * A type alias for a function that takes an EntityMetamodelScope and a META instance, and returns Unit.
+ *
+ * @param META The type of the metamodel.
+ */
 typealias EntityMetamodelDeclaration<META> = EntityMetamodelScope.(META) -> Unit
 
+/**
+ * Combines two EntityMetamodelDeclaration functions into a single declaration.
+ * This operator function allows chaining of two metamodel declarations.
+ *
+ * @param ENTITY The type of the entity.
+ * @param ID The type of the entity's identifier.
+ * @param META The type of the metamodel.
+ * @param other Another EntityMetamodelDeclaration to be combined with the current one.
+ * @return A new EntityMetamodelDeclaration that combines the current and the other declaration.
+ */
 infix operator fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> EntityMetamodelDeclaration<META>.plus(
     other: EntityMetamodelDeclaration<META>,
 ): EntityMetamodelDeclaration<META> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodelScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodelScope.kt
@@ -4,10 +4,24 @@ import org.komapper.core.Scope
 import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.operator.plus
 
+/**
+ * A scope for defining metamodel-related declarations.
+ * This class is used internally to manage where declarations within the metamodel.
+ */
 @Scope
 class EntityMetamodelScope {
+    /**
+     * The where declaration used to filter entities.
+     * This is an internal property that accumulates where conditions.
+     */
     internal var where: WhereDeclaration = {}
 
+    /**
+     * Adds a where declaration to the current scope.
+     * This method allows chaining multiple where conditions.
+     *
+     * @param declaration The where declaration to be added.
+     */
     fun where(declaration: WhereDeclaration) {
         where += declaration
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/PropertyMetamodel.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/PropertyMetamodel.kt
@@ -5,14 +5,50 @@ import org.komapper.core.Value
 import org.komapper.core.dsl.expression.PropertyExpression
 import kotlin.reflect.KType
 
+/**
+ * Represents a property metamodel that maps an entity type to exterior and interior types.
+ *
+ * @param ENTITY the entity type
+ * @param EXTERIOR the exterior type
+ * @param INTERIOR the interior type
+ */
 @ThreadSafe
 interface PropertyMetamodel<ENTITY : Any, EXTERIOR : Any, INTERIOR : Any> : PropertyExpression<EXTERIOR, INTERIOR> {
     override val owner: EntityMetamodel<ENTITY, *, *>
+
+    /**
+     * The name of the property.
+     */
     val name: String
+
+    /**
+     * A function that retrieves the exterior type value from the given entity.
+     *
+     * @param ENTITY the entity type
+     * @return the exterior type value or null if not present
+     */
     val getter: (ENTITY) -> EXTERIOR?
+
+    /**
+     * A function that sets the exterior type value to the given entity.
+     *
+     * @param ENTITY the entity type
+     * @param EXTERIOR the exterior type
+     * @return the updated entity
+     */
     val setter: (ENTITY, EXTERIOR) -> ENTITY
+
+    /**
+     * Indicates whether the property is nullable.
+     */
     val nullable: Boolean
 
+    /**
+     * Converts the given entity to a `Value` object containing the interior type.
+     *
+     * @param entity the entity to convert
+     * @return a `Value` object containing the interior type
+     */
     fun toValue(entity: ENTITY): Value<INTERIOR> {
         val exterior = getter(entity)
         val interior = if (exterior == null) null else unwrap(exterior)

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/BackquotedSymbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/BackquotedSymbols.kt
@@ -25,6 +25,7 @@ internal object BackquotedSymbols {
     const val KClass = "`kotlin.reflect`.KClass"
     const val KomapperExperimentalAssociation = "`org.komapper.annotation`.KomapperExperimentalAssociation"
     const val LocalDateTime = "`java.time`.LocalDateTime"
+    const val Map = "`kotlin.collections`.Map"
     const val Operand = "`org.komapper.core.dsl.expression`.Operand"
     const val ProjectionType = "`org.komapper.core.dsl.query`.ProjectionType"
     const val ProjectionType_INDEX = "`org.komapper.core.dsl.query`.ProjectionType.INDEX"

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/BackquotedSymbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/BackquotedSymbols.kt
@@ -1,6 +1,7 @@
 package org.komapper.processor
 
 internal object BackquotedSymbols {
+    const val typeOf = "`kotlin.reflect`.typeOf"
     const val Argument = "`org.komapper.core.dsl.expression`.Operand.Argument"
     const val AutoIncrement = "`org.komapper.core.dsl.metamodel`.IdGenerator.AutoIncrement"
     const val Clock = "`java.time`.Clock"

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -36,6 +36,7 @@ import org.komapper.processor.BackquotedSymbols.Sequence
 import org.komapper.processor.BackquotedSymbols.TemplateSelectQuery
 import org.komapper.processor.BackquotedSymbols.TemplateSelectQueryBuilder
 import org.komapper.processor.BackquotedSymbols.UUID
+import org.komapper.processor.BackquotedSymbols.typeOf
 import org.komapper.processor.Symbols.KotlinInstant
 import org.komapper.processor.Symbols.KotlinLocalDateTime
 import org.komapper.processor.Symbols.checkMetamodelVersion
@@ -184,8 +185,8 @@ internal class EntityMetamodelGenerator(
         fun leafPropertyDescriptor(p: LeafProperty, getter: String, setter: String, nullability: Nullability): String {
             val exteriorTypeName = p.exteriorTypeName
             val interiorTypeName = p.interiorTypeName
-            val exteriorType = "kotlin.reflect.typeOf<$exteriorTypeName>()"
-            val interiorType = "kotlin.reflect.typeOf<$interiorTypeName>()"
+            val exteriorType = "$typeOf<$exteriorTypeName>()"
+            val interiorType = "$typeOf<$interiorTypeName>()"
             val columnName = "\"${p.column.name}\""
             val alwaysQuote = "${p.column.alwaysQuote}"
             val masking = "${p.column.masking}"

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/EntityMetamodelGenerator.kt
@@ -24,6 +24,7 @@ import org.komapper.processor.BackquotedSymbols.Instant
 import org.komapper.processor.BackquotedSymbols.KClass
 import org.komapper.processor.BackquotedSymbols.KomapperExperimentalAssociation
 import org.komapper.processor.BackquotedSymbols.LocalDateTime
+import org.komapper.processor.BackquotedSymbols.Map
 import org.komapper.processor.BackquotedSymbols.Operand
 import org.komapper.processor.BackquotedSymbols.ProjectionType
 import org.komapper.processor.BackquotedSymbols.ProjectionType_INDEX
@@ -134,6 +135,9 @@ internal class EntityMetamodelGenerator(
         w.println("    private val __disableSequenceAssignment = disableSequenceAssignment")
         w.println("    private val __declaration = declaration")
         w.println("    private val __disableAutoIncrement = disableAutoIncrement")
+        w.println("    private val __propertyMap: $Map<String, $PropertyMetamodel<$entityTypeName, *, *>> by lazy { ")
+        w.println("        properties().associateBy { it.name }")
+        w.println("    }")
 
         entityDescriptor()
 
@@ -163,6 +167,8 @@ internal class EntityMetamodelGenerator(
         preInsert()
         preUpdate()
         postUpdate()
+
+        get()
 
         newEntity()
         newMetamodel()
@@ -632,6 +638,10 @@ internal class EntityMetamodelGenerator(
                 }
             }
         }
+    }
+
+    private fun get() {
+        w.println("    override operator fun get(name: String): $PropertyMetamodel<$entityTypeName, *, *>? = __propertyMap[name]")
     }
 
     private fun newEntity() {


### PR DESCRIPTION
This PR allows retrieving `PropertyMetamodel` by name from `EntityMetamodel`. For example, you can do the following:

```kotlin
val date: PropertyMetamodel<Address, *, *>? = Meta.address["date"]
```

Practically, this can be useful when dynamically constructing common search conditions across multiple tables.

```kotlin
fun main() {
    val a = Meta.address
    val query1 = QueryDsl.from(a).where {
        addCommonWhere(a)
        a.street eq "Tokyo"
    }

    val e = Meta.employee
    val query2 = QueryDsl.from(e).where {
        addCommonWhere(e)
        e.departmentId eq 1
    }
}

private fun <ENTITY: Any, ID: Any, META: EntityMetamodel<ENTITY, ID, META>> WhereScope.addCommonWhere(meta: META) {
    val date = meta["date"] as PropertyMetamodel<ENTITY, LocalDate, LocalDate>
    val where: WhereDeclaration =  {
        date greater LocalDate.now()
    }
    this.apply(where)
}
```