### PR TITLE
Fix SpringBoot autoconfiguration dependencies & polish

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ spring-tx = { module = "org.springframework:spring-tx", version.ref = "springfra
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "spring-boot" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "spring-boot" }
 spring-boot-starter-jdbc = { module = "org.springframework.boot:spring-boot-starter-jdbc", version.ref = "spring-boot" }
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot" }
 
 quarkus-bom = { module = "io.quarkus:quarkus-bom", version.ref = "quarkus" }
 quarkus-core = { module = "io.quarkus:quarkus-core" }

--- a/komapper-spring-boot-autoconfigure-jdbc/build.gradle.kts
+++ b/komapper-spring-boot-autoconfigure-jdbc/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     api(project(":komapper-spring-jdbc"))
     testImplementation(project(":komapper-slf4j"))
     testImplementation(project(":komapper-dialect-h2-jdbc"))
+    testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.logback.classic)
     testImplementation(libs.hikariCP)
 }

--- a/komapper-spring-boot-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfiguration.kt
+++ b/komapper-spring-boot-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfiguration.kt
@@ -25,13 +25,13 @@ import org.komapper.jdbc.JdbcDialects
 import org.komapper.jdbc.JdbcSession
 import org.komapper.jdbc.SimpleJdbcDatabaseConfig
 import org.komapper.spring.jdbc.SpringJdbcTransactionSession
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.core.env.Environment
 import org.springframework.transaction.PlatformTransactionManager
 import java.util.Optional
@@ -39,9 +39,9 @@ import java.util.UUID
 import javax.sql.DataSource
 
 @Suppress("unused")
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = [DataSourceAutoConfiguration::class, DataSourceTransactionManagerAutoConfiguration::class])
 @ConditionalOnClass(JdbcDatabase::class)
-@ImportAutoConfiguration(value = [DataSourceAutoConfiguration::class, DataSourceTransactionManagerAutoConfiguration::class])
+@ConditionalOnBean(PlatformTransactionManager::class, DataSource::class)
 open class KomapperJdbcAutoConfiguration {
     companion object {
         private const val DATASOURCE_URL_PROPERTY = "spring.datasource.url"

--- a/komapper-spring-boot-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfiguration.kt
+++ b/komapper-spring-boot-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfiguration.kt
@@ -49,7 +49,7 @@ open class KomapperJdbcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    open fun dialect(environment: Environment): JdbcDialect {
+    open fun komapperDialect(environment: Environment): JdbcDialect {
         val url = environment.getProperty(DATASOURCE_URL_PROPERTY)
             ?: error(
                 "$DATASOURCE_URL_PROPERTY is not found. " +
@@ -60,62 +60,68 @@ open class KomapperJdbcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    open fun clockProvider(): ClockProvider {
+    open fun komapperClockProvider(): ClockProvider {
         return DefaultClockProvider()
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun executionOptions(): ExecutionOptions {
+    open fun komapperExecutionOptions(): ExecutionOptions {
         return ExecutionOptions()
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun logger(): Logger {
+    open fun komapperLogger(): Logger {
         return Loggers.get()
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun loggerFacade(logger: Logger): LoggerFacade {
+    open fun komapperLoggerFacade(logger: Logger): LoggerFacade {
         return LoggerFacades.get(logger)
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun session(transactionManager: PlatformTransactionManager, dataSource: DataSource): JdbcSession {
+    open fun komapperSession(transactionManager: PlatformTransactionManager, dataSource: DataSource): JdbcSession {
         return SpringJdbcTransactionSession(transactionManager, dataSource)
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun statementInspector(): StatementInspector {
+    open fun komapperStatementInspector(): StatementInspector {
         return StatementInspectors.get()
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun dataFactory(databaseSession: JdbcSession): JdbcDataFactory {
+    open fun komapperDataFactory(databaseSession: JdbcSession): JdbcDataFactory {
         return DefaultJdbcDataFactory(databaseSession)
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun dataOperator(dialect: JdbcDialect, dataTypeProvider: Optional<JdbcDataTypeProvider>): JdbcDataOperator {
+    open fun komapperDataOperator(
+        dialect: JdbcDialect,
+        dataTypeProvider: Optional<JdbcDataTypeProvider>,
+    ): JdbcDataOperator {
         val provider = JdbcDataTypeProviders.get(dialect.driver, dataTypeProvider.orElse(null))
         return DefaultJdbcDataOperator(dialect, provider)
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun templateStatementBuilder(dialect: JdbcDialect, dataOperator: JdbcDataOperator): TemplateStatementBuilder {
+    open fun komapperTemplateStatementBuilder(
+        dialect: JdbcDialect,
+        dataOperator: JdbcDataOperator,
+    ): TemplateStatementBuilder {
         return TemplateStatementBuilders.get(BuilderDialect(dialect, dataOperator))
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun databaseConfig(
+    open fun komapperDatabaseConfig(
         dialect: JdbcDialect,
         clockProvider: ClockProvider,
         executionOptions: ExecutionOptions,
@@ -146,7 +152,7 @@ open class KomapperJdbcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    open fun database(config: JdbcDatabaseConfig): JdbcDatabase {
+    open fun komapperDatabase(config: JdbcDatabaseConfig): JdbcDatabase {
         return JdbcDatabase(config)
     }
 }

--- a/komapper-spring-boot-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfigurationTest.kt
+++ b/komapper-spring-boot-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfigurationTest.kt
@@ -88,6 +88,18 @@ class KomapperJdbcAutoConfigurationTest {
             }
     }
 
+    @Test
+    fun disabledConfiguration() {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KomapperJdbcAutoConfiguration::class.java))
+            .withPropertyValues("spring.datasource.url=jdbc:h2:mem:example")
+            .run { context ->
+                assertThat(context)
+                    .hasNotFailed()
+                    .doesNotHaveBean(JdbcDatabase::class.java)
+            }
+    }
+
     @Suppress("unused", "UNCHECKED_CAST")
     @Configuration
     open class CustomConfigure {

--- a/komapper-spring-boot-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfigurationTest.kt
+++ b/komapper-spring-boot-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfigurationTest.kt
@@ -1,5 +1,6 @@
 package org.komapper.spring.boot.autoconfigure.jdbc
 
+import org.assertj.core.api.Assertions.assertThat
 import org.komapper.core.ClockProvider
 import org.komapper.core.ExecutionOptions
 import org.komapper.core.Statement
@@ -11,11 +12,12 @@ import org.komapper.jdbc.JdbcDataType
 import org.komapper.jdbc.JdbcDataTypeProvider
 import org.komapper.jdbc.JdbcDatabase
 import org.komapper.jdbc.JdbcStringType
+import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.env.MapPropertySource
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -28,64 +30,62 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class KomapperJdbcAutoConfigurationTest {
-    private val context = AnnotationConfigApplicationContext()
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                DataSourceAutoConfiguration::class.java,
+                DataSourceTransactionManagerAutoConfiguration::class.java,
+                KomapperJdbcAutoConfiguration::class.java,
+            )
+        )
+        .withPropertyValues(
+            "spring.datasource.url=jdbc:h2:mem:example",
+        )
 
     @Test
     fun defaultConfiguration() {
-        val source = mapOf("spring.datasource.url" to "jdbc:h2:mem:example")
-        val sources = context.environment.propertySources
-        sources.addFirst(MapPropertySource("test", source))
-        context.register(
-            KomapperJdbcAutoConfiguration::class.java,
-            DataSourceAutoConfiguration::class.java,
-        )
-        context.refresh()
+        contextRunner
+            .run { context ->
+                assertThat(context).hasNotFailed()
 
-        val database = context.getBean(JdbcDatabase::class.java)
-        assertNotNull(database)
-        assertTrue(database.config.dialect is H2JdbcDialect)
-        assertNotNull(database.config.templateStatementBuilder)
+                val database = context.getBean(JdbcDatabase::class.java)
+                assertNotNull(database)
+                assertTrue(database.config.dialect is H2JdbcDialect)
+                assertNotNull(database.config.templateStatementBuilder)
+            }
     }
 
     @Test
     fun customConfiguration() {
-        val source = mapOf("spring.datasource.url" to "jdbc:h2:mem:example")
-        val sources = context.environment.propertySources
-        sources.addFirst(MapPropertySource("test", source))
-        context.register(
-            CustomConfigure::class.java,
-            KomapperJdbcAutoConfiguration::class.java,
-            DataSourceAutoConfiguration::class.java,
-        )
-        context.refresh()
+        contextRunner
+            .withUserConfiguration(CustomConfigure::class.java)
+            .run { context ->
+                assertThat(context).hasNotFailed()
 
-        val database = context.getBean(JdbcDatabase::class.java)
-        assertNotNull(database)
-        val dataType = database.config.dataOperator.getDataType<String>(typeOf<String>())
-        assertEquals("abc", dataType.name)
-        val clock = database.config.clockProvider.now()
-        val timestamp = LocalDateTime.now(clock)
-        assertEquals(LocalDateTime.of(2021, 4, 25, 16, 17, 18), timestamp)
-        val jdbcOption = database.config.executionOptions
-        assertEquals(1234, jdbcOption.queryTimeoutSeconds)
+                val database = context.getBean(JdbcDatabase::class.java)
+                assertNotNull(database)
+                val dataType = database.config.dataOperator.getDataType<String>(typeOf<String>())
+                assertEquals("abc", dataType.name)
+                val clock = database.config.clockProvider.now()
+                val timestamp = LocalDateTime.now(clock)
+                assertEquals(LocalDateTime.of(2021, 4, 25, 16, 17, 18), timestamp)
+                val jdbcOption = database.config.executionOptions
+                assertEquals(1234, jdbcOption.queryTimeoutSeconds)
+            }
     }
 
     @Test
     fun templateStatementBuilderConfiguration() {
-        val source = mapOf("spring.datasource.url" to "jdbc:h2:mem:example")
-        val sources = context.environment.propertySources
-        sources.addFirst(MapPropertySource("test", source))
-        context.register(
-            TemplateStatementBuilderConfigure::class.java,
-            KomapperJdbcAutoConfiguration::class.java,
-            DataSourceAutoConfiguration::class.java,
-        )
-        context.refresh()
+        contextRunner
+            .withUserConfiguration(TemplateStatementBuilderConfigure::class.java)
+            .run { context ->
+                assertThat(context).hasNotFailed()
 
-        val database = context.getBean(JdbcDatabase::class.java)
-        assertNotNull(database)
-        val builder = database.config.templateStatementBuilder
-        assertTrue(builder is MyStatementBuilder)
+                val database = context.getBean(JdbcDatabase::class.java)
+                assertNotNull(database)
+                val builder = database.config.templateStatementBuilder
+                assertTrue(builder is MyStatementBuilder)
+            }
     }
 
     @Suppress("unused", "UNCHECKED_CAST")

--- a/komapper-spring-boot-autoconfigure-r2dbc/build.gradle.kts
+++ b/komapper-spring-boot-autoconfigure-r2dbc/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     api(project(":komapper-spring-r2dbc"))
     testImplementation(project(":komapper-slf4j"))
     testImplementation(project(":komapper-dialect-h2-r2dbc"))
+    testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.r2dbc.pool)
     testImplementation(libs.logback.classic)
 }

--- a/komapper-spring-boot-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/r2dbc/KomapperR2dbcAutoConfiguration.kt
+++ b/komapper-spring-boot-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/r2dbc/KomapperR2dbcAutoConfiguration.kt
@@ -24,22 +24,22 @@ import org.komapper.r2dbc.R2dbcDialects
 import org.komapper.r2dbc.R2dbcSession
 import org.komapper.r2dbc.SimpleR2dbcDatabaseConfig
 import org.komapper.spring.r2dbc.SpringR2dbcTransactionSession
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration
 import org.springframework.boot.autoconfigure.r2dbc.R2dbcTransactionManagerAutoConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.core.env.Environment
 import org.springframework.transaction.ReactiveTransactionManager
 import java.util.Optional
 import java.util.UUID
 
 @Suppress("unused")
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = [R2dbcAutoConfiguration::class, R2dbcTransactionManagerAutoConfiguration::class])
 @ConditionalOnClass(R2dbcDatabase::class)
-@ImportAutoConfiguration(value = [R2dbcAutoConfiguration::class, R2dbcTransactionManagerAutoConfiguration::class])
+@ConditionalOnBean(ReactiveTransactionManager::class, ConnectionFactory::class)
 open class KomapperR2dbcAutoConfiguration {
     companion object {
         private const val R2DBC_URL_PROPERTY = "spring.r2dbc.url"

--- a/komapper-spring-boot-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/r2dbc/KomapperR2dbcAutoConfiguration.kt
+++ b/komapper-spring-boot-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/r2dbc/KomapperR2dbcAutoConfiguration.kt
@@ -47,7 +47,7 @@ open class KomapperR2dbcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    open fun dialect(environment: Environment): R2dbcDialect {
+    open fun komapperDialect(environment: Environment): R2dbcDialect {
         val url = environment.getProperty(R2DBC_URL_PROPERTY)
             ?: error(
                 "$R2DBC_URL_PROPERTY is not found. " +
@@ -59,31 +59,31 @@ open class KomapperR2dbcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    open fun clockProvider(): ClockProvider {
+    open fun komapperClockProvider(): ClockProvider {
         return DefaultClockProvider()
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun executionOptions(): ExecutionOptions {
+    open fun komapperExecutionOptions(): ExecutionOptions {
         return ExecutionOptions()
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun logger(): Logger {
+    open fun komapperLogger(): Logger {
         return Loggers.get()
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun loggerFacade(logger: Logger): LoggerFacade {
+    open fun komapperLoggerFacade(logger: Logger): LoggerFacade {
         return LoggerFacades.get(logger)
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun session(
+    open fun komapperSession(
         transactionManager: ReactiveTransactionManager,
         connectionFactory: ConnectionFactory,
     ): R2dbcSession {
@@ -92,20 +92,23 @@ open class KomapperR2dbcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    open fun statementInspector(): StatementInspector {
+    open fun komapperStatementInspector(): StatementInspector {
         return StatementInspectors.get()
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun dataOperator(dialect: R2dbcDialect, dataTypeProvider: Optional<R2dbcDataTypeProvider>): R2dbcDataOperator {
+    open fun komapperDataOperator(
+        dialect: R2dbcDialect,
+        dataTypeProvider: Optional<R2dbcDataTypeProvider>,
+    ): R2dbcDataOperator {
         val provider = R2dbcDataTypeProviders.get(dialect.driver, dataTypeProvider.orElse(null))
         return DefaultR2dbcDataOperator(dialect, provider)
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun templateStatementBuilder(
+    open fun komapperTemplateStatementBuilder(
         dialect: R2dbcDialect,
         dataOperator: R2dbcDataOperator,
     ): TemplateStatementBuilder {
@@ -114,7 +117,7 @@ open class KomapperR2dbcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    open fun databaseConfig(
+    open fun komapperDatabaseConfig(
         dialect: R2dbcDialect,
         clockProvider: ClockProvider,
         executionOptions: ExecutionOptions,
@@ -143,7 +146,7 @@ open class KomapperR2dbcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    open fun r2dbcDatabase(config: R2dbcDatabaseConfig): R2dbcDatabase {
+    open fun komapperR2dbcDatabase(config: R2dbcDatabaseConfig): R2dbcDatabase {
         return R2dbcDatabase(config)
     }
 }

--- a/komapper-spring-boot-autoconfigure-r2dbc/src/test/kotlin/org/komapper/spring/boot/autoconfigure/r2dbc/KomapperR2dbcAutoConfigurationTest.kt
+++ b/komapper-spring-boot-autoconfigure-r2dbc/src/test/kotlin/org/komapper/spring/boot/autoconfigure/r2dbc/KomapperR2dbcAutoConfigurationTest.kt
@@ -81,6 +81,18 @@ class KomapperR2dbcAutoConfigurationTest {
             }
     }
 
+    @Test
+    fun disabledConfiguration() {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KomapperR2dbcAutoConfiguration::class.java))
+            .withPropertyValues("spring.r2dbc.url=r2dbc:h2:mem:///test")
+            .run { context ->
+                assertThat(context)
+                    .hasNotFailed()
+                    .doesNotHaveBean(R2dbcDatabase::class.java)
+            }
+    }
+
     @Suppress("unused")
     @Configuration
     open class CustomConfigure {


### PR DESCRIPTION
## Use `ApplicationContextRunner` to test Spring Boot autoconfigurations

Spring Boot provides `ApplicationContextRunner` as a way to properly test autoconfigurations. It matches the way Spring Boot loads configurations by itself, making sure, e.g., that user configuration beans take precedence over autoconfigured ones, autoconfigurations are properly ordered, etc.

Using `ApplicationContextRunner` makes tests more resilient to configuration and better match real behaviour.

See https://spring.io/blog/2018/03/07/testing-auto-configurations-with-spring-boot-2-0 for more details.

## Fix Spring Boot autoconfiguration dependencies

Avoid using `@ImportAutoConfiguration` on autoconfiguration classes. That creates rigid dependencies that can become problematic in case when multiple autoconfigurations provide the same bean.

In particular, that causes issues when `KomapperJdbcAutoConfiguration` is used along with Spring Data JPA in the same application - `KomapperJdbcAutoConfiguration` forces `DataSourceTransactionManagerAutoConfiguration` to be loaded, which creates `TransactionManager` as `JdbcTransactionManager` (or `DataSourceTransactionManager`), even though when Spring Data JPA is present, `TransactionManager` is supposed to be defined by `JpaBaseConfiguration` (loaded by e.g. `HibernateJpaAutoConfiguration`). That in turn makes it impossible to use `EntityManager` and Spring Data JPA repositories inside Spring-initiated transactions.

Spring Boot's own autoconfigurations do not use `@ImportAutoConfiguration`, instead preferring to declare ordering via
`@AutoConfigureBefore`/`@AutoConfigureAfter` and various `@Conditional`s.

PS. This is the primary reason for this PR.

## Use more distinct names for Spring beans

By default, Spring Boot uses the name of `@Bean`-annotated method as a bean name. It should resolve possible name conflicts, however, generic bean names like "dialect", "clockProvider" or "logger" might be somewhat confusing when inspecting the context.

This change adds "komapper" as a prefix for all bean names to make them more unique.