### PR TITLE
Fix and improve `CommandProcessor` and related classes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4.0.1
 
       - name: Check
-        run: ./gradlew javatoolchain check -x h2 -x :integration-test-jdbc:check -x :integration-test-r2dbc:check -PexcludeTags=
+        run: ./gradlew javatoolchain check -x h2 -x :integration-test-jdbc:check -x :integration-test-r2dbc:check
 
       - name: Upload reports
         if: failure()

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ springVersion=5.3.39
 springBootVersion=2.7.18
 
 # test
-excludeTags=slow
+excludeTags=
 
 # release
 projectUrl=https://github.com/komapper/komapper

--- a/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprException.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprException.kt
@@ -1,3 +1,3 @@
 package org.komapper.core.template.expression
 
-class ExprException(message: String) : Exception(message)
+open class ExprException(message: String) : Exception(message)

--- a/komapper-core/src/main/kotlin/org/komapper/core/template/sql/SqlException.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/sql/SqlException.kt
@@ -1,5 +1,5 @@
 package org.komapper.core.template.sql
 
-class SqlException(message: String, cause: Throwable?) : Exception(message, cause) {
+open class SqlException(message: String, cause: Throwable?) : Exception(message, cause) {
     constructor(message: String) : this(message, null)
 }

--- a/komapper-core/src/test/kotlin/org/komapper/core/template/sql/SqlReassemblerTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/template/sql/SqlReassemblerTest.kt
@@ -1,0 +1,80 @@
+package org.komapper.core.template.sql
+
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SqlReassemblerTest {
+
+    @Test
+    fun test() {
+        val sql = """
+            /**
+             * multi line comment
+             */
+            -- single line comment
+            select
+                *
+            from
+                dept
+            where
+                /*%for id in list */
+                id = /* id */1
+                /*%if id_has_next *//*# "or" *//*%end */
+                /*%end */
+            union all
+            select
+                * 
+            from
+                emp 
+            where 
+                id = /* id */1
+                and
+                name = /*^ name */'foo'
+            /*%if orderBy != null*/
+            /*# orderBy */
+            /*%else */
+            order by id
+            /*%end */
+        """.trimIndent()
+        val newSql = SqlReassembler(sql, emptyMap()).assemble()
+        assertEquals(sql, newSql)
+    }
+
+    @Test
+    fun partialFound() {
+        val sql = """
+            select
+                *
+            from
+                dept
+            /*> orderBy */
+        """.trimIndent()
+        val newSql = SqlReassembler(sql, mapOf("orderBy" to "order by id, name")).assemble()
+        assertEquals(
+            newSql,
+            """
+            select
+                *
+            from
+                dept
+            order by id, name
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun partialNotFound() {
+        val sql = """
+            select
+                *
+            from
+                dept
+            /*> orderBy */
+        """.trimIndent()
+        val e = assertThrows<SqlReassembler.SqlPartialNotFoundException> {
+            SqlReassembler(sql, emptyMap()).assemble()
+        }
+        assertEquals("orderBy", e.name)
+    }
+}

--- a/komapper-core/src/test/kotlin/org/komapper/core/template/sql/SqlReassemblerTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/template/sql/SqlReassemblerTest.kt
@@ -33,6 +33,10 @@ class SqlReassemblerTest {
                 name = /*^ name */'foo'
             /*%if orderBy != null*/
             /*# orderBy */
+            /*%elseif orderBy == "hoge" */
+            order by hoge
+            /*%elseif orderBy == "foo" */
+            order by foo
             /*%else */
             order by id
             /*%end */

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Context.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Context.kt
@@ -15,7 +15,7 @@ internal data class Context(
     val codeGenerator get() = environment.codeGenerator
 }
 
-internal interface ContextFactory {
+internal fun interface ContextFactory {
     fun create(resolver: Resolver): Context
 }
 

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/command/CommandAnalyzer.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/command/CommandAnalyzer.kt
@@ -49,7 +49,7 @@ internal class CommandAnalyzer(private val context: Context, private val annotat
 
     private fun validateCommand(command: Command) {
         val usedParams = try {
-            SqlValidator(context, command).validate()
+            SqlValidator(context, command.sql, command.paramMap).validate()
         } catch (e: SqlException) {
             report("SQL validation error: ${e.message}", command.annotation)
         }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/command/CommandProcessorProvider.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/command/CommandProcessorProvider.kt
@@ -1,6 +1,5 @@
 package org.komapper.processor.command
 
-import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -13,11 +12,7 @@ import org.komapper.processor.ContextFactory
 internal class CommandProcessorProvider : SymbolProcessorProvider {
     override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
         val config = Config.create(environment.options)
-        val factory = object : ContextFactory {
-            override fun create(resolver: Resolver): Context {
-                return Context(environment, config, resolver)
-            }
-        }
+        val factory = ContextFactory { resolver -> Context(environment, config, resolver) }
         return CommandProcessor(factory)
     }
 }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/entity/EntityProcessor.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/entity/EntityProcessor.kt
@@ -14,10 +14,9 @@ internal class EntityProcessor(
     private val processingAnnotations: List<ProcessingAnnotation>,
 ) : SymbolProcessor {
 
-    private val processedSymbols = mutableSetOf<KSAnnotated>()
-
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val context = contextFactory.create(resolver)
+        val processedSymbols = mutableSetOf<KSAnnotated>()
         for (annotation in processingAnnotations) {
             val annotationName = annotation.annotationClass.qualifiedName!!
             val symbols = resolver.getSymbolsWithAnnotation(annotationName)

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/entity/EntityProcessorProvider.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/entity/EntityProcessorProvider.kt
@@ -1,6 +1,5 @@
 package org.komapper.processor.entity
 
-import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -17,11 +16,7 @@ import org.komapper.processor.ContextFactory
 class EntityProcessorProvider : SymbolProcessorProvider {
     override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
         val config = Config.create(environment.options)
-        val factory = object : ContextFactory {
-            override fun create(resolver: Resolver): Context {
-                return Context(environment, config, resolver)
-            }
-        }
+        val factory = ContextFactory { resolver -> Context(environment, config, resolver) }
         val processingAnnotations = listOf(
             ProcessingAnnotation(
                 KomapperEntityDef::class,

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/command/CommandProcessorErrorTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/command/CommandProcessorErrorTest.kt
@@ -69,7 +69,7 @@ class CommandProcessorErrorTest : AbstractKspTest(CommandProcessorProvider()) {
             """,
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("The expression eval result must be a Boolean"))
+        assertTrue(result.messages.contains("The expression must be a Boolean"))
     }
 
     @Test
@@ -84,7 +84,7 @@ class CommandProcessorErrorTest : AbstractKspTest(CommandProcessorProvider()) {
             """,
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("The expression eval result must be a Boolean"))
+        assertTrue(result.messages.contains("The expression must be a Boolean"))
     }
 
     @Test
@@ -174,7 +174,7 @@ class CommandProcessorErrorTest : AbstractKspTest(CommandProcessorProvider()) {
             """,
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("Cannot compare because the operands are not the same type"))
+        assertTrue(result.messages.contains("Cannot compare because the operands(left=String, right=Boolean) are not the same type"))
     }
 
     @Test
@@ -190,11 +190,11 @@ class CommandProcessorErrorTest : AbstractKspTest(CommandProcessorProvider()) {
             """,
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("Cannot compare because operands are not Comparable type"))
+        assertTrue(result.messages.contains("Cannot compare because operands(left=User, right=User) are not Comparable type"))
     }
 
     @Test
-    fun `The variable is not found`() {
+    fun `The parameter is not found`() {
         val result = compile(
             """
             package test
@@ -205,7 +205,7 @@ class CommandProcessorErrorTest : AbstractKspTest(CommandProcessorProvider()) {
             """,
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("The variable \"d\" is not found at <d>:1. Available variables are: [a, b, c]"))
+        assertTrue(result.messages.contains("The parameter \"d\" is not found at <d>:1. Available parameters are: [a, b, c]"))
     }
 
     @Test
@@ -235,6 +235,6 @@ class CommandProcessorErrorTest : AbstractKspTest(CommandProcessorProvider()) {
             """,
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("The function \"unknown\" is not found"))
+        assertTrue(result.messages.contains("The function \"unknown\" (parameter size is 1) is not found"))
     }
 }

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/command/CommandProcessorErrorTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/command/CommandProcessorErrorTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertTrue
 class CommandProcessorErrorTest : AbstractKspTest(CommandProcessorProvider()) {
 
     @Test
-    fun `The class with type parameters is not supported`() {
+    fun `The class must not have type parameters`() {
         val result = compile(
             """
             package test
@@ -22,7 +22,7 @@ class CommandProcessorErrorTest : AbstractKspTest(CommandProcessorProvider()) {
             """,
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("The class with type parameters is not supported."))
+        assertTrue(result.messages.contains("The class \"Execute\" must not have type parameters."))
     }
 
     @Test
@@ -236,5 +236,37 @@ class CommandProcessorErrorTest : AbstractKspTest(CommandProcessorProvider()) {
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
         assertTrue(result.messages.contains("The function \"unknown\" (parameter size is 1) is not found"))
+    }
+
+    @Test
+    fun `The class must not be private`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            import org.komapper.core.*
+            @KomapperCommand("/* a */'' /* b */''")
+            private class Execute(val a: String, val b: Int): Exec()
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The class \"Execute\" must not be private."))
+    }
+
+    @Test
+    fun `The enclosing declaration must not be private`() {
+        val result = compile(
+            """
+            package test
+            import org.komapper.annotation.*
+            import org.komapper.core.*
+            private class MyClass {
+                @KomapperCommand("/* a */'' /* b */''")
+                class Execute(val a: String, val b: Int): Exec()
+            }
+            """,
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("The enclosing declaration \"MyClass\" of the class \"Execute\" must not be private."))
     }
 }

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/command/SqlValidatorTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/command/SqlValidatorTest.kt
@@ -1,0 +1,161 @@
+package org.komapper.processor.command
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.Variance
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.assertThrows
+import org.komapper.processor.AbstractKspTest
+import org.komapper.processor.Config
+import org.komapper.processor.Context
+import org.komapper.processor.ContextFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Tag("slow")
+class SqlValidatorTest : AbstractKspTest() {
+
+    @Test
+    fun `bind variable - success`() {
+        val result = compile("") { env, resolver ->
+            val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
+            val sql = "/* items */(1, 2, 3)"
+            val iterableDecl = resolver.builtIns.iterableType.declaration as KSClassDeclaration
+            val typeRef = resolver.createKSTypeReferenceFromKSType(resolver.builtIns.intType)
+            val typeArg = resolver.getTypeArgument(typeRef, Variance.INVARIANT)
+            val iterableType = iterableDecl.asType(listOf(typeArg))
+            val paramMap = mapOf("items" to iterableType)
+            val usedParams = SqlValidator(context, sql, paramMap).validate()
+            assertEquals(setOf("items"), usedParams)
+
+            emptyList()
+        }
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `bind variable - ExprMustBeIterableException`() {
+        val result = compile("") { env, resolver ->
+            val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
+            val sql = "/* items */(1, 2, 3)"
+            val paramMap = mapOf("items" to resolver.builtIns.intType)
+            val ex = assertThrows<SqlValidator.ExprMustBeIterableException> {
+                SqlValidator(context, sql, paramMap).validate()
+            }
+            println(ex)
+
+            emptyList()
+        }
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `if - success`() {
+        val result = compile("") { env, resolver ->
+            val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
+            val sql = "/*%if a */ /*%end */"
+            val paramMap = mapOf("a" to resolver.builtIns.booleanType)
+            val usedParams = SqlValidator(context, sql, paramMap).validate()
+            assertEquals(setOf("a"), usedParams)
+
+            emptyList()
+        }
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `if - ExprMustBeBooleanException`() {
+        val result = compile("") { env, resolver ->
+            val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
+            val sql = "/*%if a */ /*%end */"
+            val paramMap = mapOf("a" to resolver.builtIns.stringType)
+            val ex = assertThrows<SqlValidator.ExprMustBeBooleanException> {
+                SqlValidator(context, sql, paramMap).validate()
+            }
+            println(ex)
+
+            emptyList()
+        }
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `elseif - success`() {
+        val result = compile("") { env, resolver ->
+            val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
+            val sql = "/*%if a */ /*%elseif b */ /*%end */"
+            val paramMap = mapOf("a" to resolver.builtIns.booleanType, "b" to resolver.builtIns.booleanType)
+            val usedParams = SqlValidator(context, sql, paramMap).validate()
+            assertEquals(setOf("a", "b"), usedParams)
+
+            emptyList()
+        }
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `elseif - ExprMustBeBooleanException`() {
+        val result = compile("") { env, resolver ->
+            val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
+            val sql = "/*%if a */ /*%elseif b */ /*%end */"
+            val paramMap = mapOf("a" to resolver.builtIns.booleanType, "b" to resolver.builtIns.stringType)
+            val ex = assertThrows<SqlValidator.ExprMustBeBooleanException> {
+                SqlValidator(context, sql, paramMap).validate()
+            }
+            println(ex)
+
+            emptyList()
+        }
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `for - success`() {
+        val result = compile("") { env, resolver ->
+            val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
+            val sql = "/*%for item in items */ /*%end */"
+            val iterableDecl = resolver.builtIns.iterableType.declaration as KSClassDeclaration
+            val typeRef = resolver.createKSTypeReferenceFromKSType(resolver.builtIns.stringType)
+            val typeArg = resolver.getTypeArgument(typeRef, Variance.INVARIANT)
+            val iterableType = iterableDecl.asType(listOf(typeArg))
+            val paramMap = mapOf("items" to iterableType)
+            val usedParams = SqlValidator(context, sql, paramMap).validate()
+            assertEquals(setOf("items"), usedParams)
+
+            emptyList()
+        }
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `for - ExprMustBeIterableException`() {
+        val result = compile("") { env, resolver ->
+            val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
+            val sql = "/*%for item in items */ /*%end */"
+            val paramMap = mapOf("items" to resolver.builtIns.stringType)
+            val ex = assertThrows<SqlValidator.ExprMustBeIterableException> {
+                SqlValidator(context, sql, paramMap).validate()
+            }
+            println(ex)
+
+            emptyList()
+        }
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `for - StarProjectionNotSupportedException`() {
+        val result = compile("") { env, resolver ->
+            val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
+            val sql = "/*%for item in items */ /*%end */"
+            val paramMap = mapOf("items" to resolver.builtIns.iterableType)
+            val ex = assertThrows<SqlValidator.StarProjectionNotSupportedException> {
+                SqlValidator(context, sql, paramMap).validate()
+            }
+            println(ex)
+
+            emptyList()
+        }
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+}


### PR DESCRIPTION

- Fixed an issue where comparison operations would fail.
- Fixed an issue where literal variable directives were not handled correctly when reassembling SQL.
- Prohibited the command class from being nested within a private class.