### PR TITLE
Re-enable Gradle parallel execution

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 kotlin.code.style=official
 ksp.useKSP2=true
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m
-org.gradle.parallel=false
+org.gradle.parallel=true
 org.gradle.caching=true
 
 # artifact


### PR DESCRIPTION
## Summary
- Re-enables Gradle parallel execution by reverting the previous fix that disabled it for Quarkus compatibility
- Sets `org.gradle.parallel=true` in gradle.properties

## Context
This reverts the change made to disable parallel execution for Quarkus Gradle Extension compatibility issues. The parallel execution can improve build performance.

## Test plan
- [ ] Run build with `./gradlew build`
- [ ] Run tests with `./gradlew test`
- [ ] Verify Quarkus-related builds still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)