### PR TITLE
Enable binding functions to SQL templates

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcCommandTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcCommandTest.kt
@@ -718,7 +718,6 @@ class JdbcCommandTest(private val db: JdbcDatabase) {
             QueryDsl.execute(UsePartial(Pagination(2, 3)))
         }
         assertEquals(2, addresses.size)
-        println(addresses)
         assertEquals(listOf(4, 5), addresses.map { it.addressId })
     }
 
@@ -746,30 +745,28 @@ class JdbcCommandTest(private val db: JdbcDatabase) {
         )
     }
 
-    /* TODO
     @KomapperCommand(
         """
         insert into address
             (address_id, street, version)
         values
-            (/* id */0, /* f() */'', /* id */0)
+            (/* id() */0, /* hello("world") */'', /* add(1, 2) */0)
         """,
     )
-    class FunctionPassing(val id: Int, val f: () -> String) : Exec
+    class CallableValue(val id: () -> Int, val hello: (String) -> String, val add: (Int, Int) -> Int) : Exec()
 
     @Test
-    fun functionPassing() {
+    fun callableValue() {
         val count = db.runQuery {
-            QueryDsl.execute(FunctionPassing(16, {"good"}))
+            QueryDsl.execute(CallableValue({ 16 }, { "hello $it" }, { a, b -> a + b }))
         }
         assertEquals(1, count)
         val a = Meta.address
         val address = db.runQuery {
             QueryDsl.from(a).where { a.addressId eq 16 }.single()
         }
-        assertEquals("good", address.street)
+        assertEquals(Address(16, "hello world", 3), address)
     }
-     */
 }
 
 @Suppress("UNUSED")

--- a/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprNode.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprNode.kt
@@ -35,4 +35,10 @@ sealed class ExprNode {
         val receiver: ExprNode,
         val args: ExprNode,
     ) : ExprNode()
+
+    data class CallableValue(
+        override val location: Loc,
+        val name: String,
+        val args: ExprNode,
+    ) : ExprNode()
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprParser.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprParser.kt
@@ -2,6 +2,7 @@ package org.komapper.core.template.expression
 
 import org.komapper.core.template.expression.ExprTokenType.AND
 import org.komapper.core.template.expression.ExprTokenType.BIG_DECIMAL
+import org.komapper.core.template.expression.ExprTokenType.CALLABLE_VALUE
 import org.komapper.core.template.expression.ExprTokenType.CHAR
 import org.komapper.core.template.expression.ExprTokenType.CLASS_REF
 import org.komapper.core.template.expression.ExprTokenType.CLOSE_PAREN
@@ -61,6 +62,7 @@ internal class ExprParser(
                 }
                 CLASS_REF -> parseClassRef()
                 VALUE -> parseValue()
+                CALLABLE_VALUE -> parseCallableValue()
                 CHAR -> parseCharLiteral()
                 STRING -> parseStringLiteral()
                 INT -> parseIntLiteral()
@@ -107,6 +109,13 @@ internal class ExprParser(
     private fun parseValue() {
         val node = ExprNode.Value(location, token)
         nodes.push(node)
+    }
+
+    private fun parseCallableValue() {
+        val reducer = CallableValueReducer(location, token)
+        pushReducer(reducer)
+        tokenType = tokenizer.next()
+        parseParen()
     }
 
     private fun parseParen() {

--- a/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprReducer.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprReducer.kt
@@ -26,6 +26,17 @@ internal class FunctionReducer(location: ExprLocation, val name: String, private
     }
 }
 
+/**
+ * Callable value is a function that has no receiver.
+ */
+internal class CallableValueReducer(location: ExprLocation, val name: String) :
+    ExprReducer(100, location) {
+    override fun reduce(deque: Deque<ExprNode>): ExprNode {
+        val args = pop(deque)
+        return ExprNode.CallableValue(location, name, args)
+    }
+}
+
 internal class NotReducer(location: ExprLocation) : ExprReducer(50, location) {
     override fun reduce(deque: Deque<ExprNode>): ExprNode {
         val expr = pop(deque)

--- a/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprTokenType.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprTokenType.kt
@@ -5,6 +5,7 @@ enum class ExprTokenType {
     OPEN_PAREN,
     CLOSE_PAREN,
     VALUE,
+    CALLABLE_VALUE,
     CHAR,
     STRING,
     INT,

--- a/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprTokenizer.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprTokenizer.kt
@@ -2,6 +2,7 @@ package org.komapper.core.template.expression
 
 import org.komapper.core.template.expression.ExprTokenType.AND
 import org.komapper.core.template.expression.ExprTokenType.BIG_DECIMAL
+import org.komapper.core.template.expression.ExprTokenType.CALLABLE_VALUE
 import org.komapper.core.template.expression.ExprTokenType.CHAR
 import org.komapper.core.template.expression.ExprTokenType.CLASS_REF
 import org.komapper.core.template.expression.ExprTokenType.CLOSE_PAREN
@@ -265,6 +266,15 @@ class ExprTokenizer(private val expression: String) {
                     buf.reset()
                     break
                 }
+            }
+            if (buf.hasRemaining()) {
+                buf.mark()
+                val c1 = buf.get()
+                if (c1 == '(') {
+                    type = CALLABLE_VALUE
+                    binaryOpAvailable = false
+                }
+                buf.reset()
             }
         } else if (c == '.') {
             type = PROPERTY

--- a/komapper-core/src/test/kotlin/org/komapper/core/template/expression/ExprParserTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/template/expression/ExprParserTest.kt
@@ -83,6 +83,19 @@ class ExprParserTest {
     }
 
     @Test
+    fun topLevelFunction() {
+        when (val expr = ExprParser("hello()").parse()) {
+            is ExprNode.CallableValue -> {
+                assertEquals("hello", expr.name)
+                assertTrue(expr.args is ExprNode.Empty)
+            }
+            else -> {
+                throw AssertionError()
+            }
+        }
+    }
+
+    @Test
     fun nestedFunction() {
         when (val expr = ExprParser("aaa.hello(1, 2, 3).bye(4)").parse()) {
             is ExprNode.Function -> {

--- a/komapper-core/src/test/kotlin/org/komapper/core/template/expression/ExprParserTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/template/expression/ExprParserTest.kt
@@ -1,8 +1,5 @@
-package org.komapper.template.expression
+package org.komapper.core.template.expression
 
-import org.komapper.core.template.expression.ExprException
-import org.komapper.core.template.expression.ExprNode
-import org.komapper.core.template.expression.ExprParser
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -16,6 +13,7 @@ class ExprParserTest {
             is ExprNode.ClassRef -> {
                 assertEquals("aaa.bbb.Ccc", expr.name)
             }
+
             else -> throw AssertionError(expr)
         }
     }
@@ -27,6 +25,7 @@ class ExprParserTest {
                 assertTrue(expr.left is ExprNode.Value)
                 assertTrue(expr.right is ExprNode.Literal)
             }
+
             else -> throw AssertionError()
         }
     }
@@ -38,6 +37,7 @@ class ExprParserTest {
                 assertTrue(expr.left is ExprNode.Gt)
                 assertTrue(expr.right is ExprNode.Literal)
             }
+
             else -> throw AssertionError()
         }
     }
@@ -48,8 +48,9 @@ class ExprParserTest {
             is ExprNode.Property -> {
                 assertEquals("age", expr.name)
                 assertTrue(expr.receiver is ExprNode.Value)
-                assertEquals("aaa", expr.receiver.name)
+                assertEquals("aaa", (expr.receiver as ExprNode.Value).name)
             }
+
             else -> throw AssertionError()
         }
     }
@@ -66,6 +67,7 @@ class ExprParserTest {
                 assertTrue(grandParent is ExprNode.Value)
                 assertEquals("aaa", grandParent.name)
             }
+
             else -> throw AssertionError()
         }
     }
@@ -76,8 +78,9 @@ class ExprParserTest {
             is ExprNode.Function -> {
                 assertEquals("hello", expr.name)
                 assertTrue(expr.receiver is ExprNode.Value)
-                assertEquals("aaa", expr.receiver.name)
+                assertEquals("aaa", (expr.receiver as ExprNode.Value).name)
             }
+
             else -> throw AssertionError()
         }
     }
@@ -89,6 +92,7 @@ class ExprParserTest {
                 assertEquals("hello", expr.name)
                 assertTrue(expr.args is ExprNode.Empty)
             }
+
             else -> {
                 throw AssertionError()
             }
@@ -101,16 +105,17 @@ class ExprParserTest {
             is ExprNode.Function -> {
                 assertEquals("bye", expr.name)
                 assertTrue(expr.args is ExprNode.Literal)
-                assertEquals(4, expr.args.value)
+                assertEquals(4, (expr.args as ExprNode.Literal).value)
                 val parent = expr.receiver
                 assertTrue(parent is ExprNode.Function)
                 assertEquals("hello", parent.name)
                 assertTrue(parent.args is ExprNode.Comma)
-                assertEquals(3, parent.args.nodeList.size)
+                assertEquals(3, (parent.args as ExprNode.Comma).nodeList.size)
                 val grandParent = parent.receiver
                 assertTrue(grandParent is ExprNode.Value)
                 assertEquals("aaa", grandParent.name)
             }
+
             else -> throw AssertionError()
         }
     }
@@ -121,6 +126,7 @@ class ExprParserTest {
             is ExprNode.Comma -> {
                 assertEquals(3, expr.nodeList.size)
             }
+
             else -> throw AssertionError()
         }
     }

--- a/komapper-core/src/test/kotlin/org/komapper/core/template/expression/ExprTokenizerTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/template/expression/ExprTokenizerTest.kt
@@ -1,6 +1,5 @@
-package org.komapper.template.expression
+package org.komapper.core.template.expression
 
-import org.komapper.core.template.expression.ExprException
 import org.komapper.core.template.expression.ExprTokenType.AND
 import org.komapper.core.template.expression.ExprTokenType.BIG_DECIMAL
 import org.komapper.core.template.expression.ExprTokenType.CLASS_REF
@@ -17,7 +16,6 @@ import org.komapper.core.template.expression.ExprTokenType.STRING
 import org.komapper.core.template.expression.ExprTokenType.TRUE
 import org.komapper.core.template.expression.ExprTokenType.VALUE
 import org.komapper.core.template.expression.ExprTokenType.WHITESPACE
-import org.komapper.core.template.expression.ExprTokenizer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/komapper-core/src/test/kotlin/org/komapper/core/template/sql/SqlParserTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/template/sql/SqlParserTest.kt
@@ -1,8 +1,6 @@
-package org.komapper.template.sql
+package org.komapper.core.template.sql
 
-import org.komapper.core.template.sql.SqlException
-import org.komapper.core.template.sql.SqlNode
-import org.komapper.core.template.sql.SqlParser
+import org.junit.jupiter.api.Nested
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -44,7 +42,8 @@ class SqlParserTest {
         assertEquals(sql, node.toText())
     }
 
-    class ClauseTest {
+    @Nested
+    inner class ClauseTest {
         @Test
         fun select() {
             val sql = "select name, age"
@@ -88,7 +87,8 @@ class SqlParserTest {
         }
     }
 
-    class LogicalOperatorTest {
+    @Nested
+    inner class LogicalOperatorTest {
         @Test
         fun and() {
             val sql = "and age > 1"
@@ -104,7 +104,8 @@ class SqlParserTest {
         }
     }
 
-    class BindValueDirectiveTest {
+    @Nested
+    inner class BindValueDirectiveTest {
         @Test
         fun bindValue() {
             val sql = "/* age */1"
@@ -182,7 +183,8 @@ class SqlParserTest {
         }
     }
 
-    class CommentTest {
+    @Nested
+    inner class CommentTest {
         @Test
         fun multiLineComment() {
             val sql = """
@@ -210,7 +212,8 @@ class SqlParserTest {
         }
     }
 
-    class SetTest {
+    @Nested
+    inner class SetTest {
 
         @Test
         fun simple() {
@@ -233,7 +236,8 @@ class SqlParserTest {
         }
     }
 
-    class ParenTest {
+    @Nested
+    inner class ParenTest {
 
         @Test
         fun empty() {
@@ -257,7 +261,8 @@ class SqlParserTest {
         }
     }
 
-    class IfBlockTest {
+    @Nested
+    inner class IfBlockTest {
 
         @Test
         fun `if`() {
@@ -358,7 +363,8 @@ class SqlParserTest {
         }
     }
 
-    class ForBlockTest {
+    @Nested
+    inner class ForBlockTest {
 
         @Test
         fun simple() {

--- a/komapper-core/src/test/kotlin/org/komapper/core/template/sql/SqlTokenizerTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/template/sql/SqlTokenizerTest.kt
@@ -1,6 +1,5 @@
-package org.komapper.template.sql
+package org.komapper.core.template.sql
 
-import org.komapper.core.template.sql.SqlException
 import org.komapper.core.template.sql.SqlTokenType.AND
 import org.komapper.core.template.sql.SqlTokenType.BIND_VALUE_DIRECTIVE
 import org.komapper.core.template.sql.SqlTokenType.DELIMITER
@@ -31,7 +30,6 @@ import org.komapper.core.template.sql.SqlTokenType.SPACE
 import org.komapper.core.template.sql.SqlTokenType.UNION
 import org.komapper.core.template.sql.SqlTokenType.WHERE
 import org.komapper.core.template.sql.SqlTokenType.WORD
-import org.komapper.core.template.sql.SqlTokenizer
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -44,7 +42,7 @@ class SqlTokenizerTest {
 
     @BeforeTest
     fun setUp() {
-        lineSeparator = System.getProperty("line.separator")
+        lineSeparator = System.lineSeparator()
         System.setProperty("line.separator", "\r\n")
     }
 

--- a/komapper-template/src/test/kotlin/org/komapper/template/ExprEvaluatorTest.kt
+++ b/komapper-template/src/test/kotlin/org/komapper/template/ExprEvaluatorTest.kt
@@ -420,6 +420,36 @@ class ExprEvaluatorTest {
         }
 
         @Test
+        fun callable0() {
+            val ctx = ExprContext(
+                mapOf("h" to Value(::hello0, typeOf<Function<String>>())),
+                extensions,
+            )
+            val result = evaluator.eval("h()", ctx)
+            assertEquals(Value("hello world", typeOf<String>()), result)
+        }
+
+        @Test
+        fun callable1() {
+            val ctx = ExprContext(
+                mapOf("h" to Value(::hello1, typeOf<Function<String>>())),
+                extensions,
+            )
+            val result = evaluator.eval("h(\"WORLD\")", ctx)
+            assertEquals(Value("hello WORLD", typeOf<String>()), result)
+        }
+
+        @Test
+        fun callable2() {
+            val ctx = ExprContext(
+                mapOf("add" to Value(::add, typeOf<Function<Int>>())),
+                extensions,
+            )
+            val result = evaluator.eval("add(1, 2)", ctx)
+            assertEquals(Value(3, typeOf<Int>()), result)
+        }
+
+        @Test
         fun `The template variable is not bound to a value`() {
             val ctx = ExprContext(emptyMap(), extensions)
             val ex = assertFailsWith<ExprException> {
@@ -611,4 +641,16 @@ class ExprEvaluatorTest {
             assertEquals(Value(1u, typeOf<UInt>()), result)
         }
     }
+}
+
+fun hello0(): String {
+    return "hello world"
+}
+
+fun hello1(name: String): String {
+    return "hello $name"
+}
+
+fun add(a: Int, b: Int): Int {
+    return a + b
 }


### PR DESCRIPTION
For example, this PR supports code like the following:

```kotlin
@KomapperCommand(
    """
    insert into address
        (address_id, street, version)
    values
        (/* id() */0, /* hello("world") */'', /* add(1, 2) */0)
    """,
)
class AddAddress(val id: () -> Int, val hello: (String) -> String, val add: (Int, Int) -> Int) : Exec()
```