### PR TITLE
Spring Boot: autodetect *DataType beans

### DIFF
--- a/komapper-spring-boot-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfiguration.kt
+++ b/komapper-spring-boot-autoconfigure-jdbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/jdbc/KomapperJdbcAutoConfiguration.kt
@@ -16,6 +16,7 @@ import org.komapper.jdbc.DefaultJdbcDataFactory
 import org.komapper.jdbc.DefaultJdbcDataOperator
 import org.komapper.jdbc.JdbcDataFactory
 import org.komapper.jdbc.JdbcDataOperator
+import org.komapper.jdbc.JdbcDataType
 import org.komapper.jdbc.JdbcDataTypeProvider
 import org.komapper.jdbc.JdbcDataTypeProviders
 import org.komapper.jdbc.JdbcDatabase
@@ -25,6 +26,7 @@ import org.komapper.jdbc.JdbcDialects
 import org.komapper.jdbc.JdbcSession
 import org.komapper.jdbc.SimpleJdbcDatabaseConfig
 import org.komapper.spring.jdbc.SpringJdbcTransactionSession
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -98,6 +100,13 @@ open class KomapperJdbcAutoConfiguration {
     @ConditionalOnMissingBean
     open fun komapperDataFactory(databaseSession: JdbcSession): JdbcDataFactory {
         return DefaultJdbcDataFactory(databaseSession)
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(JdbcDataType::class)
+    open fun komapperBeanDataTypeProvider(dataTypes: ObjectProvider<JdbcDataType<*>>): JdbcDataTypeProvider {
+        return JdbcDataTypeProvider(*dataTypes.toList().toTypedArray())
     }
 
     @Bean

--- a/komapper-spring-boot-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/r2dbc/KomapperR2dbcAutoConfiguration.kt
+++ b/komapper-spring-boot-autoconfigure-r2dbc/src/main/kotlin/org/komapper/spring/boot/autoconfigure/r2dbc/KomapperR2dbcAutoConfiguration.kt
@@ -15,6 +15,7 @@ import org.komapper.core.TemplateStatementBuilder
 import org.komapper.core.TemplateStatementBuilders
 import org.komapper.r2dbc.DefaultR2dbcDataOperator
 import org.komapper.r2dbc.R2dbcDataOperator
+import org.komapper.r2dbc.R2dbcDataType
 import org.komapper.r2dbc.R2dbcDataTypeProvider
 import org.komapper.r2dbc.R2dbcDataTypeProviders
 import org.komapper.r2dbc.R2dbcDatabase
@@ -24,6 +25,7 @@ import org.komapper.r2dbc.R2dbcDialects
 import org.komapper.r2dbc.R2dbcSession
 import org.komapper.r2dbc.SimpleR2dbcDatabaseConfig
 import org.komapper.spring.r2dbc.SpringR2dbcTransactionSession
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -94,6 +96,13 @@ open class KomapperR2dbcAutoConfiguration {
     @ConditionalOnMissingBean
     open fun komapperStatementInspector(): StatementInspector {
         return StatementInspectors.get()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(R2dbcDataType::class)
+    open fun komapperBeanDataTypeProvider(dataTypes: ObjectProvider<R2dbcDataType<*>>): R2dbcDataTypeProvider {
+        return R2dbcDataTypeProvider(*dataTypes.toList().toTypedArray())
     }
 
     @Bean


### PR DESCRIPTION
Update Spring Boot autoconfigurations to automatically register a `JdbcDataTypeProvider`/`R2dbcDataTypeProvider` if none is declared by the user and at least one bean of type `JdbcDataType`/`R2dbcDataType` is declared.

The new `*DataTypeProvider` won't be registered if no `*DataType` beans are declared by the user. It also won't override any explicit `*DataTypeProvider` bean declared by the user.

Technically, this might be a breaking change, as it would start registering `JdbcDataType`/`R2dbcDataType`s declared as beans with the Komapper where previously they were not. However, there probably shouldn't be a need for user to declare those as beans unless they intend them to be registered with Komapper anyway.