### PR TITLE
Fix  `onDuplicateKeyUpdate` and `onDuplicateKeyIgnore` multiple method return type

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyIgnoreQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyIgnoreQueryBuilder.kt
@@ -35,7 +35,7 @@ interface InsertOnDuplicateKeyIgnoreQueryBuilder<ENTITY : Any, ID : Any, META : 
      * @param entities the entities to be inserted
      * @return the query
      */
-    fun multiple(vararg entities: ENTITY): EntityUpsertQuery<Long>
+    fun multiple(vararg entities: ENTITY): EntityUpsertMultipleQuery<ENTITY>
 
     /**
      * Builds a query to insert a list of entities in a batch.

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyUpdateQueryBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/query/InsertOnDuplicateKeyUpdateQueryBuilder.kt
@@ -49,7 +49,7 @@ interface InsertOnDuplicateKeyUpdateQueryBuilder<ENTITY : Any, ID : Any, META : 
      * @param entities the entities to be inserted or updated
      * @return the query
      */
-    fun multiple(vararg entities: ENTITY): EntityUpsertQuery<Long>
+    fun multiple(vararg entities: ENTITY): EntityUpsertMultipleQuery<ENTITY>
 
     /**
      * Builds a query to insert or update a list of entities in a batch.


### PR DESCRIPTION
because, cannot use returning entity value.