### PR TITLE
Avoid the use of deprecated class

### DIFF
--- a/komapper-quarkus-jdbc/src/main/java/org/komapper/quarkus/jdbc/DefaultDataSourceResolver.java
+++ b/komapper-quarkus-jdbc/src/main/java/org/komapper/quarkus/jdbc/DefaultDataSourceResolver.java
@@ -1,9 +1,8 @@
 package org.komapper.quarkus.jdbc;
 
-import io.quarkus.agroal.runtime.DataSources;
+import io.quarkus.agroal.runtime.AgroalDataSourceUtil;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.arc.Unremovable;
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.Objects;
 import javax.sql.DataSource;
@@ -13,16 +12,9 @@ import javax.sql.DataSource;
 @Unremovable
 public class DefaultDataSourceResolver implements DataSourceResolver {
 
-  private final DataSources dataSources;
-
-  @Inject
-  public DefaultDataSourceResolver(DataSources dataSources) {
-    this.dataSources = Objects.requireNonNull(dataSources);
-  }
-
   @Override
   public DataSource resolve(String dataSourceName) {
     Objects.requireNonNull(dataSourceName);
-    return dataSources.getDataSource(dataSourceName);
+    return AgroalDataSourceUtil.dataSourceInstance(dataSourceName).get();
   }
 }


### PR DESCRIPTION
We stop using `io.quarkus.agroal.runtime.DataSources` and switch to `AgroalDataSourceUtil`.