### PR TITLE
Accept a Clock in DefaultDefaultClockProvider's Primary Constructor

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/ClockProvider.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/ClockProvider.kt
@@ -1,7 +1,6 @@
 package org.komapper.core
 
 import java.time.Clock
-import java.time.Instant
 import java.time.ZoneId
 
 /**
@@ -20,8 +19,10 @@ fun interface ClockProvider {
 /**
  * The default implementation of [ClockProvider].
  */
-class DefaultClockProvider(private val zoneId: ZoneId = ZoneId.systemDefault()) : ClockProvider {
+class DefaultClockProvider(private val source: Clock = Clock.systemDefaultZone()) : ClockProvider {
+    constructor(zoneId: ZoneId) : this(Clock.system(zoneId))
+
     override fun now(): Clock {
-        return Clock.fixed(Instant.now(), zoneId)
+        return Clock.fixed(source.instant(), source.zone)
     }
 }

--- a/komapper-core/src/test/kotlin/org/komapper/core/ClockProviderTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/ClockProviderTest.kt
@@ -1,0 +1,38 @@
+package org.komapper.core
+
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.test.assertEquals
+
+class ClockProviderTest {
+    @Test
+    fun testDefaultClockProvider_NoArgsUsesSystemDefaultZone() {
+        val providedClock = DefaultClockProvider().now()
+        assertEquals(ZoneId.systemDefault(), providedClock.zone)
+    }
+
+    @Test
+    fun testDefaultClockProvider_WithSourceClock() {
+        val now = Instant.now()
+        val clock = Clock.fixed(now, ZoneId.of("Etc/UTC"))
+        val actualInstant = DefaultClockProvider(clock).now().instant()
+        assertEquals(now, actualInstant)
+    }
+
+    @Test
+    fun testDefaultClockProvider_FromZone() {
+        val zone = ZoneId.of("Europe/Madrid")
+        val providedClock = DefaultClockProvider(zone).now()
+        assertEquals(zone, providedClock.zone)
+    }
+
+    @Test
+    fun testDefaultClockProvider_ReturnsFixedClock() {
+        val providedClock = DefaultClockProvider().now()
+        val first = providedClock.instant()
+        Thread.sleep(5)
+        assertEquals(first, providedClock.instant())
+    }
+}


### PR DESCRIPTION
# Description
If the application has a bean of type `Clock` available in the context, pass that through to the `DefaultClockProvider` instead of using `Instant.now()`

This allows easier synchronization (and unit testing) when an application has a clock defined in the context