### PR TITLE
Enhance Komapper Spring Boot Testcontainers integration

### DIFF
--- a/komapper-spring-boot-test-autoconfigure-jdbc/src/main/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.jdbc.AutoConfigureKomapperJdbc.imports
+++ b/komapper-spring-boot-test-autoconfigure-jdbc/src/main/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.jdbc.AutoConfigureKomapperJdbc.imports
@@ -6,3 +6,4 @@ org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConf
 org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration
 org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration
 org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
+optional:org.springframework.boot.testcontainers.service.connection.ServiceConnectionAutoConfiguration

--- a/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.r2dbc.AutoConfigureKomapperR2dbc.imports
+++ b/komapper-spring-boot-test-autoconfigure-r2dbc/src/main/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.r2dbc.AutoConfigureKomapperR2dbc.imports
@@ -6,3 +6,4 @@ org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration
 org.springframework.boot.autoconfigure.r2dbc.R2dbcTransactionManagerAutoConfiguration
 org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration
 org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
+optional:org.springframework.boot.testcontainers.service.connection.ServiceConnectionAutoConfiguration


### PR DESCRIPTION
Tune the way Komapper Spring Boot integration works with properties, so it could natively work with Spring Boot Testcontainers integration.

For that, Komapper autoconfigurations should read `JdbcConnectionDetails`/`R2dbcConnectionDetails` beans instead of directly reading application properties (although properties can be used as a fallback).

`AutoConfigureKomapperJdbc`/`AutoConfigureKomapperR2dbc` test slices are also updated to optionally load `ServiceConnectionAutoConfiguration` from the `spring-boot-testcontainers` module.

This requires at least Spring Boot 3.1.0.

References:
* https://spring.io/blog/2023/06/19/spring-boot-31-connectiondetails-abstraction
* https://spring.io/blog/2023/06/23/improved-testcontainers-support-in-spring-boot-3-1
* https://docs.spring.io/spring-boot/reference/testing/testcontainers.html#testing.testcontainers.service-connections