### PR TITLE
Remove unnecessary sorting in R2dbcSequentialExecutionTest

### DIFF
--- a/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcSequentialExecutionTest.kt
+++ b/integration-test-r2dbc/src/test/kotlin/integration/r2dbc/R2dbcSequentialExecutionTest.kt
@@ -24,7 +24,7 @@ class R2dbcSequentialExecutionTest(private val db: R2dbcDatabase) {
         for (i in 1..1000) {
             val list: List<Address> = db.runQuery(query)
             assertEquals(3, list.size, "i=$i")
-            assertEquals(listOf(1, 2, 3), list.map { it.addressId }.sorted(), "i=$i")
+            assertEquals(listOf(1, 2, 3), list.map { it.addressId }, "i=$i")
         }
     }
 


### PR DESCRIPTION
Update R2dbcSequentialExecutionTest to remove unnecessary sorting operations.