### PR TITLE
Add support for `ON CONFLICT WHERE` in Postgres

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/Entities.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/Entities.kt
@@ -404,3 +404,13 @@ public data class Spot(
     val street: String?,
     @KomapperVersion val version: Int,
 )
+
+@KomapperEntity
+@KomapperTable(name = "names")
+public data class Name(
+    @KomapperId
+    val id: Long,
+    val firstName: String?,
+    val lastName: String?,
+    val deletedAt: Instant?,
+)

--- a/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
@@ -66,7 +66,15 @@ public interface PostgreSqlSetting<DATABASE : Database> : Setting<DATABASE> {
 
             create table if not exists friend(uuid1 uuid, uuid2 uuid, pending boolean, constraint pk_friend primary key(uuid1, uuid2));
             create unique index friend_unique_idx on friend (greatest(uuid1, uuid2), least(uuid1, uuid2));
-            
+
+            create table names(
+                id bigint primary key not null,
+                first_name varchar(255),
+                last_name varchar(255),
+                deleted_at timestamp with time zone null
+            );
+            create unique index idx_uq_last_name on names(last_name) where deleted_at is null;
+
             insert into department values(1,10,'ACCOUNTING','NEW YORK',1);
             insert into department values(2,20,'RESEARCH','DALLAS',1);
             insert into department values(3,30,'SALES','CHICAGO',1);

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertMultipleTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcInsertMultipleTest.kt
@@ -5,12 +5,14 @@ import integration.core.Dbms
 import integration.core.Department
 import integration.core.IdentityStrategy
 import integration.core.Man
+import integration.core.Name
 import integration.core.Person
 import integration.core.Run
 import integration.core.address
 import integration.core.department
 import integration.core.identityStrategy
 import integration.core.man
+import integration.core.name
 import integration.core.person
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.UniqueConstraintException
@@ -294,5 +296,39 @@ class JdbcInsertMultipleTest(private val db: JdbcDatabase) {
             db.runQuery { query }
             Unit
         }
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdateWithIndexPredicate() {
+        val n = Meta.name
+        val names = listOf(
+            Name(1, "first1", "last1", null),
+            Name(2, "first2", "last2", null),
+        )
+        val query = QueryDsl.insert(n).onDuplicateKeyUpdate(n.lastName) {
+            n.deletedAt.isNull()
+        }.multiple(names)
+        db.runQuery { query }
+        val found = db.runQuery { QueryDsl.from(n).where { n.id inList listOf(1, 2) } }
+        assertEquals(2, found.size)
+    }
+
+    @Run(unless = [Dbms.POSTGRESQL])
+    @Test
+    fun onDuplicateKeyUpdateWithIndexPredicate_unsupported() {
+        val n = Meta.name
+        val names = listOf(
+            Name(1, "first1", "last1", null),
+            Name(2, "first2", "last2", null),
+        )
+        val query = QueryDsl.insert(n).onDuplicateKeyUpdate(n.lastName) {
+            n.deletedAt.isNull()
+        }.multiple(names)
+        val ex = assertFailsWith<UnsupportedOperationException> {
+            db.runQuery(query)
+            Unit
+        }
+        println(ex)
     }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -278,6 +278,11 @@ interface Dialect {
     fun supportsConflictTargetInUpsertStatement(): Boolean = false
 
     /**
+     * Returns whether the index_predicate is supported in the UPSERT statement.
+     */
+    fun supportsIndexPredicateInUpsertStatement(): Boolean = false
+
+    /**
      * Returns whether the "CREATE TABLE/SEQUENCE IF NOT EXISTS" syntax is supported.
      */
     fun supportsCreateIfNotExists(): Boolean = true

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderUtility.kt
@@ -35,6 +35,13 @@ internal fun SelectContext<*, *, *>.getHavingCriteria(): List<Criterion> {
     return support.toList()
 }
 
+fun EntityUpsertContext<*, *, *>.getIndexCriteria(): List<Criterion> {
+    if (indexPredicate == null) return emptyList()
+    val support = FilterScopeSupport(::WhereScope)
+    WhereScope(support).apply(indexPredicate)
+    return support.toList()
+}
+
 internal fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> RelationUpdateContext<ENTITY, ID, META>.getAssignments(): List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>> {
     val context = this
     val assignments = mutableListOf<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>()

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityInsertContext.kt
@@ -5,6 +5,7 @@ import org.komapper.core.dsl.element.Returning
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.SubqueryExpression
 import org.komapper.core.dsl.expression.TableExpression
+import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.options.InsertOptions
@@ -22,24 +23,28 @@ data class EntityInsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     fun asEntityUpsertContext(
         keys: List<PropertyMetamodel<ENTITY, *, *>>,
         duplicateKeyType: DuplicateKeyType,
+        indexPredicate: WhereDeclaration?,
     ): EntityUpsertContext<ENTITY, ID, META> {
         return EntityUpsertContext(
             insertContext = this,
             target = target,
             keys = keys,
             duplicateKeyType = duplicateKeyType,
+            indexPredicate = indexPredicate,
         )
     }
 
     fun asEntityUpsertContext(
         conflictTarget: String,
         duplicateKeyType: DuplicateKeyType,
+        indexPredicate: WhereDeclaration?,
     ): EntityUpsertContext<ENTITY, ID, META> {
         return EntityUpsertContext(
             insertContext = this,
             target = target,
             conflictTarget = conflictTarget,
             duplicateKeyType = duplicateKeyType,
+            indexPredicate = indexPredicate,
         )
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/EntityUpsertContext.kt
@@ -29,6 +29,7 @@ data class EntityUpsertContext<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     val set: AssignmentDeclaration<ENTITY, META> = {},
     val where: WhereDeclaration = {},
     override val returning: Returning = Returning.Expressions(emptyList()),
+    val indexPredicate: WhereDeclaration?,
 ) : WhereProvider, TablesProvider, ReturningProvider {
     override val options: WhereOptions
         get() = insertContext.options

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertQueryBuilder.kt
@@ -5,6 +5,7 @@ import org.komapper.core.dsl.context.DuplicateKeyType
 import org.komapper.core.dsl.context.EntityInsertContext
 import org.komapper.core.dsl.expression.AssignmentDeclaration
 import org.komapper.core.dsl.expression.SubqueryExpression
+import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.PropertyMetamodel
 
@@ -21,10 +22,12 @@ interface InsertQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * Creates a builder of the query that inserts or updates entities.
      *
      * @param keys the keys used for duplicate checking
+     * @param where the index predicate
      * @return the query
      */
     fun onDuplicateKeyUpdate(
         vararg keys: PropertyMetamodel<ENTITY, *, *> = emptyArray(),
+        where: WhereDeclaration? = null,
     ): InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY, ID, META>
 
     /**
@@ -40,10 +43,12 @@ interface InsertQueryBuilder<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTI
      * Creates a builder of the query that inserts entities and ignores duplicate keys.
      *
      * @param keys the keys used for duplicate checking
+     * @param where the index predicate
      * @return the query
      */
     fun onDuplicateKeyIgnore(
         vararg keys: PropertyMetamodel<ENTITY, *, *> = emptyArray(),
+        where: WhereDeclaration? = null,
     ): InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META>
 
     /**
@@ -126,23 +131,24 @@ internal data class InsertQueryBuilderImpl<ENTITY : Any, ID : Any, META : Entity
     InsertQueryBuilder<ENTITY, ID, META> {
     override fun onDuplicateKeyUpdate(
         vararg keys: PropertyMetamodel<ENTITY, *, *>,
+        where: WhereDeclaration?,
     ): InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY, ID, META> {
-        val newContext = context.asEntityUpsertContext(keys.toList(), DuplicateKeyType.UPDATE)
+        val newContext = context.asEntityUpsertContext(keys.toList(), DuplicateKeyType.UPDATE, where)
         return InsertOnDuplicateKeyUpdateQueryBuilderNonNullImpl(newContext)
     }
 
     override fun dangerouslyOnDuplicateKeyUpdate(conflictTarget: String): InsertOnDuplicateKeyUpdateQueryBuilderNonNull<ENTITY, ID, META> {
-        val newContext = context.asEntityUpsertContext(conflictTarget, DuplicateKeyType.UPDATE)
+        val newContext = context.asEntityUpsertContext(conflictTarget, DuplicateKeyType.UPDATE, null)
         return InsertOnDuplicateKeyUpdateQueryBuilderNonNullImpl(newContext)
     }
 
-    override fun onDuplicateKeyIgnore(vararg keys: PropertyMetamodel<ENTITY, *, *>): InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META> {
-        val newContext = context.asEntityUpsertContext(keys.toList(), DuplicateKeyType.IGNORE)
+    override fun onDuplicateKeyIgnore(vararg keys: PropertyMetamodel<ENTITY, *, *>, where: WhereDeclaration?): InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META> {
+        val newContext = context.asEntityUpsertContext(keys.toList(), DuplicateKeyType.IGNORE, where)
         return InsertOnDuplicateKeyIgnoreQueryBuilderImpl(newContext)
     }
 
     override fun dangerouslyOnDuplicateKeyIgnore(conflictTarget: String): InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY, ID, META> {
-        val newContext = context.asEntityUpsertContext(conflictTarget, DuplicateKeyType.IGNORE)
+        val newContext = context.asEntityUpsertContext(conflictTarget, DuplicateKeyType.IGNORE, null)
         return InsertOnDuplicateKeyIgnoreQueryBuilderImpl(newContext)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertBatchRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertBatchRunner.kt
@@ -17,6 +17,7 @@ class EntityUpsertBatchRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<ENT
         checkBatchExecutionOfParameterizedStatement(config)
         checkSearchConditionInUpsertStatement(config, context)
         checkConflictTargetInUpsertStatement(config, context.conflictTarget)
+        checkIndexPredicateInUpsertStatement(config, context.indexPredicate)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertMultipleRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertMultipleRunner.kt
@@ -16,6 +16,7 @@ class EntityUpsertMultipleRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<
     override fun check(config: DatabaseConfig) {
         checkSearchConditionInUpsertStatement(config, context)
         checkConflictTargetInUpsertStatement(config, context.conflictTarget)
+        checkIndexPredicateInUpsertStatement(config, context.indexPredicate)
         checkAutoIncrementWhenInsertingMultipleRows(config, context.target)
     }
 

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertSingleRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/EntityUpsertSingleRunner.kt
@@ -16,6 +16,7 @@ class EntityUpsertSingleRunner<ENTITY : Any, ID : Any, META : EntityMetamodel<EN
     override fun check(config: DatabaseConfig) {
         checkSearchConditionInUpsertStatement(config, context)
         checkConflictTargetInUpsertStatement(config, context.conflictTarget)
+        checkIndexPredicateInUpsertStatement(config, context.indexPredicate)
     }
 
     override fun dryRun(config: DatabaseConfig): DryRunStatement {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/RunnerUtility.kt
@@ -5,6 +5,7 @@ import org.komapper.core.EntityNotFoundException
 import org.komapper.core.OptimisticLockException
 import org.komapper.core.dsl.builder.getWhereCriteria
 import org.komapper.core.dsl.context.WhereProvider
+import org.komapper.core.dsl.expression.WhereDeclaration
 import org.komapper.core.dsl.metamodel.EntityMetamodel
 import org.komapper.core.dsl.metamodel.hasAutoIncrementProperty
 import org.komapper.core.dsl.options.InsertOptions
@@ -88,6 +89,15 @@ internal fun checkConflictTargetInUpsertStatement(config: DatabaseConfig, confli
     if (!config.dialect.supportsConflictTargetInUpsertStatement() && conflictTarget != null) {
         throw UnsupportedOperationException(
             "The dialect(driver=${dialect.driver}) does not support specifying a conflict target in upsert statements.",
+        )
+    }
+}
+
+internal fun checkIndexPredicateInUpsertStatement(config: DatabaseConfig, indexPredicate: WhereDeclaration?) {
+    val dialect = config.dialect
+    if (!config.dialect.supportsIndexPredicateInUpsertStatement() && indexPredicate != null) {
+        throw UnsupportedOperationException(
+            "The dialect(driver=${dialect.driver}) does not support specifying a index predicate in upsert statements.",
         )
     }
 }

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlDialect.kt
@@ -98,6 +98,8 @@ interface PostgreSqlDialect : Dialect {
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = true
 
+    override fun supportsIndexPredicateInUpsertStatement(): Boolean = true
+
     override fun supportsDeleteReturning(): Boolean = true
 
     override fun supportsLockOfTables(): Boolean = true

--- a/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
+++ b/komapper-dialect-postgresql/src/main/kotlin/org/komapper/dialect/postgresql/PostgreSqlEntityUpsertStatementBuilder.kt
@@ -5,8 +5,10 @@ import org.komapper.core.Statement
 import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.builder.AliasManager
 import org.komapper.core.dsl.builder.BuilderSupport
+import org.komapper.core.dsl.builder.EmptyAliasManager
 import org.komapper.core.dsl.builder.EntityUpsertStatementBuilder
 import org.komapper.core.dsl.builder.TableNameType
+import org.komapper.core.dsl.builder.getIndexCriteria
 import org.komapper.core.dsl.builder.getWhereCriteria
 import org.komapper.core.dsl.context.DuplicateKeyType
 import org.komapper.core.dsl.context.EntityUpsertContext
@@ -96,6 +98,16 @@ class PostgreSqlEntityUpsertStatementBuilder<ENTITY : Any, ID : Any, META : Enti
                 }
                 buf.cutBack(2)
                 buf.append(")")
+            }
+            val criteria = context.getIndexCriteria()
+            if (criteria.isNotEmpty()) {
+                val support = BuilderSupport(dialect, EmptyAliasManager, buf, context.insertContext.options.escapeSequence)
+                buf.append(" where ")
+                for ((index, criterion) in criteria.withIndex()) {
+                    support.visitCriterion(index, criterion)
+                    buf.append(" and ")
+                }
+                buf.cutBack(5)
             }
         }
     }


### PR DESCRIPTION
This PR introduces support for the `ON CONFLICT WHERE` clause in PostgreSQL. The `ON CONFLICT WHERE` clause allows for more granular control over conflict handling by adding conditional constraints during `INSERT` operations, enabling developers to specify when conflicts should be handled based on additional criteria.

Please also refer to the explanation of index_predicate in the PostgreSQL documentation:
https://www.postgresql.org/docs/current/sql-insert.html

## Example

### Query DSL
```kotlin
val n = Meta.name
val name = Name(1, "first", "last", null)

val query = QueryDsl.insert(n).onDuplicateKeyUpdate(n.lastName) {
    n.deletedAt.isNull()
}.single(name)
```

### Generated SQL
``` sql
insert into names as t0_ (id, first_name, last_name, deleted_at) 
values (1, 'first', 'last', null) 
on conflict (last_name) where deleted_at is null
do update set 
first_name = excluded.first_name, last_name = excluded.last_name, deleted_at = excluded.deleted_at
```