### PR TITLE
Support returning result sets when executing INSERT, UPDATE, and DELETE using SQL templates

### DIFF
--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcTemplateTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcTemplateTest.kt
@@ -15,6 +15,7 @@ import org.komapper.core.dsl.query.bind
 import org.komapper.core.dsl.query.first
 import org.komapper.core.dsl.query.get
 import org.komapper.core.dsl.query.getNotNull
+import org.komapper.core.dsl.query.single
 import org.komapper.r2dbc.R2dbcDatabase
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -288,5 +289,34 @@ class R2dbcTemplateTest(private val db: R2dbcDatabase) {
         }
         assertEquals(15, list.size)
         assertEquals(Address(1, "STREET 1", 1), list[0])
+    }
+
+    @Test
+    @Run(unless = [Dbms.H2, Dbms.MYSQL, Dbms.MYSQL_5, Dbms.SQLSERVER, Dbms.ORACLE])
+    fun insertReturning(info: TestInfo) = inTransaction(db, info) {
+        val address = db.runQuery {
+            val sql = """
+                insert into address
+                    (address_id, street, version)
+                values
+                    (/*id*/0, /*street*/'', /*version*/0)
+                returning address_id, street, version
+            """.trimIndent()
+            QueryDsl.executeTemplate(sql)
+                .returning()
+                .bind("id", 16)
+                .bind("street", "NY street")
+                .bind("version", 1)
+                .select(asAddress)
+                .single()
+        }
+        assertEquals(
+            Address(
+                16,
+                "NY street",
+                1,
+            ),
+            address,
+        )
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/TemplateExecuteContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/TemplateExecuteContext.kt
@@ -3,10 +3,24 @@ package org.komapper.core.dsl.context
 import org.komapper.core.ThreadSafe
 import org.komapper.core.Value
 import org.komapper.core.dsl.options.TemplateExecuteOptions
+import org.komapper.core.dsl.options.TemplateSelectOptions
 
 @ThreadSafe
 data class TemplateExecuteContext(
     val sql: String,
     val valueMap: Map<String, Value<*>> = emptyMap(),
     val options: TemplateExecuteOptions = TemplateExecuteOptions.DEFAULT,
-)
+) {
+    fun asTemplateSelectContext(returning: Boolean): TemplateSelectContext {
+        return TemplateSelectContext(
+            sql = sql,
+            valueMap = valueMap,
+            options = TemplateSelectOptions(
+                escapeSequence = options.escapeSequence,
+                queryTimeoutSeconds = options.queryTimeoutSeconds,
+                suppressLogging = options.suppressLogging,
+            ),
+            returning = returning,
+        )
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/TemplateSelectContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/TemplateSelectContext.kt
@@ -9,4 +9,5 @@ data class TemplateSelectContext(
     val sql: String,
     val valueMap: Map<String, Value<*>> = emptyMap(),
     val options: TemplateSelectOptions = TemplateSelectOptions.DEFAULT,
+    val returning: Boolean = false,
 )

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateExecuteQuery.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/TemplateExecuteQuery.kt
@@ -17,6 +17,11 @@ interface TemplateExecuteQuery : Query<Long>, TemplateBinder<TemplateExecuteQuer
      * @return the query
      */
     fun options(configure: (TemplateExecuteOptions) -> TemplateExecuteOptions): TemplateExecuteQuery
+
+    /**
+     * Enables the returning clause and returns a [TemplateSelectQueryBuilder] to specify the columns to return.
+     */
+    fun returning(): TemplateSelectQueryBuilder
 }
 
 internal data class TemplateExecuteQueryImpl(
@@ -26,6 +31,10 @@ internal data class TemplateExecuteQueryImpl(
     override fun options(configure: (TemplateExecuteOptions) -> TemplateExecuteOptions): TemplateExecuteQuery {
         val newContext = context.copy(options = configure(context.options))
         return copy(context = newContext)
+    }
+
+    override fun returning(): TemplateSelectQueryBuilder {
+        return TemplateSelectQueryBuilderImpl(context.asTemplateSelectContext(returning = true))
     }
 
     override fun bindValue(name: String, value: Value<*>): TemplateExecuteQuery {

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcTemplateEntityProjectionSelectRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcTemplateEntityProjectionSelectRunner.kt
@@ -24,11 +24,19 @@ internal class JdbcTemplateEntityProjectionSelectRunner<T, R>(
     override fun run(config: JdbcDatabaseConfig): R {
         val statement = runner.buildStatement(config)
         val executor = config.dialect.createExecutor(config, context.options)
-        return executor.executeQuery(
-            statement,
-            transform,
-            collect,
-        )
+        return if (context.returning) {
+            executor.executeReturning(
+                statement,
+                transform,
+                collect,
+            )
+        } else {
+            executor.executeQuery(
+                statement,
+                transform,
+                collect,
+            )
+        }
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcTemplateSelectRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcTemplateSelectRunner.kt
@@ -6,7 +6,9 @@ import org.komapper.core.DryRunStatement
 import org.komapper.core.dsl.context.TemplateSelectContext
 import org.komapper.core.dsl.query.Row
 import org.komapper.core.dsl.runner.TemplateSelectRunner
+import org.komapper.jdbc.JdbcDataOperator
 import org.komapper.jdbc.JdbcDatabaseConfig
+import java.sql.ResultSet
 
 internal class JdbcTemplateSelectRunner<T, R>(
     private val context: TemplateSelectContext,
@@ -22,15 +24,24 @@ internal class JdbcTemplateSelectRunner<T, R>(
 
     override fun run(config: JdbcDatabaseConfig): R {
         val statement = runner.buildStatement(config)
+        val transform: (JdbcDataOperator, ResultSet) -> T = { dataOperator, rs ->
+            val row = JdbcResultSetWrapper(dataOperator, rs)
+            transform(row)
+        }
         val executor = config.dialect.createExecutor(config, context.options)
-        return executor.executeQuery(
-            statement,
-            { dataOperator, rs ->
-                val row = JdbcResultSetWrapper(dataOperator, rs)
-                transform(row)
-            },
-            collect,
-        )
+        return if (context.returning) {
+            executor.executeReturning(
+                statement,
+                transform,
+                collect,
+            )
+        } else {
+            executor.executeQuery(
+                statement,
+                transform,
+                collect,
+            )
+        }
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {


### PR DESCRIPTION
We can write as follows:

```kotlin
val sql = """
    insert into address
        (address_id, street, version)
    values
        (/*id*/0, /*street*/'', /*version*/0)
    returning address_id, street, version
""".trimIndent()

QueryDsl.executeTemplate(sql)
    .returning()
    .bind("id", 16)
    .bind("street", "NY street")
    .bind("version", 1)
    .select(asAddress)
    .single()
```

However, the SQL for returning result sets varies by DBMS. For example, the above example works in PostgreSQL, but not in MySQL. It is the user's responsibility to write SQL that is compatible with their specific DBMS.