### PR TITLE
Add support for resolving package names with reserved keywords

### DIFF
--- a/gradle-plugin/src/main/java/org/komapper/gradle/codegen/GenerateTask.java
+++ b/gradle-plugin/src/main/java/org/komapper/gradle/codegen/GenerateTask.java
@@ -57,6 +57,7 @@ public class GenerateTask extends DefaultTask {
         new CodeGenerator(
             settings.getPackageName().getOrNull(),
             tables,
+            settings.getPackageNameResolver().get(),
             settings.getClassNameResolver().get(),
             settings.getPropertyNameResolver().get());
     var destinationDir = settings.getDestinationDir().get().getAsFile().toPath();

--- a/gradle-plugin/src/main/java/org/komapper/gradle/codegen/Generator.java
+++ b/gradle-plugin/src/main/java/org/komapper/gradle/codegen/Generator.java
@@ -9,10 +9,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
-import org.komapper.codegen.ClassNameResolver;
-import org.komapper.codegen.Enquote;
-import org.komapper.codegen.PropertyNameResolver;
-import org.komapper.codegen.PropertyTypeResolver;
+import org.komapper.codegen.*;
 
 public class Generator {
   private final String name;
@@ -36,6 +33,7 @@ public class Generator {
   private final Property<PropertyTypeResolver> propertyTypeResolver;
   private final Property<Enquote> enquote;
 
+  private final Property<PackageNameResolver> packageNameResolver;
   private final Property<ClassNameResolver> classNameResolver;
   private final Property<PropertyNameResolver> propertyNameResolver;
   private final Property<String> versionPropertyName;
@@ -72,6 +70,8 @@ public class Generator {
         objects.property(PropertyTypeResolver.class).value(PropertyTypeResolver.of());
     this.enquote = objects.property(Enquote.class);
     enquote.set(jdbc.getUrl().map(Enquote::of));
+    this.packageNameResolver =
+        objects.property(PackageNameResolver.class).value(PackageNameResolver.of());
     this.classNameResolver = objects.property(ClassNameResolver.class);
     classNameResolver.set(
         prefix.zip(suffix, Pair::of).zip(singularize, (a, b) -> ClassNameResolver.of(a.a, a.b, b)));
@@ -160,6 +160,10 @@ public class Generator {
 
   public Property<Enquote> getEnquote() {
     return enquote;
+  }
+
+  public Property<PackageNameResolver> getPackageNameResolver() {
+    return packageNameResolver;
   }
 
   public Property<ClassNameResolver> getClassNameResolver() {

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcMetadataReaderTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcMetadataReaderTest.kt
@@ -3,12 +3,7 @@ package integration.jdbc
 import integration.core.Dbms
 import integration.core.Run
 import org.junit.jupiter.api.extension.ExtendWith
-import org.komapper.codegen.ClassNameResolver
-import org.komapper.codegen.CodeGenerator
-import org.komapper.codegen.MetadataReader
-import org.komapper.codegen.PropertyNameResolver
-import org.komapper.codegen.PropertyTypeResolver
-import org.komapper.codegen.Table
+import org.komapper.codegen.*
 import org.komapper.jdbc.JdbcDatabase
 import java.io.StringWriter
 import kotlin.test.Test
@@ -29,7 +24,7 @@ class JdbcMetadataReaderTest(val db: JdbcDatabase) {
     @Test
     fun dump() {
         val tables = getTables()
-        val generator = CodeGenerator(null, tables, ClassNameResolver.of("", "", false), PropertyNameResolver.of())
+        val generator = CodeGenerator(null, tables, PackageNameResolver.of(), ClassNameResolver.of("", "", false), PropertyNameResolver.of())
         val writer = StringWriter()
         generator.generateEntities(writer, false, false, false, false, false, PropertyTypeResolver.of(), "", "", "")
         println(writer)
@@ -39,7 +34,7 @@ class JdbcMetadataReaderTest(val db: JdbcDatabase) {
     @Test
     fun dump_h2() {
         val tables = getTables("PUBLIC")
-        val generator = CodeGenerator(null, tables, ClassNameResolver.of("", "", false), PropertyNameResolver.of())
+        val generator = CodeGenerator(null, tables, PackageNameResolver.of(), ClassNameResolver.of("", "", false), PropertyNameResolver.of())
         val writer = StringWriter()
         generator.generateEntities(writer, false, false, false, false, false, PropertyTypeResolver.of(), "", "", "")
         println(writer)

--- a/komapper-codegen/src/main/java/org/komapper/codegen/CodeGenerator.java
+++ b/komapper-codegen/src/main/java/org/komapper/codegen/CodeGenerator.java
@@ -17,17 +17,20 @@ public class CodeGenerator {
 
   private final String packageName;
   private final List<Table> tables;
+  private final PackageNameResolver packageNameResolver;
   private final ClassNameResolver classNameResolver;
   private final PropertyNameResolver propertyNameResolver;
 
   public CodeGenerator(
       @Nullable String packageName,
       @NotNull List<Table> tables,
+      @NotNull PackageNameResolver packageNameResolver,
       @NotNull ClassNameResolver classNameResolver,
       @NotNull PropertyNameResolver propertyNameResolver) {
     this.packageName = packageName;
     this.tables = new ArrayList<>(Objects.requireNonNull(tables));
     this.classNameResolver = Objects.requireNonNull(classNameResolver);
+    this.packageNameResolver = Objects.requireNonNull(packageNameResolver);
     this.propertyNameResolver = Objects.requireNonNull(propertyNameResolver);
   }
 
@@ -59,7 +62,7 @@ public class CodeGenerator {
     Objects.requireNonNull(resolver);
     var p = new PrintWriter(writer);
     if (packageName != null) {
-      p.println("package " + packageName);
+      p.println("package " + packageNameResolver.resolve(packageName));
     }
     if (useSelfMapping) {
       p.println();
@@ -111,7 +114,7 @@ public class CodeGenerator {
     Objects.requireNonNull(writer);
     var p = new PrintWriter(writer);
     if (packageName != null) {
-      p.println("package " + packageName);
+      p.println("package " + packageNameResolver.resolve(packageName));
       p.println();
     }
     p.print(

--- a/komapper-codegen/src/main/java/org/komapper/codegen/PackageNameResolver.java
+++ b/komapper-codegen/src/main/java/org/komapper/codegen/PackageNameResolver.java
@@ -1,0 +1,14 @@
+package org.komapper.codegen;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface PackageNameResolver {
+
+  @NotNull
+  String resolve(@NotNull String name);
+
+  @NotNull
+  static PackageNameResolver of() {
+    return new PackageNameResolverImpl();
+  }
+}

--- a/komapper-codegen/src/main/java/org/komapper/codegen/PackageNameResolverImpl.java
+++ b/komapper-codegen/src/main/java/org/komapper/codegen/PackageNameResolverImpl.java
@@ -1,0 +1,26 @@
+package org.komapper.codegen;
+
+import org.jetbrains.annotations.NotNull;
+
+class PackageNameResolverImpl implements PackageNameResolver {
+
+  PackageNameResolverImpl() {}
+
+  @Override
+  public @NotNull String resolve(@NotNull String name) {
+    final String[] parts = name.split("\\.");
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      if (i > 0) {
+        sb.append(".");
+      }
+      String part = parts[i];
+      if (Constants.KEYWORDS.contains(part)) {
+        sb.append("`").append(part).append("`");
+      } else {
+        sb.append(part);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/komapper-codegen/src/test/kotlin/org/komapper/codegen/CodeGeneratorTest.kt
+++ b/komapper-codegen/src/test/kotlin/org/komapper/codegen/CodeGeneratorTest.kt
@@ -18,8 +18,9 @@ class CodeGeneratorTest {
     fun generateEntities() {
         val destinationDir = tempDir!!.resolve(Paths.get("src", "kotlin", "main"))
         val generator = CodeGenerator(
-            "entity",
+            "entity.class",
             createTables(),
+            PackageNameResolver.of(),
             ClassNameResolver.of("", "", false),
             PropertyNameResolver.of()
         )
@@ -27,10 +28,10 @@ class CodeGeneratorTest {
             generator.generateEntities(writer, false, false, false, false, false, DummyPropertyTypeResolver(), "", "", "")
         }
 
-        val file = destinationDir.resolve(Paths.get("entity", "entities.kt"))
+        val file = destinationDir.resolve(Paths.get("entity", "class", "entities.kt"))
         val expected =
             """
-            package entity
+            package entity.`class`
             
             data class Address (
                 val addressId: Int,
@@ -60,18 +61,19 @@ class CodeGeneratorTest {
     fun generateEntities_declareAsNullable() {
         val destinationDir = tempDir!!.resolve(Paths.get("src", "kotlin", "main"))
         val generator = CodeGenerator(
-            "entity",
+            "entity.return",
             createTables(),
+            PackageNameResolver.of(),
             ClassNameResolver.of("", "", false),
             PropertyNameResolver.of()
         )
         generator.createNewFile(destinationDir, "entities.kt", false).use { writer ->
             generator.generateEntities(writer, true, false, false, false, false, DummyPropertyTypeResolver(), "", "", "")
         }
-        val file = destinationDir.resolve(Paths.get("entity", "entities.kt"))
+        val file = destinationDir.resolve(Paths.get("entity", "return", "entities.kt"))
         val expected =
             """
-            package entity
+            package entity.`return`
             
             data class Address (
                 val addressId: Int?,
@@ -103,6 +105,7 @@ class CodeGeneratorTest {
         val generator = CodeGenerator(
             "entity",
             createTables(),
+            PackageNameResolver.of(),
             ClassNameResolver.of("", "", false),
             PropertyNameResolver.of()
         )
@@ -156,6 +159,7 @@ class CodeGeneratorTest {
         val generator = CodeGenerator(
             "entity",
             createTablesWithPluralNames(),
+            PackageNameResolver.of(),
             ClassNameResolver.of("", "", true),
             PropertyNameResolver.of()
         )
@@ -196,18 +200,19 @@ class CodeGeneratorTest {
     fun generateEntityDefinition() {
         val destinationDir = tempDir!!.resolve(Paths.get("src", "kotlin", "main"))
         val generator = CodeGenerator(
-            "entity",
+            "entity.class",
             createTables(),
+            PackageNameResolver.of(),
             ClassNameResolver.of("", "", false),
             PropertyNameResolver.of()
         )
         generator.createNewFile(destinationDir, "entityDefinitions.kt", false).use { writer ->
             generator.generateDefinitions(writer, false, false, false, "", "", "")
         }
-        val file = destinationDir.resolve(Paths.get("entity", "entityDefinitions.kt"))
+        val file = destinationDir.resolve(Paths.get("entity", "class", "entityDefinitions.kt"))
         val expected =
             """
-            package entity
+            package entity.`class`
             
             import org.komapper.annotation.KomapperAutoIncrement
             import org.komapper.annotation.KomapperColumn
@@ -251,6 +256,7 @@ class CodeGeneratorTest {
         val generator = CodeGenerator(
             "entity",
             createTables(),
+            PackageNameResolver.of(),
             ClassNameResolver.of("", "", false),
             PropertyNameResolver.of()
         )
@@ -307,6 +313,7 @@ class CodeGeneratorTest {
         val generator = CodeGenerator(
             "entity",
             createTablesWithPluralNames(),
+            PackageNameResolver.of(),
             ClassNameResolver.of("", "", true),
             PropertyNameResolver.of()
         )
@@ -360,6 +367,7 @@ class CodeGeneratorTest {
         val generator = CodeGenerator(
             "entity",
             createTables(),
+            PackageNameResolver.of(),
             ClassNameResolver.of("", "Entity", false),
             PropertyNameResolver.of()
         )

--- a/komapper-codegen/src/test/kotlin/org/komapper/codegen/PackageNameResolverImplTest.kt
+++ b/komapper-codegen/src/test/kotlin/org/komapper/codegen/PackageNameResolverImplTest.kt
@@ -1,0 +1,15 @@
+package org.komapper.codegen
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PackageNameResolverImplTest {
+    private val converter = PackageNameResolverImpl()
+
+    @Test
+    fun resolve() {
+        assertEquals("abc", converter.resolve("abc"))
+        assertEquals("`class`", converter.resolve("class"))
+        assertEquals("example.`class`", converter.resolve("example.class"))
+    }
+}


### PR DESCRIPTION
Introduce `PackageNameResolver` to handle package names containing reserved keywords like `class` by wrapping them in backticks. Updated `CodeGenerator` and relevant tests to use the new resolver for proper package name handling.

#608 
#609 