### PR TITLE
Add EntityMetamodelInstance annotation for better code traceability

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodelInstance.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/metamodel/EntityMetamodelInstance.kt
@@ -1,0 +1,7 @@
+package org.komapper.core.dsl.metamodel
+
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.PROPERTY_GETTER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class EntityMetamodelInstance(val entity: KClass<*>)

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/Symbols.kt
@@ -43,6 +43,7 @@ internal object BackquotedSymbols {
     const val EntityMetamodelFactory = "`org`.`komapper`.`core`.`dsl`.`metamodel`.EntityMetamodelFactory"
     const val EntityMetamodelFactorySpi = "`org`.`komapper`.`core`.`spi`.EntityMetamodelFactory"
     const val EntityMetamodelImplementor = "`org`.`komapper`.`core`.`dsl`.`metamodel`.EntityMetamodelImplementor"
+    const val EntityMetamodelInstance = "`org`.`komapper`.`core`.`dsl`.`metamodel`.EntityMetamodelInstance"
     const val EntityMetamodelStub = "`org`.`komapper`.`core`.`dsl`.`metamodel`.EntityMetamodelStub"
     const val EntityStore = "`org`.`komapper`.`core`.`dsl`.`query`.EntityStore"
     const val EntityStoreContext = "`org`.`komapper`.`core`.`dsl`.`query`.EntityStoreContext"

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/entity/EntityMetamodelGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/entity/EntityMetamodelGenerator.kt
@@ -14,6 +14,7 @@ import org.komapper.processor.BackquotedSymbols.EntityMetamodelDeclaration
 import org.komapper.processor.BackquotedSymbols.EntityMetamodelFactory
 import org.komapper.processor.BackquotedSymbols.EntityMetamodelFactorySpi
 import org.komapper.processor.BackquotedSymbols.EntityMetamodelImplementor
+import org.komapper.processor.BackquotedSymbols.EntityMetamodelInstance
 import org.komapper.processor.BackquotedSymbols.EntityStore
 import org.komapper.processor.BackquotedSymbols.EntityStoreContext
 import org.komapper.processor.BackquotedSymbols.EnumMappingException
@@ -741,6 +742,7 @@ internal class EntityMetamodelGenerator(
 
     private fun metamodels() {
         for (alias in aliases) {
+            w.println("@get:$EntityMetamodelInstance($entityTypeName::class)")
             w.println("public val $unitTypeName.`$alias`: $simpleName get() = $simpleName.`$alias`")
         }
         w.println()

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/entity/EntityMetamodelStubGenerator.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/entity/EntityMetamodelStubGenerator.kt
@@ -2,6 +2,7 @@ package org.komapper.processor.entity
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import org.komapper.processor.BackquotedSymbols.EntityMetamodelImplementor
+import org.komapper.processor.BackquotedSymbols.EntityMetamodelInstance
 import org.komapper.processor.BackquotedSymbols.EntityMetamodelStub
 import org.komapper.processor.BackquotedSymbols.PropertyMetamodel
 import org.komapper.processor.BackquotedSymbols.PropertyMetamodelStub
@@ -58,6 +59,7 @@ internal class EntityMetamodelStubGenerator(
         w.println("}")
         w.println("")
         for (alias in aliases) {
+            w.println("@get:$EntityMetamodelInstance($entityTypeName::class)")
             w.println("val $unitTypeName.`$alias`: $simpleName get() = $simpleName.`$alias`")
         }
     }


### PR DESCRIPTION
## Summary
- Added `EntityMetamodelInstance` annotation to improve code traceability
- Applied the annotation to generated metamodel properties to make it easier to trace and follow generated code
- Added necessary symbol definitions and imports in the processor

## Test plan
- [x] Verify the code builds successfully with `./gradlew build`
- [x] Check that generated metamodel code includes the new annotation
- [x] Ensure existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)