### PR TITLE
Inherit from RuntimeException instead of Exception

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprException.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprException.kt
@@ -1,3 +1,3 @@
 package org.komapper.core.template.expression
 
-open class ExprException(message: String) : Exception(message)
+open class ExprException(message: String) : RuntimeException(message)

--- a/komapper-core/src/main/kotlin/org/komapper/core/template/sql/SqlException.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/sql/SqlException.kt
@@ -1,5 +1,5 @@
 package org.komapper.core.template.sql
 
-open class SqlException(message: String, cause: Throwable?) : Exception(message, cause) {
+open class SqlException(message: String, cause: Throwable?) : RuntimeException(message, cause) {
     constructor(message: String) : this(message, null)
 }


### PR DESCRIPTION
This fix ensures that exceptions will trigger a rollback under transaction management in the Spring Framework.