### PR TITLE
Support subquery for between and notBetween operators

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectTest.kt
@@ -27,6 +27,7 @@ import org.komapper.core.dsl.operator.columnExpression
 import org.komapper.core.dsl.operator.concat
 import org.komapper.core.dsl.operator.desc
 import org.komapper.core.dsl.operator.literal
+import org.komapper.core.dsl.operator.max
 import org.komapper.core.dsl.options.SelectOptions
 import org.komapper.core.dsl.query.first
 import org.komapper.core.dsl.query.firstOrNull
@@ -49,6 +50,14 @@ class JdbcSelectTest(private val db: JdbcDatabase) {
             QueryDsl.select(literal("hello")).single()
         }
         assertEquals("hello", result)
+    }
+
+    @Test
+    fun select_scalar() {
+        val result = db.runQuery {
+            QueryDsl.select(max(literal(1)))
+        }
+        assertEquals(1, result)
     }
 
     @Test

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWhereTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWhereTest.kt
@@ -64,8 +64,8 @@ class JdbcSelectWhereTest(private val db: JdbcDatabase) {
     @Test
     fun between_pair() {
         val a = Meta.address
-        val start = QueryDsl.from(a).select(max(literal(5)))
-        val end = QueryDsl.from(a).select(max(literal(10)))
+        val start = QueryDsl.select(max(literal(5)))
+        val end = QueryDsl.select(max(literal(10)))
         val idList = db.runQuery {
             QueryDsl.from(a).where {
                 a.addressId between (start to end)
@@ -89,8 +89,8 @@ class JdbcSelectWhereTest(private val db: JdbcDatabase) {
     @Test
     fun notBetween_pair() {
         val a = Meta.address
-        val start = QueryDsl.from(a).select(max(literal(5)))
-        val end = QueryDsl.from(a).select(max(literal(10)))
+        val start = QueryDsl.select(max(literal(5)))
+        val end = QueryDsl.select(max(literal(10)))
         val idList = db.runQuery {
             QueryDsl.from(a).where {
                 a.addressId notBetween (start to end)

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWhereTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWhereTest.kt
@@ -13,6 +13,8 @@ import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.operator.CriteriaContext
 import org.komapper.core.dsl.operator.desc
+import org.komapper.core.dsl.operator.literal
+import org.komapper.core.dsl.operator.max
 import org.komapper.core.dsl.operator.plus
 import org.komapper.core.dsl.query.andThen
 import org.komapper.core.dsl.query.firstOrNull
@@ -60,11 +62,38 @@ class JdbcSelectWhereTest(private val db: JdbcDatabase) {
     }
 
     @Test
+    fun between_pair() {
+        val a = Meta.address
+        val start = QueryDsl.from(a).select(max(literal(5)))
+        val end = QueryDsl.from(a).select(max(literal(10)))
+        val idList = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId between (start to end)
+            }.orderBy(a.addressId)
+        }
+        assertEquals((5..10).toList(), idList.map { it.addressId })
+    }
+
+    @Test
     fun notBetween() {
         val a = Meta.address
         val idList = db.runQuery {
             QueryDsl.from(a).where {
                 a.addressId notBetween 5..10
+            }.orderBy(a.addressId)
+        }
+        val ids = (1..4) + (11..15)
+        assertEquals(ids.toList(), idList.map { it.addressId })
+    }
+
+    @Test
+    fun notBetween_pair() {
+        val a = Meta.address
+        val start = QueryDsl.from(a).select(max(literal(5)))
+        val end = QueryDsl.from(a).select(max(literal(10)))
+        val idList = db.runQuery {
+            QueryDsl.from(a).where {
+                a.addressId notBetween (start to end)
             }.orderBy(a.addressId)
         }
         val ids = (1..4) + (11..15)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
@@ -124,7 +124,7 @@ interface QueryDsl {
     ): SelectQueryBuilder<ENTITY, ID, META>
 
     /**
-     * Creates a SELECT query builder for a single column expression.
+     * Creates a SELECT query for a single column expression.
      *
      * @param A the type of the column expression
      * @param expression the column expression
@@ -133,7 +133,7 @@ interface QueryDsl {
     fun <A : Any> select(expression: ColumnExpression<A, *>): FlowSubquery<A?>
 
     /**
-     * Creates a SELECT query builder for two column expressions.
+     * Creates a SELECT query for two column expressions.
      *
      * @param A the type of the first column expression
      * @param B the type of the second column expression
@@ -147,7 +147,7 @@ interface QueryDsl {
     ): FlowSubquery<Pair<A?, B?>>
 
     /**
-     * Creates a SELECT query builder for three column expressions.
+     * Creates a SELECT query for three column expressions.
      *
      * @param A the type of the first column expression
      * @param B the type of the second column expression
@@ -164,7 +164,7 @@ interface QueryDsl {
     ): FlowSubquery<Triple<A?, B?, C?>>
 
     /**
-     * Creates a SELECT query builder for a scalar expression.
+     * Creates a SELECT query for a scalar expression.
      *
      * @param T the exterior type of the scalar expression
      * @param S the interior type of the scalar expression

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
@@ -12,6 +12,7 @@ import org.komapper.core.dsl.context.TemplateExecuteContext
 import org.komapper.core.dsl.context.TemplateSelectContext
 import org.komapper.core.dsl.element.With
 import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.ScalarExpression
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.metamodel.EmptyMetamodel
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -28,6 +29,7 @@ import org.komapper.core.dsl.query.DeleteQueryBuilderImpl
 import org.komapper.core.dsl.query.FlowSubquery
 import org.komapper.core.dsl.query.InsertQueryBuilder
 import org.komapper.core.dsl.query.InsertQueryBuilderImpl
+import org.komapper.core.dsl.query.ScalarQuery
 import org.komapper.core.dsl.query.SchemaCreateQuery
 import org.komapper.core.dsl.query.SchemaCreateQueryImpl
 import org.komapper.core.dsl.query.SchemaDropQuery
@@ -160,6 +162,18 @@ interface QueryDsl {
         expression2: ColumnExpression<B, *>,
         expression3: ColumnExpression<C, *>,
     ): FlowSubquery<Triple<A?, B?, C?>>
+
+    /**
+     * Creates a SELECT query builder for a scalar expression.
+     *
+     * @param T the exterior type of the scalar expression
+     * @param S the interior type of the scalar expression
+     * @param expression the scalar expression
+     * @return a scalar query for the scalar expression
+     */
+    fun <T : Any, S : Any> select(
+        expression: ScalarExpression<T, S>,
+    ): ScalarQuery<T?, T, S>
 
     /**
      * Creates a INSERT query builder.
@@ -328,6 +342,10 @@ internal class QueryDslImpl(
         expression3: ColumnExpression<C, *>,
     ): FlowSubquery<Triple<A?, B?, C?>> {
         return from(EmptyMetamodel).select(expression1, expression2, expression3)
+    }
+
+    override fun <T : Any, S : Any> select(expression: ScalarExpression<T, S>): ScalarQuery<T?, T, S> {
+        return from(EmptyMetamodel).select(expression)
     }
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> insert(

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
@@ -206,9 +206,19 @@ interface FilterScope<F : FilterScope<F>> {
     infix fun <T : Comparable<T>, S : Any> ColumnExpression<T, S>.between(range: ClosedRange<T>)
 
     /**
+     * Applies the `BETWEEN` predicate.
+     */
+    infix fun <T : Comparable<T>, S : Any> ColumnExpression<T, S>.between(range: Pair<ColumnExpression<T, S>, ColumnExpression<T, S>>)
+
+    /**
      * Applies the `NOT BETWEEN` predicate.
      */
     infix fun <T : Comparable<T>, S : Any> ColumnExpression<T, S>.notBetween(range: ClosedRange<T>)
+
+    /**
+     * Applies the `NOT BETWEEN` predicate.
+     */
+    infix fun <T : Comparable<T>, S : Any> ColumnExpression<T, S>.notBetween(range: Pair<ColumnExpression<T, S>, ColumnExpression<T, S>>)
 
     /**
      * Applies the `IN` predicate.

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
@@ -9,8 +9,7 @@ import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.SqlBuilderScope
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.operator.CriteriaContext
-import java.util.Deque
-import java.util.LinkedList
+import java.util.*
 
 class FilterScopeSupport<F : FilterScope<F>>(
     private val constructFilterScope: (FilterScopeSupport<F>) -> F,
@@ -238,9 +237,21 @@ class FilterScopeSupport<F : FilterScope<F>>(
         add(Criterion.Between(left, right))
     }
 
+    override fun <T : Comparable<T>, S : Any> ColumnExpression<T, S>.between(range: Pair<ColumnExpression<T, S>, ColumnExpression<T, S>>) {
+        val left = Operand.Column(this)
+        val right = Operand.Column(range.first) to Operand.Column(range.second)
+        add(Criterion.Between(left, right))
+    }
+
     override infix fun <T : Comparable<T>, S : Any> ColumnExpression<T, S>.notBetween(range: ClosedRange<T>) {
         val left = Operand.Column(this)
         val right = Operand.Argument(this, range.start) to Operand.Argument(this, range.endInclusive)
+        add(Criterion.NotBetween(left, right))
+    }
+
+    override infix fun <T : Comparable<T>, S : Any> ColumnExpression<T, S>.notBetween(range: Pair<ColumnExpression<T, S>, ColumnExpression<T, S>>) {
+        val left = Operand.Column(this)
+        val right = Operand.Column(range.first) to Operand.Column(range.second)
         add(Criterion.NotBetween(left, right))
     }
 


### PR DESCRIPTION
We've updated the between and notBetween operators to accept Pair types for ColumnExpression.

```kotlin
val a = Meta.address
val start = QueryDsl.select(max(literal(5)))
val end = QueryDsl.select(max(literal(10)))

val query = QueryDsl.from(a).where {
    a.addressId between (start to end)
  }.orderBy(a.addressId)
```