### PR TITLE
Fix mapping of Primitive Boxed Generic Array Types

### DIFF
--- a/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
+++ b/integration-test-core/src/main/kotlin/integration/core/PostgreSqlSetting.kt
@@ -28,6 +28,12 @@ public interface PostgreSqlSetting<DATABASE : Database> : Setting<DATABASE> {
             create table if not exists sequence_strategy(id integer not null primary key, value varchar(10));
 
             create table if not exists array_data(id integer not null primary key, value text[]);
+            create table if not exists array_boolean_data(id integer not null primary key, value boolean[]);
+            create table if not exists array_double_data(id integer not null primary key, value double precision[]);
+            create table if not exists array_float_data(id integer not null primary key, value real[]);
+            create table if not exists array_int_data(id integer not null primary key, value integer[]);
+            create table if not exists array_long_data(id integer not null primary key, value bigint[]);
+            create table if not exists array_short_data(id integer not null primary key, value smallint[]);
             create table if not exists big_decimal_data(id integer not null primary key, value numeric);
             create table if not exists big_integer_data(id integer not null primary key, value numeric);
             create table if not exists blob_data(id integer not null primary key, value bytea);
@@ -35,12 +41,12 @@ public interface PostgreSqlSetting<DATABASE : Database> : Setting<DATABASE> {
             create table if not exists byte_data(id integer not null primary key, value int2);
             create table if not exists byte_array_data(id integer not null primary key, value bytea);
             create table if not exists clob_data(id integer not null primary key, value text);
-            create table if not exists double_data(id integer not null primary key, value float8);
+            create table if not exists double_data(id integer not null primary key, value double precision);
             create table if not exists enum_data(id integer not null primary key, value varchar(20));
             create table if not exists enum_ordinal_data(id integer not null primary key, value integer);
             create table if not exists enum_property_data(id integer not null primary key, value integer);
             create table if not exists enum_udt_data(id integer not null primary key, value mood);
-            create table if not exists float_data(id integer not null primary key, value float);
+            create table if not exists float_data(id integer not null primary key, value real);
             create table if not exists instant_data(id integer not null primary key, value timestamp with time zone);
             create table if not exists int_data(id integer not null primary key, value integer);
             create table if not exists local_date_time_data(id integer not null primary key, value timestamp);

--- a/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/EntityDataType.kt
+++ b/integration-test-r2dbc/src/main/kotlin/integration/r2dbc/EntityDataType.kt
@@ -24,6 +24,102 @@ data class ArrayOfNullableData(
     @KomapperColumn(alwaysQuote = true) val value: Array<String?>?,
 )
 
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_boolean_data")
+data class ArrayBooleanData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Boolean>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_boolean_data")
+data class ArrayBooleanOfNullableData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Boolean?>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_double_data")
+data class ArrayDoubleData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Double>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_double_data")
+data class ArrayDoubleOfNullableData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Double?>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_float_data")
+data class ArrayFloatData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Float>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_float_data")
+data class ArrayFloatOfNullableData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Float?>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_int_data")
+data class ArrayIntData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Int>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_int_data")
+data class ArrayIntOfNullableData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Int?>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_long_data")
+data class ArrayLongData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Long>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_long_data")
+data class ArrayLongOfNullableData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Long?>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_short_data")
+data class ArrayShortData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Short>?,
+)
+
+@Suppress("ArrayInDataClass")
+@KomapperEntity
+@KomapperTable("array_short_data")
+data class ArrayShortOfNullableData(
+    @KomapperId val id: Int,
+    @KomapperColumn(alwaysQuote = true) val value: Array<Short?>?,
+)
+
 @KomapperEntity
 @KomapperTable("blob_data")
 data class BlobData(

--- a/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlMapping.kt
+++ b/integration-test-r2dbc/src/postgresql/kotlin/integration/r2dbc/postgresql/R2dbcPostgreSqlMapping.kt
@@ -30,6 +30,24 @@ data class R2dbcPostgreSqlMapping(
     @KomapperColumn(alwaysQuote = true)
     @Suppress("ArrayInDataClass")
     val array: Array<String>,
+    @KomapperColumn(alwaysQuote = true)
+    @Suppress("ArrayInDataClass")
+    val arrayBoolean: Array<Boolean>,
+    @KomapperColumn(alwaysQuote = true)
+    @Suppress("ArrayInDataClass")
+    val arrayDouble: Array<Double>,
+    @KomapperColumn(alwaysQuote = true)
+    @Suppress("ArrayInDataClass")
+    val arrayFloat: Array<Float>,
+    @KomapperColumn(alwaysQuote = true)
+    @Suppress("ArrayInDataClass")
+    val arrayInt: Array<Int>,
+    @KomapperColumn(alwaysQuote = true)
+    @Suppress("ArrayInDataClass")
+    val arrayLong: Array<Long>,
+    @KomapperColumn(alwaysQuote = true)
+    @Suppress("ArrayInDataClass")
+    val arrayShort: Array<Short>,
     @KomapperColumn(alwaysQuote = true) val bigDecimal: BigDecimal,
     @KomapperColumn(alwaysQuote = true) val bigInteger: BigInteger,
     @KomapperColumn(alwaysQuote = true) val blob: Blob,

--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcDataTypeTest.kt
@@ -174,6 +174,353 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
         assertNull(data2.value)
     }
 
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayBoolean(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayBooleanData
+        val array = arrayOf(true, false)
+        val data = ArrayBooleanData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(2, value.size)
+        assertEquals(true, value[0])
+        assertEquals(false, value[1])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayBoolean_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayBooleanData
+        val data = ArrayBooleanData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayBooleanOfNullable(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayBooleanOfNullableData
+        val array = arrayOf(true, null, false)
+        val data = ArrayBooleanOfNullableData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(true, value[0])
+        assertNull(value[1])
+        assertEquals(false, value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayBooleanOfNullable_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayBooleanOfNullableData
+        val data = ArrayBooleanOfNullableData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayDouble(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayDoubleData
+        val array = arrayOf(1.0, 2.0, 3.0)
+        val data = ArrayDoubleData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(1.0, value[0])
+        assertEquals(2.0, value[1])
+        assertEquals(3.0, value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayDouble_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayDoubleData
+        val data = ArrayDoubleData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayDoubleOfNullable(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayDoubleOfNullableData
+        val array = arrayOf(1.0, null, 3.0)
+        val data = ArrayDoubleOfNullableData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(1.0, value[0])
+        assertNull(value[1])
+        assertEquals(3.0, value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayDoubleOfNullable_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayDoubleOfNullableData
+        val data = ArrayDoubleOfNullableData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayFloat(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayFloatData
+        val array = arrayOf(1.0f, 2.0f, 3.0f)
+        val data = ArrayFloatData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(1.0f, value[0])
+        assertEquals(2.0f, value[1])
+        assertEquals(3.0f, value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayFloat_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayFloatData
+        val data = ArrayFloatData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayFloatOfNullable(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayFloatOfNullableData
+        val array = arrayOf(1.0f, null, 3.0f)
+        val data = ArrayFloatOfNullableData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(1.0f, value[0])
+        assertNull(value[1])
+        assertEquals(3.0f, value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayFloatOfNullable_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayFloatOfNullableData
+        val data = ArrayFloatOfNullableData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayInt(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayIntData
+        val array = arrayOf(1, 2, 3)
+        val data = ArrayIntData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(1, value[0])
+        assertEquals(2, value[1])
+        assertEquals(3, value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayInt_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayIntData
+        val data = ArrayIntData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayIntOfNullable(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayIntOfNullableData
+        val array = arrayOf(1, null, 3)
+        val data = ArrayIntOfNullableData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(1, value[0])
+        assertNull(value[1])
+        assertEquals(3, value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayIntOfNullable_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayIntOfNullableData
+        val data = ArrayIntOfNullableData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayLong(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayLongData
+        val array = arrayOf(1L, 2L, 3L)
+        val data = ArrayLongData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(1L, value[0])
+        assertEquals(2L, value[1])
+        assertEquals(3L, value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayLong_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayLongData
+        val data = ArrayLongData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayLongOfNullable(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayLongOfNullableData
+        val array = arrayOf(1L, null, 3L)
+        val data = ArrayLongOfNullableData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(1L, value[0])
+        assertNull(value[1])
+        assertEquals(3L, value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayLongOfNullable_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayLongOfNullableData
+        val data = ArrayLongOfNullableData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayShort(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayShortData
+        val array = arrayOf(1.toShort(), 2.toShort(), 3.toShort())
+        val data = ArrayShortData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(1.toShort(), value[0])
+        assertEquals(2.toShort(), value[1])
+        assertEquals(3.toShort(), value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayShort_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayShortData
+        val data = ArrayShortData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayShortOfNullable(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayShortOfNullableData
+        val array = arrayOf(1.toShort(), null, 3.toShort())
+        val data = ArrayShortOfNullableData(1, array)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        val value = data2.value!!
+        assertEquals(3, value.size)
+        assertEquals(1.toShort(), value[0])
+        assertNull(value[1])
+        assertEquals(3.toShort(), value[2])
+    }
+
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    @Test
+    fun arrayShortOfNullable_null(info: TestInfo) = inTransaction(db, info) {
+        val m = Meta.arrayShortOfNullableData
+        val data = ArrayShortOfNullableData(1, null)
+        db.runQuery { QueryDsl.insert(m).single(data) }
+        val data2 = db.runQuery {
+            QueryDsl.from(m).where { m.id eq 1 }.first()
+        }
+        assertNull(data2.value)
+    }
+
     @Test
     fun bigDecimal(info: TestInfo) = inTransaction(db, info) {
         val m = Meta.bigDecimalData
@@ -454,10 +801,16 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
             }
             Unit
         }
-        assertEquals("Failed to map a value to the property \"value\" of the entity class \"integration.core.EnumData\".", ex.message)
+        assertEquals(
+            "Failed to map a value to the property \"value\" of the entity class \"integration.core.EnumData\".",
+            ex.message
+        )
         val cause = ex.cause
         assertTrue(cause is ValueExtractingException)
-        assertEquals("Failed to extract a value from column. The column index is 1. (Column indices start from 0.)", cause.message)
+        assertEquals(
+            "Failed to extract a value from column. The column index is 1. (Column indices start from 0.)",
+            cause.message
+        )
         val cause2 = cause.cause
         assertTrue(cause2 is EnumMappingException)
         assertEquals(
@@ -509,7 +862,10 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
         )
         val cause = ex.cause
         assertTrue(cause is ValueExtractingException)
-        assertEquals("Failed to extract a value from column. The column index is 1. (Column indices start from 0.)", cause.message)
+        assertEquals(
+            "Failed to extract a value from column. The column index is 1. (Column indices start from 0.)",
+            cause.message
+        )
         val cause2 = cause.cause
         assertTrue(cause2 is EnumMappingException)
         assertEquals(
@@ -561,7 +917,10 @@ class R2dbcDataTypeTest(val db: R2dbcDatabase) {
         )
         val cause = ex.cause
         assertTrue(cause is ValueExtractingException)
-        assertEquals("Failed to extract a value from column. The column index is 1. (Column indices start from 0.)", cause.message)
+        assertEquals(
+            "Failed to extract a value from column. The column index is 1. (Column indices start from 0.)",
+            cause.message
+        )
         val cause2 = cause.cause
         assertTrue(cause2 is EnumMappingException)
         assertEquals(


### PR DESCRIPTION
The changes in this pull request address the mapping of arrays such as `Array<Int>` and `Array<Long>` to database types in PostgreSQL R2DBC. This update ensures proper handling of Primitive Boxed Generic Array Types.