### PR TITLE
Add Spring Boot test slices

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -138,6 +138,22 @@ module/spring-boot-starter-r2dbc:
 - changed-files:
   - any-glob-to-any-file: 'komapper-spring-boot-starter-r2dbc/**/*'
 
+module/spring-boot-starter-test-jdbc:
+- changed-files:
+  - any-glob-to-any-file: 'komapper-spring-boot-starter-test-jdbc/**/*'
+
+module/spring-boot-starter-test-r2dbc:
+- changed-files:
+  - any-glob-to-any-file: 'komapper-spring-boot-starter-test-r2dbc/**/*'
+
+module/spring-boot-test-autoconfigure-jdbc:
+  - changed-files:
+      - any-glob-to-any-file: 'komapper-spring-boot-test-autoconfigure-jdbc/**/*'
+
+module/spring-boot-test-autoconfigure-r2dbc:
+  - changed-files:
+      - any-glob-to-any-file: 'komapper-spring-boot-test-autoconfigure-r2dbc/**/*'
+
 module/spring-jdbc:
 - changed-files:
   - any-glob-to-any-file: 'komapper-spring-jdbc/**/*'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,12 +51,14 @@ spring-core = { module = "org.springframework:spring-core", version.ref = "sprin
 spring-context = { module = "org.springframework:spring-context", version.ref = "springframework" }
 spring-jdbc = { module = "org.springframework:spring-jdbc", version.ref = "springframework" }
 spring-r2dbc = { module = "org.springframework:spring-r2dbc", version.ref = "springframework" }
+spring-test = { module = "org.springframework:spring-test", version.ref = "springframework" }
 spring-tx = { module = "org.springframework:spring-tx", version.ref = "springframework" }
 
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "spring-boot" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "spring-boot" }
 spring-boot-starter-jdbc = { module = "org.springframework.boot:spring-boot-starter-jdbc", version.ref = "spring-boot" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot" }
+spring-boot-test-autoconfigure = { module = "org.springframework.boot:spring-boot-test-autoconfigure", version.ref = "spring-boot" }
 
 quarkus-bom = { module = "io.quarkus:quarkus-bom", version.ref = "quarkus" }
 quarkus-core = { module = "io.quarkus:quarkus-core" }

--- a/komapper-spring-boot-starter-test-jdbc/build.gradle.kts
+++ b/komapper-spring-boot-starter-test-jdbc/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    api(project(":komapper-spring-boot-test-autoconfigure-jdbc"))
+}

--- a/komapper-spring-boot-starter-test-jdbc/gradle.properties
+++ b/komapper-spring-boot-starter-test-jdbc/gradle.properties
@@ -1,0 +1,1 @@
+description=Komapper Spring Boot Test Starter for JDBC

--- a/komapper-spring-boot-starter-test-jdbc/src/main/resources/META-INF/spring.provides
+++ b/komapper-spring-boot-starter-test-jdbc/src/main/resources/META-INF/spring.provides
@@ -1,1 +1,0 @@
-provides: komapper-spring-boot-test-autoconfigure-jdbc

--- a/komapper-spring-boot-starter-test-jdbc/src/main/resources/META-INF/spring.provides
+++ b/komapper-spring-boot-starter-test-jdbc/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: komapper-spring-boot-test-autoconfigure-jdbc

--- a/komapper-spring-boot-starter-test-r2dbc/build.gradle.kts
+++ b/komapper-spring-boot-starter-test-r2dbc/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    api(project(":komapper-spring-boot-test-autoconfigure-r2dbc"))
+}

--- a/komapper-spring-boot-starter-test-r2dbc/gradle.properties
+++ b/komapper-spring-boot-starter-test-r2dbc/gradle.properties
@@ -1,0 +1,1 @@
+description=Komapper Spring Boot Test Starter for R2DBC

--- a/komapper-spring-boot-starter-test-r2dbc/src/main/resources/META-INF/spring.provides
+++ b/komapper-spring-boot-starter-test-r2dbc/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: komapper-spring-boot-test-autoconfigure-r2dbc

--- a/komapper-spring-boot-starter-test-r2dbc/src/main/resources/META-INF/spring.provides
+++ b/komapper-spring-boot-starter-test-r2dbc/src/main/resources/META-INF/spring.provides
@@ -1,1 +1,0 @@
-provides: komapper-spring-boot-test-autoconfigure-r2dbc

--- a/komapper-spring-boot-test-autoconfigure-jdbc/build.gradle.kts
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/build.gradle.kts
@@ -1,0 +1,11 @@
+dependencies {
+    api(libs.spring.test)
+    api(libs.spring.tx)
+    api(libs.spring.boot.autoconfigure)
+    api(libs.spring.boot.test.autoconfigure)
+    implementation(libs.spring.boot.starter.test)
+
+    testImplementation(project(":komapper-spring-boot-starter-jdbc"))
+    testImplementation(project(":komapper-slf4j"))
+    testImplementation(project(":komapper-dialect-h2-jdbc"))
+}

--- a/komapper-spring-boot-test-autoconfigure-jdbc/gradle.properties
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/gradle.properties
@@ -1,0 +1,1 @@
+description=Komapper Spring Boot Auto Configuration for JDBC Tests

--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/AutoConfigureKomapperJdbc.kt
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/AutoConfigureKomapperJdbc.kt
@@ -1,0 +1,15 @@
+package org.komapper.spring.boot.test.autoconfigure.jdbc
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import java.lang.annotation.Inherited
+
+/**
+ * [Auto-configuration imports][ImportAutoConfiguration] for typical Komapper JDBC tests.
+ * Most tests should consider using [@KomapperJdbcTest][KomapperJdbcTest] rather than using this annotation directly.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Inherited
+@ImportAutoConfiguration
+annotation class AutoConfigureKomapperJdbc

--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/KomapperJdbcTest.kt
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/KomapperJdbcTest.kt
@@ -1,0 +1,78 @@
+package org.komapper.spring.boot.test.autoconfigure.jdbc
+
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration
+import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.core.annotation.AliasFor
+import org.springframework.core.env.Environment
+import org.springframework.test.context.BootstrapWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.transaction.annotation.Transactional
+import java.lang.annotation.Inherited
+import kotlin.reflect.KClass
+
+/**
+ * Annotation for a Komapper JDBC test that focuses **only** on Komapper JDBC-based components.
+ *
+ * Using this annotation only enables auto-configuration that is relevant to Komapper JDBC tests.
+ * Similarly, component scanning is configured to skip regular components and
+ * configuration properties.
+ *
+ * By default, tests annotated with `@KomapperJdbcTest` use the configured database. If you
+ * want to replace any explicit or usually auto-configured DataSource by an embedded
+ * in-memory database, the [@AutoConfigureTestDatabase][AutoConfigureTestDatabase]
+ * annotation can be used to override these settings.
+ *
+ * When using JUnit 4, this annotation should be used in combination with `@RunWith(SpringRunner.class)`.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Inherited
+@BootstrapWith(KomapperJdbcTestContextBootstrapper::class)
+@ExtendWith(SpringExtension::class)
+@OverrideAutoConfiguration(enabled = false)
+@TypeExcludeFilters(KomapperJdbcTypeExcludeFilter::class)
+@Transactional
+@AutoConfigureCache
+@AutoConfigureKomapperJdbc
+@ImportAutoConfiguration
+annotation class KomapperJdbcTest(
+
+    /**
+     * Properties in form `key=value` that should be added to the Spring [Environment] before the test runs.
+     */
+    val properties: Array<String> = [],
+
+    /**
+     * Determines if default filtering should be used with [@SpringBootApplication][SpringBootApplication].
+     * By default, no beans are included.
+     *
+     * @see includeFilters
+     * @see excludeFilters
+     */
+    val useDefaultFilters: Boolean = true,
+
+    /**
+     * A set of include filters which can be used to add otherwise filtered beans
+     * to the application context.
+     */
+    val includeFilters: Array<ComponentScan.Filter> = [],
+
+    /**
+     * A set of exclude filters which can be used to filter beans that would otherwise be added
+     * to the application context.
+     */
+    val excludeFilters: Array<ComponentScan.Filter> = [],
+
+    /**
+     * Auto-configuration exclusions that should be applied for this test.
+     */
+    @get:AliasFor(annotation = ImportAutoConfiguration::class, attribute = "exclude")
+    val excludeAutoConfiguration: Array<KClass<*>> = [],
+)

--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/KomapperJdbcTestContextBootstrapper.kt
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/KomapperJdbcTestContextBootstrapper.kt
@@ -1,0 +1,14 @@
+package org.komapper.spring.boot.test.autoconfigure.jdbc
+
+import org.springframework.boot.test.context.SpringBootTestContextBootstrapper
+import org.springframework.test.context.TestContextAnnotationUtils.findMergedAnnotation
+import org.springframework.test.context.TestContextBootstrapper
+
+/**
+ * [TestContextBootstrapper] for [@KomapperJdbcTest][KomapperJdbcTest] support.
+ */
+internal class KomapperJdbcTestContextBootstrapper : SpringBootTestContextBootstrapper() {
+    override fun getProperties(testClass: Class<*>): Array<String>? {
+        return findMergedAnnotation(testClass, KomapperJdbcTest::class.java)?.properties
+    }
+}

--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/KomapperJdbcTypeExcludeFilter.kt
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/KomapperJdbcTypeExcludeFilter.kt
@@ -1,0 +1,10 @@
+package org.komapper.spring.boot.test.autoconfigure.jdbc
+
+import org.springframework.boot.context.TypeExcludeFilter
+import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCustomizableTypeExcludeFilter
+
+/**
+ * [TypeExcludeFilter] for [@KomapperJdbcTest][KomapperJdbcTest].
+ */
+internal class KomapperJdbcTypeExcludeFilter(testClass: Class<*>) :
+    StandardAnnotationCustomizableTypeExcludeFilter<KomapperJdbcTest>(testClass)

--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/main/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.jdbc.AutoConfigureKomapperJdbc.imports
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/main/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.jdbc.AutoConfigureKomapperJdbc.imports
@@ -1,0 +1,8 @@
+# AutoConfigureKomapperJdbc auto-configuration imports
+org.komapper.spring.boot.autoconfigure.jdbc.KomapperJdbcAutoConfiguration
+org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration
+org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration
+org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration

--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/BasicKomapperJdbcApplication.kt
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/BasicKomapperJdbcApplication.kt
@@ -1,0 +1,6 @@
+package org.komapper.spring.boot.test.autoconfigure.jdbc
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication
+internal open class BasicKomapperJdbcApplication

--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/KomapperJdbcTestTest.kt
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/KomapperJdbcTestTest.kt
@@ -1,0 +1,23 @@
+package org.komapper.spring.boot.test.autoconfigure.jdbc
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.komapper.jdbc.JdbcDatabase
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.context.ConfigurableApplicationContext
+
+@KomapperJdbcTest(properties = ["spring.datasource.url=jdbc:h2:mem:example"])
+open class KomapperJdbcTestTest(
+    @Autowired
+    private val applicationContext: ConfigurableApplicationContext,
+) {
+    @Test
+    fun `only Komapper-related beans are loaded`() {
+        assertThat(AssertableApplicationContext.get { applicationContext })
+            .hasNotFailed()
+            .hasSingleBean(JdbcDatabase::class.java)
+            .hasSingleBean(KomapperRelatedService::class.java)
+            .doesNotHaveBean(UnrelatedService::class.java)
+    }
+}

--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/KomapperRelatedService.kt
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/KomapperRelatedService.kt
@@ -1,0 +1,9 @@
+package org.komapper.spring.boot.test.autoconfigure.jdbc
+
+import org.komapper.jdbc.JdbcDatabase
+import org.springframework.stereotype.Component
+
+@Component
+internal class KomapperRelatedService(
+    private val db: JdbcDatabase,
+)

--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/UnrelatedService.kt
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/jdbc/UnrelatedService.kt
@@ -1,0 +1,6 @@
+package org.komapper.spring.boot.test.autoconfigure.jdbc
+
+import org.springframework.stereotype.Component
+
+@Component
+internal class UnrelatedService

--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/test/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.jdbc.AutoConfigureKomapperJdbc.imports
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/test/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.jdbc.AutoConfigureKomapperJdbc.imports
@@ -1,0 +1,1 @@
+org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperRelatedService

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/build.gradle.kts
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/build.gradle.kts
@@ -1,0 +1,10 @@
+dependencies {
+    api(libs.spring.test)
+    api(libs.spring.boot.autoconfigure)
+    api(libs.spring.boot.test.autoconfigure)
+    implementation(libs.spring.boot.starter.test)
+
+    testImplementation(project(":komapper-spring-boot-starter-r2dbc"))
+    testImplementation(project(":komapper-slf4j"))
+    testImplementation(project(":komapper-dialect-h2-r2dbc"))
+}

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/gradle.properties
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/gradle.properties
@@ -1,0 +1,1 @@
+description=Komapper Spring Boot Auto Configuration for R2DBC Tests

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/AutoConfigureKomapperR2dbc.kt
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/AutoConfigureKomapperR2dbc.kt
@@ -1,0 +1,15 @@
+package org.komapper.spring.boot.test.autoconfigure.r2dbc
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import java.lang.annotation.Inherited
+
+/**
+ * [Auto-configuration imports][ImportAutoConfiguration] for typical Komapper JDBC tests.
+ * Most tests should consider using [@KomapperR2dbcTest][KomapperR2dbcTest] rather than using this annotation directly.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Inherited
+@ImportAutoConfiguration
+annotation class AutoConfigureKomapperR2dbc

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/KomapperR2dbcTest.kt
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/KomapperR2dbcTest.kt
@@ -1,0 +1,68 @@
+package org.komapper.spring.boot.test.autoconfigure.r2dbc
+
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.core.annotation.AliasFor
+import org.springframework.core.env.Environment
+import org.springframework.test.context.BootstrapWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.lang.annotation.Inherited
+import kotlin.reflect.KClass
+
+/**
+ * Annotation for a Komapper R2DBC test that focuses **only** on Komapper R2DBC-based components.
+ *
+ * Using this annotation only enables auto-configuration that is relevant to Komapper R2DBC tests.
+ * Similarly, component scanning is configured to skip regular components and
+ * configuration properties.
+ *
+ * When using JUnit 4, this annotation should be used in combination with `@RunWith(SpringRunner.class)`.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Inherited
+@BootstrapWith(KomapperR2dbcTestContextBootstrapper::class)
+@ExtendWith(SpringExtension::class)
+@OverrideAutoConfiguration(enabled = false)
+@TypeExcludeFilters(KomapperR2dbcTypeExcludeFilter::class)
+@AutoConfigureKomapperR2dbc
+@ImportAutoConfiguration
+annotation class KomapperR2dbcTest(
+
+    /**
+     * Properties in form `key=value` that should be added to the Spring [Environment] before the test runs.
+     */
+    val properties: Array<String> = [],
+
+    /**
+     * Determines if default filtering should be used with [@SpringBootApplication][SpringBootApplication].
+     * By default, no beans are included.
+     *
+     * @see includeFilters
+     * @see excludeFilters
+     */
+    val useDefaultFilters: Boolean = true,
+
+    /**
+     * A set of include filters which can be used to add otherwise filtered beans
+     * to the application context.
+     */
+    val includeFilters: Array<ComponentScan.Filter> = [],
+
+    /**
+     * A set of exclude filters which can be used to filter beans that would otherwise be added
+     * to the application context.
+     */
+    val excludeFilters: Array<ComponentScan.Filter> = [],
+
+    /**
+     * Auto-configuration exclusions that should be applied for this test.
+     */
+    @get:AliasFor(annotation = ImportAutoConfiguration::class, attribute = "exclude")
+    val excludeAutoConfiguration: Array<KClass<*>> = [],
+)

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/KomapperR2dbcTestContextBootstrapper.kt
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/KomapperR2dbcTestContextBootstrapper.kt
@@ -1,0 +1,14 @@
+package org.komapper.spring.boot.test.autoconfigure.r2dbc
+
+import org.springframework.boot.test.context.SpringBootTestContextBootstrapper
+import org.springframework.test.context.TestContextAnnotationUtils.findMergedAnnotation
+import org.springframework.test.context.TestContextBootstrapper
+
+/**
+ * [TestContextBootstrapper] for [@KomapperR2dbcTest][KomapperR2dbcTest] support.
+ */
+internal class KomapperR2dbcTestContextBootstrapper : SpringBootTestContextBootstrapper() {
+    override fun getProperties(testClass: Class<*>): Array<String>? {
+        return findMergedAnnotation(testClass, KomapperR2dbcTest::class.java)?.properties
+    }
+}

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/KomapperR2dbcTypeExcludeFilter.kt
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/KomapperR2dbcTypeExcludeFilter.kt
@@ -1,0 +1,10 @@
+package org.komapper.spring.boot.test.autoconfigure.r2dbc
+
+import org.springframework.boot.context.TypeExcludeFilter
+import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCustomizableTypeExcludeFilter
+
+/**
+ * [TypeExcludeFilter] for [@KomapperR2dbcTest][KomapperR2dbcTest].
+ */
+internal class KomapperR2dbcTypeExcludeFilter(testClass: Class<*>) :
+    StandardAnnotationCustomizableTypeExcludeFilter<KomapperR2dbcTest>(testClass)

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.r2dbc.AutoConfigureKomapperR2dbc.imports
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.r2dbc.AutoConfigureKomapperR2dbc.imports
@@ -1,0 +1,8 @@
+# AutoConfigureKomapperR2dbc auto-configuration imports
+org.komapper.spring.boot.autoconfigure.r2dbc.KomapperR2dbcAutoConfiguration
+org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration
+org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration
+org.springframework.boot.autoconfigure.r2dbc.R2dbcTransactionManagerAutoConfiguration
+org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration
+org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/BasicKomapperR2dbcApplication.kt
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/BasicKomapperR2dbcApplication.kt
@@ -1,0 +1,6 @@
+package org.komapper.spring.boot.test.autoconfigure.r2dbc
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication
+internal open class BasicKomapperR2dbcApplication

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/KomapperR2dbcTestTest.kt
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/KomapperR2dbcTestTest.kt
@@ -1,0 +1,23 @@
+package org.komapper.spring.boot.test.autoconfigure.r2dbc
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.komapper.r2dbc.R2dbcDatabase
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.context.ConfigurableApplicationContext
+
+@KomapperR2dbcTest(properties = ["spring.r2dbc.url=r2dbc:h2:mem:///test"])
+open class KomapperR2dbcTestTest(
+    @Autowired
+    private val applicationContext: ConfigurableApplicationContext,
+) {
+    @Test
+    fun `only Komapper-related beans are loaded`() {
+        assertThat(AssertableApplicationContext.get { applicationContext })
+            .hasNotFailed()
+            .hasSingleBean(R2dbcDatabase::class.java)
+            .hasSingleBean(KomapperRelatedService::class.java)
+            .doesNotHaveBean(UnrelatedService::class.java)
+    }
+}

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/KomapperRelatedService.kt
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/KomapperRelatedService.kt
@@ -1,0 +1,9 @@
+package org.komapper.spring.boot.test.autoconfigure.r2dbc
+
+import org.komapper.r2dbc.R2dbcDatabase
+import org.springframework.stereotype.Component
+
+@Component
+internal class KomapperRelatedService(
+    private val db: R2dbcDatabase,
+)

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/UnrelatedService.kt
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/test/kotlin/org/komapper/spring/boot/test/autoconfigure/r2dbc/UnrelatedService.kt
@@ -1,0 +1,6 @@
+package org.komapper.spring.boot.test.autoconfigure.r2dbc
+
+import org.springframework.stereotype.Component
+
+@Component
+internal class UnrelatedService

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/test/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.r2dbc.AutoConfigureKomapperR2dbc.imports
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/test/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.r2dbc.AutoConfigureKomapperR2dbc.imports
@@ -1,0 +1,1 @@
+org.komapper.spring.boot.test.autoconfigure.r2dbc.KomapperRelatedService

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,6 +56,10 @@ include("komapper-spring-boot-autoconfigure-jdbc")
 include("komapper-spring-boot-autoconfigure-r2dbc")
 include("komapper-spring-boot-starter-jdbc")
 include("komapper-spring-boot-starter-r2dbc")
+include("komapper-spring-boot-starter-test-jdbc")
+include("komapper-spring-boot-starter-test-r2dbc")
+include("komapper-spring-boot-test-autoconfigure-jdbc")
+include("komapper-spring-boot-test-autoconfigure-r2dbc")
 
 // OPTIONAL
 include("komapper-template")


### PR DESCRIPTION
Introduce Spring Boot test slices for Komapper JDBC and R2DBC applications.

Custom Spring Boot [test slices](https://spring.io/blog/2016/08/30/custom-test-slice-with-spring-boot-1-4) optimize Spring Boot tests that target some specific pieces of functionality by only loading a subset of beans related to it.

Komapper test slices (`@KomapperJdbcTest` and `@KomapperR2dbcTest`) mirror the structure of Spring Boot's [`@DataJdbcTest`](https://docs.spring.io/spring-boot/reference/testing/spring-boot-applications.html#testing.spring-boot-applications.autoconfigured-spring-data-jdbc) and [`@DataR2dbcTest`](https://docs.spring.io/spring-boot/reference/testing/spring-boot-applications.html#testing.spring-boot-applications.autoconfigured-spring-data-r2dbc) slices.

#### Open questions/nuances

1. Theoretically, `komapper-spring-boot-test-autoconfigure-*` modules don't need `spring-boot-starter-test` dependency, they only need JUnit 5 (in addition to `spring-tx`, `spring-test`, `spring-boot-autoconfigure`, and `spring-boot-test-autoconfigure`). However, JUnit 5 version has to come from somewhere - it can either be inherited from `spring-boot-dependencies` BOM or be managed by Komapper itself. Both options have their pros and cons.
2. Spring Boot 3+ also includes `optional:org.springframework.boot.testcontainers.service.connection.ServiceConnectionAutoConfiguration` into all test slices to support TestContainers integration, however, Spring Boot 2.7 used in Komapper doesn't support `optional:` prefix. Until Komapper updates to Spring Boot 3 there's no way to include optional test slice deps like `ServiceConnectionAutoConfiguration`.
