### PR TITLE
Make the constructor of `DryRunStatement` public

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/Statement.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Statement.kt
@@ -78,7 +78,7 @@ data class Statement(val parts: List<StatementPart>) {
     }
 }
 
-data class DryRunStatement internal constructor(
+data class DryRunStatement(
     val sql: String = "",
     val sqlWithArgs: String = "",
     val args: List<Value<*>> = emptyList(),


### PR DESCRIPTION
Making the constructor public suppresses the following warning message:

> Non-public primary constructor is exposed via the generated 'copy()' method of the 'data' class.