### PR TITLE
Add some utility variables to the `for` directive

### DIFF
--- a/komapper-processor/src/main/kotlin/org/komapper/processor/command/SqlValidator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/command/SqlValidator.kt
@@ -24,6 +24,7 @@ internal class SqlValidator(
     private val intType = context.resolver.builtIns.intType
     private val booleanType = context.resolver.builtIns.booleanType
     private val iterableType = context.resolver.builtIns.iterableType
+    private val stringType = context.resolver.builtIns.stringType
 
     fun validate(): Set<String> {
         val node = nodeFactory.get(sql)
@@ -120,6 +121,9 @@ internal class SqlValidator(
                 id to type,
                 id + "_index" to intType,
                 id + "_has_next" to booleanType,
+                id + "_comma" to stringType,
+                id + "_and" to stringType,
+                id + "_or" to stringType,
             )
             forDirective.nodeList.fold(newParamMap, ::visit)
         }

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/command/SqlValidator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/command/SqlValidator.kt
@@ -121,9 +121,9 @@ internal class SqlValidator(
                 id to type,
                 id + "_index" to intType,
                 id + "_has_next" to booleanType,
-                id + "_comma" to stringType,
-                id + "_and" to stringType,
-                id + "_or" to stringType,
+                id + "_next_comma" to stringType,
+                id + "_next_and" to stringType,
+                id + "_next_or" to stringType,
             )
             forDirective.nodeList.fold(newParamMap, ::visit)
         }

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/command/SqlValidatorTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/command/SqlValidatorTest.kt
@@ -131,14 +131,14 @@ class SqlValidatorTest : AbstractKspTest() {
     fun `for - special variables - success`() {
         val result = compile("") { env, resolver ->
             val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
-            val sql = "/*%for item in items */ /*# item_index */ /*# item_has_next */ /*# item_comma */ /*# item_and */ /*# item_or */ /*%end */"
+            val sql = "/*%for item in items */ /*# item_index */ /*# item_has_next */ /*# item_next_comma */ /*# item_next_and */ /*# item_next_or */ /*%end */"
             val iterableDecl = resolver.builtIns.iterableType.declaration as KSClassDeclaration
             val typeRef = resolver.createKSTypeReferenceFromKSType(resolver.builtIns.stringType)
             val typeArg = resolver.getTypeArgument(typeRef, Variance.INVARIANT)
             val iterableType = iterableDecl.asType(listOf(typeArg))
             val paramMap = mapOf("items" to iterableType)
             val usedParams = SqlValidator(context, sql, paramMap).validate()
-            assertEquals(setOf("items", "item_index", "item_has_next", "item_comma", "item_and", "item_or"), usedParams)
+            assertEquals(setOf("items", "item_index", "item_has_next", "item_next_comma", "item_next_and", "item_next_or"), usedParams)
 
             emptyList()
         }

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/command/SqlValidatorTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/command/SqlValidatorTest.kt
@@ -128,6 +128,24 @@ class SqlValidatorTest : AbstractKspTest() {
     }
 
     @Test
+    fun `for - special variables - success`() {
+        val result = compile("") { env, resolver ->
+            val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)
+            val sql = "/*%for item in items */ /*# item_index */ /*# item_has_next */ /*# item_comma */ /*# item_and */ /*# item_or */ /*%end */"
+            val iterableDecl = resolver.builtIns.iterableType.declaration as KSClassDeclaration
+            val typeRef = resolver.createKSTypeReferenceFromKSType(resolver.builtIns.stringType)
+            val typeArg = resolver.getTypeArgument(typeRef, Variance.INVARIANT)
+            val iterableType = iterableDecl.asType(listOf(typeArg))
+            val paramMap = mapOf("items" to iterableType)
+            val usedParams = SqlValidator(context, sql, paramMap).validate()
+            assertEquals(setOf("items", "item_index", "item_has_next", "item_comma", "item_and", "item_or"), usedParams)
+
+            emptyList()
+        }
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
     fun `for - ExprMustBeIterableException`() {
         val result = compile("") { env, resolver ->
             val context = ContextFactory { Context(env, Config.create(env.options), it) }.create(resolver)

--- a/komapper-template/src/main/kotlin/org/komapper/template/TwoWayTemplateStatementBuilder.kt
+++ b/komapper-template/src/main/kotlin/org/komapper/template/TwoWayTemplateStatementBuilder.kt
@@ -227,9 +227,9 @@ internal class TwoWayTemplateStatementBuilder(
             var index = 0
             val idIndex = id + "_index"
             val idHasNext = id + "_has_next"
-            val idComma = id + "_comma"
-            val idAnd = id + "_and"
-            val idOr = id + "_or"
+            val idComma = id + "_next_comma"
+            val idAnd = id + "_next_and"
+            val idOr = id + "_next_or"
             while (it.hasNext()) {
                 val each = it.next()
                 s.valueMap[id] = newValue(each)

--- a/komapper-template/src/main/kotlin/org/komapper/template/TwoWayTemplateStatementBuilder.kt
+++ b/komapper-template/src/main/kotlin/org/komapper/template/TwoWayTemplateStatementBuilder.kt
@@ -227,11 +227,17 @@ internal class TwoWayTemplateStatementBuilder(
             var index = 0
             val idIndex = id + "_index"
             val idHasNext = id + "_has_next"
+            val idComma = id + "_comma"
+            val idAnd = id + "_and"
+            val idOr = id + "_or"
             while (it.hasNext()) {
                 val each = it.next()
                 s.valueMap[id] = newValue(each)
                 s.valueMap[idIndex] = Value(index++, typeOf<Int>())
                 s.valueMap[idHasNext] = Value(it.hasNext(), typeOf<Boolean>())
+                s.valueMap[idComma] = Value(if (it.hasNext()) "," else "", typeOf<String>())
+                s.valueMap[idAnd] = Value(if (it.hasNext()) "and" else "", typeOf<String>())
+                s.valueMap[idOr] = Value(if (it.hasNext()) "or" else "", typeOf<String>())
                 s = node.forDirective.nodeList.fold(s, ::visit)
             }
             if (preserved != null) {
@@ -239,6 +245,9 @@ internal class TwoWayTemplateStatementBuilder(
             }
             s.valueMap.remove(idIndex)
             s.valueMap.remove(idHasNext)
+            s.valueMap.remove(idComma)
+            s.valueMap.remove(idAnd)
+            s.valueMap.remove(idOr)
             s
         }
 

--- a/komapper-template/src/test/kotlin/org/komapper/template/TwoWayTemplateStatementBuilderTest.kt
+++ b/komapper-template/src/test/kotlin/org/komapper/template/TwoWayTemplateStatementBuilderTest.kt
@@ -287,6 +287,53 @@ class TwoWayTemplateStatementBuilderTest {
             assertEquals(3, statement.args[4].any)
             assertEquals("Item3", statement.args[5].any)
         }
+
+        @Test
+        fun comma() {
+            val template =
+                "select name, age from person order by /*%for i in list*//*# i *//*# i_comma */ /*%end*/"
+            val statement =
+                statementBuilder.build(template, mapOf("list" to Value(listOf("a", "b", "c"), typeOf<List<Int>>())), extensions)
+            assertEquals("select name, age from person order by a, b, c ", statement.toSql())
+            assertEquals(
+                emptyList(),
+                statement.args,
+            )
+        }
+
+        @Test
+        fun and() {
+            val template =
+                "select name, age from person where /*%for i in list*/age = /*i*/0 /*# i_and */ /*%end*/"
+            val statement =
+                statementBuilder.build(template, mapOf("list" to Value(listOf(1, 2, 3), typeOf<List<Int>>())), extensions)
+            assertEquals("select name, age from person where age = ? and age = ? and age = ?  ", statement.toSql())
+            assertEquals(
+                listOf(
+                    Value(1, typeOf<Int>()),
+                    Value(2, typeOf<Int>()),
+                    Value(3, typeOf<Int>()),
+                ),
+                statement.args,
+            )
+        }
+
+        @Test
+        fun or() {
+            val template =
+                "select name, age from person where /*%for i in list*/age = /*i*/0 /*# i_or */ /*%end*/"
+            val statement =
+                statementBuilder.build(template, mapOf("list" to Value(listOf(1, 2, 3), typeOf<List<Int>>())), extensions)
+            assertEquals("select name, age from person where age = ? or age = ? or age = ?  ", statement.toSql())
+            assertEquals(
+                listOf(
+                    Value(1, typeOf<Int>()),
+                    Value(2, typeOf<Int>()),
+                    Value(3, typeOf<Int>()),
+                ),
+                statement.args,
+            )
+        }
     }
 
     @Nested

--- a/komapper-template/src/test/kotlin/org/komapper/template/TwoWayTemplateStatementBuilderTest.kt
+++ b/komapper-template/src/test/kotlin/org/komapper/template/TwoWayTemplateStatementBuilderTest.kt
@@ -291,7 +291,7 @@ class TwoWayTemplateStatementBuilderTest {
         @Test
         fun comma() {
             val template =
-                "select name, age from person order by /*%for i in list*//*# i *//*# i_comma */ /*%end*/"
+                "select name, age from person order by /*%for i in list*//*# i *//*# i_next_comma */ /*%end*/"
             val statement =
                 statementBuilder.build(template, mapOf("list" to Value(listOf("a", "b", "c"), typeOf<List<Int>>())), extensions)
             assertEquals("select name, age from person order by a, b, c ", statement.toSql())
@@ -304,7 +304,7 @@ class TwoWayTemplateStatementBuilderTest {
         @Test
         fun and() {
             val template =
-                "select name, age from person where /*%for i in list*/age = /*i*/0 /*# i_and */ /*%end*/"
+                "select name, age from person where /*%for i in list*/age = /*i*/0 /*# i_next_and */ /*%end*/"
             val statement =
                 statementBuilder.build(template, mapOf("list" to Value(listOf(1, 2, 3), typeOf<List<Int>>())), extensions)
             assertEquals("select name, age from person where age = ? and age = ? and age = ?  ", statement.toSql())
@@ -321,7 +321,7 @@ class TwoWayTemplateStatementBuilderTest {
         @Test
         fun or() {
             val template =
-                "select name, age from person where /*%for i in list*/age = /*i*/0 /*# i_or */ /*%end*/"
+                "select name, age from person where /*%for i in list*/age = /*i*/0 /*# i_next_or */ /*%end*/"
             val statement =
                 statementBuilder.build(template, mapOf("list" to Value(listOf(1, 2, 3), typeOf<List<Int>>())), extensions)
             assertEquals("select name, age from person where age = ? or age = ? or age = ?  ", statement.toSql())


### PR DESCRIPTION
This pull request adds the following utility variables to the `for` directive in SQL templates:

- *identifier*_next_comma - Returns `,` if the next iteration will be executed; otherwise, returns an empty string.
- *identifier*_next_and - Returns `and` if the next iteration will be executed; otherwise, returns an empty string.
- *identifier*_next_or - Returns `or` if the next iteration will be executed; otherwise, returns an empty string.

For example, if you wanted to output the OR operator in combination with the `for` directive, you previously had to write it as follows:

```sql
/*% for name in names */
employee_name like /* name */'hoge'
  /*% if name_has_next */
/*# "or" */
  /*% end */
/*% end */
```

However, by using one of the aforementioned utility variables, you can write it more concisely as follows:

```sql
/*% for name in names */
employee_name like /* name */'hoge'
/*# name_next_or */
/*% end */
```