### PR TITLE
Update SQL Server docker image to 2019-CU28-ubuntu-20.04

### DIFF
--- a/integration-test-jdbc/gradle.properties
+++ b/integration-test-jdbc/gradle.properties
@@ -6,4 +6,4 @@ mysql.url=jdbc:tc:mysql:8.0.25:///test?TC_DAEMON=true
 mysql5.url=jdbc:tc:mysql:5.7.44:///test?TC_DAEMON=true
 oracle.url=jdbc:tc:oracle:thin:@test?TC_DAEMON=true
 postgresql.url=jdbc:tc:postgis:12-3.4:///test?TC_DAEMON=true
-sqlserver.url=jdbc:tc:sqlserver:2019-CU12-ubuntu-20.04:///test?TC_DAEMON=true
+sqlserver.url=jdbc:tc:sqlserver:2019-CU28-ubuntu-20.04:///test?TC_DAEMON=true

--- a/integration-test-jdbc/src/test/resources/container-license-acceptance.txt
+++ b/integration-test-jdbc/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04
+mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04

--- a/integration-test-r2dbc/gradle.properties
+++ b/integration-test-r2dbc/gradle.properties
@@ -6,4 +6,4 @@ mysql.url=jdbc:tc:mysql:8.0.25:///test?TC_DAEMON=true
 mysql5.url=jdbc:tc:mysql:5.7.44:///test?TC_DAEMON=true
 oracle.url=jdbc:tc:oracle:thin:@test?TC_DAEMON=true
 postgresql.url=jdbc:tc:postgis:12-3.4:///test?TC_DAEMON=true
-sqlserver.url=jdbc:tc:sqlserver:2019-CU12-ubuntu-20.04:///test?TC_DAEMON=true
+sqlserver.url=jdbc:tc:sqlserver:2019-CU28-ubuntu-20.04:///test?TC_DAEMON=true

--- a/integration-test-r2dbc/src/test/resources/container-license-acceptance.txt
+++ b/integration-test-r2dbc/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04
+mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04


### PR DESCRIPTION
It seems that the Docker image of Microsoft SQL Server 2019-CU12-ubuntu-20.04 does not work on Ubuntu 22.04.5. Therefore, we have upgraded the version to 2019-CU28-ubuntu-20.04.