### PR TITLE
Add `EntityNotFoundException` to indicate that the target record for update or delete does not exist

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteSingleReturningTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteSingleReturningTest.kt
@@ -1,10 +1,13 @@
 package integration.jdbc
 
 import integration.core.Dbms
+import integration.core.Person
 import integration.core.Run
 import integration.core.address
+import integration.core.person
 import integration.core.site
 import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.EntityNotFoundException
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
@@ -108,5 +111,30 @@ class JdbcDeleteSingleReturningTest(private val db: JdbcDatabase) {
             Unit
         }
         println(ex)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun throwEntityNotFoundException() {
+        val p = Meta.person
+        val person = Person(1, "aaa")
+        val ex = assertFailsWith<EntityNotFoundException> {
+            db.runQuery { QueryDsl.delete(p).single(person).returning() }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Run(onlyIf = [Dbms.H2, Dbms.MARIADB, Dbms.ORACLE, Dbms.POSTGRESQL, Dbms.SQLSERVER])
+    @Test
+    fun suppressEntityNotFoundException() {
+        val p = Meta.person
+        val person = Person(1, "aaa")
+        val result = db.runQuery {
+            QueryDsl.delete(p).single(person).returning().options {
+                it.copy(suppressEntityNotFoundException = true)
+            }
+        }
+        assertNull(result)
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteSingleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcDeleteSingleTest.kt
@@ -1,8 +1,11 @@
 package integration.jdbc
 
 import integration.core.Address
+import integration.core.Person
 import integration.core.address
+import integration.core.person
 import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.EntityNotFoundException
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
@@ -35,5 +38,26 @@ class JdbcDeleteSingleTest(private val db: JdbcDatabase) {
         val address = db.runQuery { query.first() }
         db.runQuery { QueryDsl.delete(a).single(address) }
         assertEquals(emptyList<Address>(), db.runQuery { query })
+    }
+
+    @Test
+    fun throwEntityNotFoundException() {
+        val p = Meta.person
+        val person = Person(1, "aaa")
+        val ex = assertFailsWith<EntityNotFoundException> {
+            db.runQuery { QueryDsl.delete(p).single(person) }
+        }
+        println(ex)
+    }
+
+    @Test
+    fun suppressEntityNotFoundException() {
+        val p = Meta.person
+        val person = Person(1, "aaa")
+        db.runQuery {
+            QueryDsl.delete(p).single(person).options {
+                it.copy(suppressEntityNotFoundException = true)
+            }
+        }
     }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcUpdateSingleTest.kt
@@ -11,6 +11,7 @@ import integration.core.noVersionDepartment
 import integration.core.person
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.ClockProvider
+import org.komapper.core.EntityNotFoundException
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.UniqueConstraintException
 import org.komapper.core.dsl.Meta
@@ -234,5 +235,28 @@ class JdbcUpdateSingleTest(private val db: JdbcDatabase) {
             db.runQuery { updateQuery }.run { }
         }
         println(ex)
+    }
+
+    @Test
+    fun throwEntityNotFoundException() {
+        val p = Meta.person
+        val person = Person(1, "aaa")
+        val ex = assertFailsWith<EntityNotFoundException> {
+            db.runQuery { QueryDsl.update(p).single(person) }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Test
+    fun suppressEntityNotFoundException() {
+        val p = Meta.person
+        val person = Person(1, "aaa")
+        val result = db.runQuery {
+            QueryDsl.update(p).single(person).options {
+                it.copy(suppressEntityNotFoundException = true)
+            }
+        }
+        assertNotNull(result)
     }
 }

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateBatchTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateBatchTest.kt
@@ -11,6 +11,7 @@ import integration.core.man
 import integration.core.person
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.EntityNotFoundException
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.UniqueConstraintException
 import org.komapper.core.dsl.Meta
@@ -192,6 +193,57 @@ class R2dbcUpdateBatchTest(private val db: R2dbcDatabase) {
         for (person in afterUpdate) {
             assertEquals("nobody", person.createdBy)
             assertEquals("somebody", person.updatedBy)
+        }
+    }
+
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.SQLSERVER])
+    @Test
+    fun throwEntityNotFoundException(info: TestInfo) = inTransaction(db, info) {
+        val p = Meta.person
+        val people = listOf(
+            Person(1, "aaa"),
+            Person(2, "bbb"),
+            Person(3, "ccc")
+        )
+        val ex = assertFailsWith<EntityNotFoundException> {
+            db.runQuery { QueryDsl.update(p).batch(people) }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.SQLSERVER])
+    @Test
+    fun throwEntityNotFoundException_at_index_2(info: TestInfo) = inTransaction(db, info) {
+        val p = Meta.person
+        db.runQuery {
+            QueryDsl.insert(p).multiple(
+                Person(1, "aaa"),
+                Person(2, "bbb")
+            )
+        }
+        val people = db.runQuery { QueryDsl.from(p).orderBy(p.personId) }
+        assertEquals(2, people.size)
+        val ex = assertFailsWith<EntityNotFoundException> {
+            db.runQuery { QueryDsl.update(p).batch(people + listOf(Person(3, "ccc"))) }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Run(onlyIf = [Dbms.ORACLE, Dbms.SQLSERVER])
+    @Test
+    fun suppressEntityNotFoundException(info: TestInfo) = inTransaction(db, info) {
+        val p = Meta.person
+        val people = listOf(
+            Person(1, "aaa"),
+            Person(2, "bbb"),
+            Person(3, "ccc")
+        )
+        db.runQuery {
+            QueryDsl.update(p).batch(people).options {
+                it.copy(suppressEntityNotFoundException = true)
+            }
         }
     }
 }

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcUpdateSingleTest.kt
@@ -12,6 +12,7 @@ import integration.core.robot
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.ClockProvider
+import org.komapper.core.EntityNotFoundException
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.UniqueConstraintException
 import org.komapper.core.dsl.Meta
@@ -214,5 +215,28 @@ class R2dbcUpdateSingleTest(private val db: R2dbcDatabase) {
                     .single(department2)
             }.let { }
         }
+    }
+
+    @Test
+    fun throwEntityNotFoundException(info: TestInfo) = inTransaction(db, info) {
+        val p = Meta.person
+        val person = Person(1, "aaa")
+        val ex = assertFailsWith<EntityNotFoundException> {
+            db.runQuery { QueryDsl.update(p).single(person) }
+            Unit
+        }
+        println(ex)
+    }
+
+    @Test
+    fun suppressEntityNotFoundException(info: TestInfo) = inTransaction(db, info) {
+        val p = Meta.person
+        val person = Person(1, "aaa")
+        val result = db.runQuery {
+            QueryDsl.update(p).single(person).options {
+                it.copy(suppressEntityNotFoundException = true)
+            }
+        }
+        assertNotNull(result)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/Exceptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Exceptions.kt
@@ -8,6 +8,13 @@ package org.komapper.core
 class OptimisticLockException(message: String) : RuntimeException(message)
 
 /**
+ * Thrown if an entity is not found.
+ *
+ * @param message the detail message
+ */
+class EntityNotFoundException(message: String) : RuntimeException(message)
+
+/**
  * Thrown if a unique constraint is violated.
  *
  * @param cause the cause exception

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/DeleteOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/DeleteOptions.kt
@@ -8,7 +8,8 @@ data class DeleteOptions(
     override val queryTimeoutSeconds: Int? = DEFAULT.queryTimeoutSeconds,
     override val suppressLogging: Boolean = DEFAULT.suppressLogging,
     override val suppressOptimisticLockException: Boolean = DEFAULT.suppressOptimisticLockException,
-) : BatchOptions, OptimisticLockOptions, WhereOptions {
+    override val suppressEntityNotFoundException: Boolean = DEFAULT.suppressEntityNotFoundException,
+) : BatchOptions, OptimisticLockOptions, MutationOptions, WhereOptions {
     companion object {
         val DEFAULT = DeleteOptions(
             allowMissingWhereClause = false,
@@ -18,6 +19,7 @@ data class DeleteOptions(
             queryTimeoutSeconds = null,
             suppressLogging = false,
             suppressOptimisticLockException = false,
+            suppressEntityNotFoundException = false,
         )
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/MutationOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/MutationOptions.kt
@@ -1,0 +1,10 @@
+package org.komapper.core.dsl.options
+
+import org.komapper.core.EntityNotFoundException
+
+interface MutationOptions : QueryOptions {
+    /**
+     * Whether to suppress [EntityNotFoundException].
+     */
+    val suppressEntityNotFoundException: Boolean
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/UpdateOptions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/options/UpdateOptions.kt
@@ -8,7 +8,8 @@ data class UpdateOptions(
     override val queryTimeoutSeconds: Int? = DEFAULT.queryTimeoutSeconds,
     override val suppressLogging: Boolean = DEFAULT.suppressLogging,
     override val suppressOptimisticLockException: Boolean = DEFAULT.suppressOptimisticLockException,
-) : BatchOptions, OptimisticLockOptions, WhereOptions {
+    override val suppressEntityNotFoundException: Boolean = DEFAULT.suppressEntityNotFoundException,
+) : BatchOptions, OptimisticLockOptions, MutationOptions, WhereOptions {
     companion object {
         val DEFAULT = UpdateOptions(
             allowMissingWhereClause = false,
@@ -18,6 +19,7 @@ data class UpdateOptions(
             queryTimeoutSeconds = null,
             suppressLogging = false,
             suppressOptimisticLockException = false,
+            suppressEntityNotFoundException = false,
         )
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteBatchRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteBatchRunner.kt
@@ -30,8 +30,9 @@ class EntityDeleteBatchRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENT
     }
 
     fun postDelete(counts: List<Long>) {
-        for ((i, count) in counts.withIndex()) {
-            support.postDelete(count, i)
+        for ((i, pair) in entities.zip(counts).withIndex()) {
+            val (entity, count) = pair
+            support.postDelete(entity, count, i)
         }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteRunnerSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteRunnerSupport.kt
@@ -14,9 +14,11 @@ internal class EntityDeleteRunnerSupport<ENTITY : Any, ID : Any, META : EntityMe
         return builder.build()
     }
 
-    internal fun postDelete(count: Long, index: Int? = null) {
+    internal fun postDelete(entity: ENTITY, count: Long, index: Int? = null) {
         if (context.target.versionProperty() != null) {
             checkOptimisticLock(context.options, count, index)
+        } else {
+            checkEntityExistence(context.options, entity, count, index)
         }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteSingleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteSingleReturningRunner.kt
@@ -25,7 +25,7 @@ class EntityDeleteSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMet
         return runner.buildStatement(config)
     }
 
-    fun postDelete(count: Long) {
-        runner.postDelete(count)
+    fun postDelete(entity: ENTITY, count: Long) {
+        runner.postDelete(entity, count)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteSingleRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityDeleteSingleRunner.kt
@@ -24,7 +24,7 @@ class EntityDeleteSingleRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
         return support.buildStatement(config, entity)
     }
 
-    fun postDelete(count: Long) {
-        support.postDelete(count)
+    fun postDelete(entity: ENTITY, count: Long) {
+        support.postDelete(entity, count)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateRunnerSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateRunnerSupport.kt
@@ -22,6 +22,8 @@ internal class EntityUpdateRunnerSupport<ENTITY : Any, ID : Any, META : EntityMe
     internal fun postUpdate(entity: ENTITY, count: Long, index: Int? = null): ENTITY {
         if (context.target.versionProperty() != null) {
             checkOptimisticLock(context.options, count, index)
+        } else {
+            checkEntityExistence(context.options, entity, count, index)
         }
         return if (!context.options.disableOptimisticLock) {
             context.target.postUpdate(entity)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateSingleReturningRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpdateSingleReturningRunner.kt
@@ -29,9 +29,11 @@ class EntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMet
         return runner.preUpdate(config, entity)
     }
 
-    fun postUpdate(count: Long) {
+    fun postUpdate(entity: ENTITY, count: Long) {
         if (context.target.versionProperty() != null) {
             checkOptimisticLock(context.options, count, null)
+        } else {
+            checkEntityExistence(context.options, entity, count, null)
         }
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
@@ -1,12 +1,14 @@
 package org.komapper.core.dsl.runner
 
 import org.komapper.core.DatabaseConfig
+import org.komapper.core.EntityNotFoundException
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.dsl.builder.getWhereCriteria
 import org.komapper.core.dsl.context.WhereProvider
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.hasAutoIncrementProperty
 import org.komapper.core.dsl.options.InsertOptions
+import org.komapper.core.dsl.options.MutationOptions
 import org.komapper.core.dsl.options.OptimisticLockOptions
 
 fun checkWhereClause(whereProvider: WhereProvider) {
@@ -14,6 +16,19 @@ fun checkWhereClause(whereProvider: WhereProvider) {
         val criteria = whereProvider.getWhereCriteria()
         if (criteria.isEmpty()) {
             error("WHERE clause not found. If this is intentional, enable the allowMissingWhereClause option.")
+        }
+    }
+}
+
+fun checkEntityExistence(
+    option: MutationOptions,
+    entity: Any,
+    count: Long,
+    index: Int?,
+) {
+    if (!option.suppressEntityNotFoundException) {
+        if (count != 1L) {
+            throw EntityNotFoundException("The specified entity does not exist. entity=$entity, count=$count, index=$index.")
         }
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityDeleteSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityDeleteSingleReturningRunner.kt
@@ -14,7 +14,7 @@ import java.sql.ResultSet
 
 internal class JdbcEntityDeleteSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
     context: EntityDeleteContext<ENTITY, ID, META>,
-    entity: ENTITY,
+    private val entity: ENTITY,
     private val transform: (JdbcDataOperator, ResultSet) -> T,
 ) : JdbcRunner<T?> {
     private val runner: EntityDeleteSingleReturningRunner<ENTITY, ID, META> =
@@ -29,7 +29,7 @@ internal class JdbcEntityDeleteSingleReturningRunner<ENTITY : Any, ID : Any, MET
 
     override fun run(config: JdbcDatabaseConfig): T? {
         val result = delete(config)
-        postDelete(result.size.toLong())
+        postDelete(entity, result.size.toLong())
         return result.singleOrNull()
     }
 
@@ -42,8 +42,8 @@ internal class JdbcEntityDeleteSingleReturningRunner<ENTITY : Any, ID : Any, MET
         }
     }
 
-    private fun postDelete(count: Long) {
-        runner.postDelete(count)
+    private fun postDelete(entity: ENTITY, count: Long) {
+        runner.postDelete(entity, count)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityDeleteSingleRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityDeleteSingleRunner.kt
@@ -9,7 +9,7 @@ import org.komapper.jdbc.JdbcDatabaseConfig
 
 internal class JdbcEntityDeleteSingleRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     context: EntityDeleteContext<ENTITY, ID, META>,
-    entity: ENTITY,
+    private val entity: ENTITY,
 ) : JdbcRunner<Unit> {
     private val runner: EntityDeleteSingleRunner<ENTITY, ID, META> =
         EntityDeleteSingleRunner(context, entity)
@@ -23,7 +23,7 @@ internal class JdbcEntityDeleteSingleRunner<ENTITY : Any, ID : Any, META : Entit
 
     override fun run(config: JdbcDatabaseConfig) {
         val (count) = delete(config)
-        postDelete(count)
+        postDelete(entity, count)
     }
 
     private fun delete(config: JdbcDatabaseConfig): Pair<Long, List<Long>> {
@@ -31,8 +31,8 @@ internal class JdbcEntityDeleteSingleRunner<ENTITY : Any, ID : Any, META : Entit
         return support.delete(config) { it.executeUpdate(statement) }
     }
 
-    private fun postDelete(count: Long) {
-        runner.postDelete(count)
+    private fun postDelete(entity: ENTITY, count: Long) {
+        runner.postDelete(entity, count)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateSingleReturningRunner.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/dsl/runner/JdbcEntityUpdateSingleReturningRunner.kt
@@ -29,7 +29,7 @@ internal class JdbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, MET
     override fun run(config: JdbcDatabaseConfig): T? {
         val newEntity = preUpdate(config, entity)
         val result = update(config, newEntity)
-        postUpdate(result.size.toLong())
+        postUpdate(newEntity, result.size.toLong())
         return result.singleOrNull()
     }
 
@@ -46,8 +46,8 @@ internal class JdbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, MET
         }
     }
 
-    private fun postUpdate(count: Long) {
-        runner.postUpdate(count)
+    private fun postUpdate(entity: ENTITY, count: Long) {
+        runner.postUpdate(entity, count)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityDeleteSingleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityDeleteSingleReturningRunner.kt
@@ -14,7 +14,7 @@ import org.komapper.r2dbc.R2dbcDatabaseConfig
 
 internal class R2dbcEntityDeleteSingleReturningRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>, T>(
     context: EntityDeleteContext<ENTITY, ID, META>,
-    entity: ENTITY,
+    private val entity: ENTITY,
     private val transform: (R2dbcDataOperator, Row) -> T,
 ) : R2dbcRunner<T?> {
     private val runner: EntityDeleteSingleReturningRunner<ENTITY, ID, META> =
@@ -29,7 +29,7 @@ internal class R2dbcEntityDeleteSingleReturningRunner<ENTITY : Any, ID : Any, ME
 
     override suspend fun run(config: R2dbcDatabaseConfig): T? {
         val result = delete(config)
-        postDelete(result.size.toLong())
+        postDelete(entity, result.size.toLong())
         return result.singleOrNull()
     }
 
@@ -41,8 +41,8 @@ internal class R2dbcEntityDeleteSingleReturningRunner<ENTITY : Any, ID : Any, ME
         }
     }
 
-    private fun postDelete(count: Long) {
-        runner.postDelete(count)
+    private fun postDelete(entity: ENTITY, count: Long) {
+        runner.postDelete(entity, count)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityDeleteSingleRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityDeleteSingleRunner.kt
@@ -9,7 +9,7 @@ import org.komapper.r2dbc.R2dbcDatabaseConfig
 
 internal class R2dbcEntityDeleteSingleRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
     context: EntityDeleteContext<ENTITY, ID, META>,
-    entity: ENTITY,
+    private val entity: ENTITY,
 ) : R2dbcRunner<Unit> {
     private val runner: EntityDeleteSingleRunner<ENTITY, ID, META> =
         EntityDeleteSingleRunner(context, entity)
@@ -23,7 +23,7 @@ internal class R2dbcEntityDeleteSingleRunner<ENTITY : Any, ID : Any, META : Enti
 
     override suspend fun run(config: R2dbcDatabaseConfig) {
         val (count) = delete(config)
-        postDelete(count)
+        postDelete(entity, count)
     }
 
     private suspend fun delete(config: R2dbcDatabaseConfig): Pair<Long, List<Long>> {
@@ -31,8 +31,8 @@ internal class R2dbcEntityDeleteSingleRunner<ENTITY : Any, ID : Any, META : Enti
         return support.delete(config) { it.executeUpdate(statement) }
     }
 
-    private fun postDelete(count: Long) {
-        runner.postDelete(count)
+    private fun postDelete(entity: ENTITY, count: Long) {
+        runner.postDelete(entity, count)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpdateSingleReturningRunner.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/dsl/runner/R2dbcEntityUpdateSingleReturningRunner.kt
@@ -29,7 +29,7 @@ internal class R2dbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, ME
     override suspend fun run(config: R2dbcDatabaseConfig): T? {
         val newEntity = preUpdate(config, entity)
         val result = update(config, newEntity)
-        postUpdate(result.size.toLong())
+        postUpdate(newEntity, result.size.toLong())
         return result.singleOrNull()
     }
 
@@ -45,8 +45,8 @@ internal class R2dbcEntityUpdateSingleReturningRunner<ENTITY : Any, ID : Any, ME
         }
     }
 
-    private fun postUpdate(count: Long) {
-        runner.postUpdate(count)
+    private fun postUpdate(entity: ENTITY, count: Long) {
+        runner.postUpdate(entity, count)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {


### PR DESCRIPTION
This pull request throws `EntityNotFoundException` when the target record is missing during UPDATE or DELETE operations for entities without a version number.

To retain the previous behavior, enable the `suppressEntityNotFoundException` option:
```kotlin
val query = QueryDsl.update(p).single(person).options {
    it.copy(suppressEntityNotFoundException = true)
}
```