### PR TITLE
Distinguish between a column being null and the absence of a record in a `returning(expression)` query

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -383,3 +383,13 @@ public data class DepartmentDto(
 
 @KomapperProjectionDef(DepartmentDto::class)
 public object DepartmentDtoDef
+
+@KomapperEntity
+@KomapperTable(name = "address")
+public data class Site(
+    @KomapperId
+    @KomapperColumn(name = "address_id")
+    val id: Int,
+    val street: String?,
+    @KomapperVersion val version: Int,
+)

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleReturningTest.kt
@@ -3,7 +3,9 @@ package integration.jdbc
 import integration.core.Address
 import integration.core.Dbms
 import integration.core.Run
+import integration.core.Site
 import integration.core.address
+import integration.core.site
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.UniqueConstraintException
@@ -98,6 +100,26 @@ class JdbcUpdateSingleReturningTest(private val db: JdbcDatabase) {
                 2,
             ),
             address2,
+        )
+    }
+
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningSingleColumn_null() {
+        val s = Meta.site
+        val query = QueryDsl.from(s).where { s.id eq 15 }
+        val site = db.runQuery { query.first() }
+        val newSite = site.copy(street = null)
+        val street = db.runQuery { QueryDsl.update(s).single(newSite).returning(s.street) }
+        val site2 = db.runQuery { query.firstOrNull() }
+        assertNull(street)
+        assertEquals(
+            Site(
+                15,
+                null,
+                2,
+            ),
+            site2,
         )
     }
 

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteSingleReturningTest.kt
@@ -83,7 +83,7 @@ class R2dbcDeleteSingleReturningTest(private val db: R2dbcDatabase) {
         assertNull(address2)
     }
 
-    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn_null(info: TestInfo) = inTransaction(db, info) {
         val s = Meta.site

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDeleteSingleReturningTest.kt
@@ -3,6 +3,7 @@ package integration.r2dbc
 import integration.core.Dbms
 import integration.core.Run
 import integration.core.address
+import integration.core.site
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.OptimisticLockException
@@ -80,6 +81,21 @@ class R2dbcDeleteSingleReturningTest(private val db: R2dbcDatabase) {
         assertEquals(Triple(address.street, address.version, address.addressId), triple)
         val address2 = db.runQuery { query.firstOrNull() }
         assertNull(address2)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningSingleColumn_null(info: TestInfo) = inTransaction(db, info) {
+        val s = Meta.site
+        val query = QueryDsl.from(s).where { s.id eq 15 }
+        val site = db.runQuery { query.first() }
+        db.runQuery { QueryDsl.update(s).single(site.copy(street = null)) }
+        val site2 = db.runQuery { query.first() }
+        assertNull(site2.street)
+        val street = db.runQuery { QueryDsl.delete(s).single(site2).returning(s.street) }
+        assertNull(street)
+        val site3 = db.runQuery { query.firstOrNull() }
+        assertNull(site3)
     }
 
     @Run(unless = [Dbms.H2, Dbms.MARIADB, Dbms.POSTGRESQL, Dbms.SQLSERVER])

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleReturningTest.kt
@@ -63,7 +63,7 @@ class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
         )
     }
 
-    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Run(onlyIf = [Dbms.POSTGRESQL, Dbms.SQLSERVER])
     @Test
     fun testReturningSingleColumn_null(info: TestInfo) = inTransaction(db, info) {
         val s = Meta.site

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleReturningTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleReturningTest.kt
@@ -3,7 +3,9 @@ package integration.r2dbc
 import integration.core.Address
 import integration.core.Dbms
 import integration.core.Run
+import integration.core.Site
 import integration.core.address
+import integration.core.site
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.OptimisticLockException
@@ -58,6 +60,26 @@ class R2dbcUpdateSingleReturningTest(private val db: R2dbcDatabase) {
                 2,
             ),
             address2,
+        )
+    }
+
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun testReturningSingleColumn_null(info: TestInfo) = inTransaction(db, info) {
+        val s = Meta.site
+        val query = QueryDsl.from(s).where { s.id eq 15 }
+        val site = db.runQuery { query.first() }
+        val newSite = site.copy(street = null)
+        val street = db.runQuery { QueryDsl.update(s).single(newSite).returning(s.street) }
+        val site2 = db.runQuery { query.firstOrNull() }
+        assertNull(street)
+        assertEquals(
+            Site(
+                15,
+                null,
+                2,
+            ),
+            site2,
         )
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateSingleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateSingleReturningRunner.kt
@@ -29,9 +29,8 @@ class EntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMet
         return runner.preUpdate(config, entity)
     }
 
-    fun postUpdate(result: Any?) {
+    fun postUpdate(count: Long) {
         if (context.target.versionProperty() != null) {
-            val count = if (result == null) 0L else 1L
             checkOptimisticLock(context.options, count, null)
         }
     }


### PR DESCRIPTION
This pull request prevents the unintended occurrence of OptimisticLockException.