### PR TITLE
Fix parameter order in quarkus configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -110,6 +110,10 @@ module/quarkus-jdbc:
 - changed-files:
   - any-glob-to-any-file: 'komapper-quarkus-jdbc/**/*'
 
+module/quarkus-jdbc-deployment:
+  - changed-files:
+      - any-glob-to-any-file: 'komapper-quarkus-jdbc-deployment/**/*'
+
 module/r2dbc:
 - changed-files:
   - any-glob-to-any-file: 'komapper-r2dbc/**/*'

--- a/komapper-quarkus-jdbc/src/main/java/org/komapper/quarkus/jdbc/KomapperRecorder.java
+++ b/komapper-quarkus-jdbc/src/main/java/org/komapper/quarkus/jdbc/KomapperRecorder.java
@@ -59,8 +59,8 @@ public class KomapperRecorder {
           executionOptions.plus(
               new ExecutionOptions(
                   dataSourceDefinition.batchSize,
-                  dataSourceDefinition.maxRows,
                   dataSourceDefinition.fetchSize,
+                  dataSourceDefinition.maxRows,
                   dataSourceDefinition.queryTimeout,
                   false));
       var statistics = container.instance(StatisticManager.class).get();


### PR DESCRIPTION
Fixed parameter order in `ExecutionOptions` instantiation by reordering `maxRows` and `fetchSize` to align with the constructor's expected sequence.