### PR TITLE
fix: Serialize r2dbc row processing by converting Flux to Flow

### DIFF
--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcExecutor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcExecutor.kt
@@ -42,7 +42,7 @@ internal class R2dbcExecutor(
                         result.map { row, _ ->
                             val value = transform(config.dataOperator, row)
                             Optional.ofNullable(value)
-                        }.collect {
+                        }.asFlow().collect {
                             val value = it.orElse(null)
                             emit(value)
                         }


### PR DESCRIPTION
## Issue Description
We identified an intermittent issue where R2DBC row processing occasionally executed concurrently across multiple threads, resulting in unpredictable ordering of results. This rare but reproducible problem occurred even when using explicit ⁠`ORDER BY` clauses in queries, violating the expected result ordering.

## Solution

This PR converts Reactor's Flux to Kotlin Flow before collecting results, ensuring single-threaded sequential processing. Specifically, we added `.asFlow()` between `result.map()` and `.collect()` to avoid Flux's concurrent behavior and guarantee ordered processing.

While a more direct approach might be using `.publishOn(Schedulers.single())` for Reactor Flux, the API returns a more generic Reactive Streams Publisher type rather than a concrete Flux, making the Flow conversion approach more appropriate in this context.

## Reproduction Code
The following code demonstrates the issue on PostgreSQL 15.3 running on macOS 15.3 (M1). Despite explicitly ordering results with an `ORDER BY` clause, Flux's concurrent nature occasionally returned results out of order.

```kotlin
@KomapperEntity
data class TestLabels(
    @KomapperId
    @KomapperColumn(name = "code")
    val code: String,
)

fun main() = runBlocking {
    val config = PostgresqlConnectionConfiguration.builder()
        .host("localhost")
        .port(5432)
        .username("user")
        .password("password")
        .database("testdb")
        .connectTimeout(Duration.ofSeconds(3))
        .build()

    val connectionFactory = PostgresqlConnectionFactory(config)    
    
    // Create test table
    val connection = connectionFactory.create().awaitSingle()
    try {
        connection.createStatement("""
            CREATE TABLE IF NOT EXISTS test_labels (
                code VARCHAR(10) PRIMARY KEY
            )
        """).execute().awaitSingle()
        
        // Insert test data if needed
        connection.createStatement("""
            INSERT INTO test_labels (code) 
            VALUES ('A'), ('B'), ('C'), ('D'), ('E')
            ON CONFLICT DO NOTHING
        """).execute().awaitSingle()
    } finally {
        connection.close().awaitFirstOrNull()
    }
    
    val dialect = PostgreSqlR2dbcDialect()
    val dbConfig = object: DefaultR2dbcDatabaseConfig(connectionFactory, dialect) {}
    val db = R2dbcDatabase(dbConfig)

    // Number of test iterations
    val iterations = 10000

    for (i in 1..iterations) {
        val l = Meta.testLabels
        val rows = db.runQuery { 
            QueryDsl.from(l).limit(3).orderBy(l.code)
        }.map { it.code }

        // Verify we got 3 results
        if (rows.size != 3) {
            error("Iteration=$i: expected 3 rows but got ${rows.size}")
        }
        // Verify results are in ascending order
        if (rows != rows.sorted()) {
            error("Iteration=$i: out-of-order rows: $rows")
        }
        
        println("Iteration $i: $rows")
    }

    println("All $iterations iterations OK!")
}
```

## Technical Considerations
I implemented this fix by converting Flux to Flow to avoid concurrent processing. I have very limited experience with Kotlin/Java concurrency patterns and reactive programming, so this solution was the most straightforward approach I could find. I discussed this issue with ChatGPT to better understand the concurrency problem and explore potential solutions.
I'm particularly interested in feedback regarding the approach's optimality, any performance implications from serialization, and potential side effects on other R2DBC operations. While this change ensures consistent ordering of results, I'm open to alternative implementations from those more experienced with reactive programming.

## Test Results
Before this fix, the reproduction code frequently encountered ordering issues. After the fix, the same test completed 10,000 iterations without any ordering problems.