### PR TITLE
Add support for Oracle and SQL Server in Quarkus

### DIFF
--- a/komapper-quarkus-jdbc-deployment/src/main/java/org/komapper/quarkus/jdbc/deployment/KomapperSettingsFactory.java
+++ b/komapper-quarkus-jdbc-deployment/src/main/java/org/komapper/quarkus/jdbc/deployment/KomapperSettingsFactory.java
@@ -75,11 +75,15 @@ public class KomapperSettingsFactory {
       case "h2":
       case "mysql":
       case "mariadb":
+      case "oracle":
         return dbKind;
       case "postgresql":
       case "pgsql":
       case "pg":
         return "postgresql";
+      case "sqlserver":
+      case "mssql":
+        return "sqlserver";
       default:
         throw new IllegalStateException(
             "Can't infer the driver name from the dbKind \""


### PR DESCRIPTION
Enhanced the detection of the appropriate JDBC driver when the `db-kind` property in Quarkus is set to `"oracle"`, `"sqlserver"`, or `"mssql"`.