### PR TITLE
chore: update Sonatype publishing URLs to Central Portal staging API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,9 +192,10 @@ configure(libraryProjects + platformProject) {
 rootProject.apply {
     nexusPublishing {
         repositories {
+            // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
             sonatype {
-                nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-                snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+                nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+                snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             }
         }
     }


### PR DESCRIPTION
## Summary
• Updates nexus publishing configuration to use the new Central Portal staging API endpoints
• Adds documentation reference for the new configuration
• Ensures compatibility with Sonatype's updated publishing infrastructure

## Test plan
- [ ] Verify build still works with `./gradlew build`
- [ ] Test publishing configuration (if applicable)
- [ ] Confirm no breaking changes to existing workflows

🤖 Generated with [Claude Code](https://claude.ai/code)