### PR TITLE
chore: migrate dependencies to version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,13 +30,9 @@ val kotlinProjects = subprojects - platformProject - javaProjects.toSet()
 
 val isReleaseVersion = !version.toString().endsWith("SNAPSHOT")
 
-// Retain a reference to rootProject.libs to make the version catalog accessible within allprojects and subprojects.
-// See https://github.com/gradle/gradle/issues/16708
-val catalog = libs
-
 allprojects {
     apply(plugin = "base")
-    apply(plugin = catalog.plugins.spotless.get().pluginId)
+    apply(plugin = rootProject.libs.plugins.spotless.get().pluginId)
 
     repositories {
         mavenCentral()
@@ -46,7 +42,7 @@ allprojects {
     spotless {
         lineEndings = com.diffplug.spotless.LineEnding.UNIX
         kotlinGradle {
-            ktlint(catalog.ktlint.get().version)
+            ktlint(rootProject.libs.ktlint.get().version)
         }
     }
 
@@ -59,7 +55,7 @@ allprojects {
 
 configure(libraryProjects + gradlePluginProject + exampleProjects + integrationTestProjects) {
     apply(plugin = "java")
-    apply(plugin = catalog.plugins.kotlin.jvm.get().pluginId)
+    apply(plugin = rootProject.libs.plugins.kotlin.jvm.get().pluginId)
 
     dependencies {
         testImplementation(rootProject.libs.kotlin.test)
@@ -109,7 +105,7 @@ configure(libraryProjects + gradlePluginProject) {
 configure(kotlinProjects) {
     spotless {
         kotlin {
-            ktlint(catalog.ktlint.get().version)
+            ktlint(rootProject.libs.ktlint.get().version)
             targetExclude("build/**")
         }
     }
@@ -118,10 +114,10 @@ configure(kotlinProjects) {
 configure(javaProjects) {
     spotless {
         java {
-            googleJavaFormat(catalog.google.java.format.get().version)
+            googleJavaFormat(rootProject.libs.google.java.format.get().version)
         }
         kotlin {
-            ktlint(catalog.ktlint.get().version)
+            ktlint(rootProject.libs.ktlint.get().version)
             targetExclude("build/**")
         }
     }

--- a/example-spring-boot-jdbc/build.gradle.kts
+++ b/example-spring-boot-jdbc/build.gradle.kts
@@ -4,15 +4,14 @@ plugins {
     alias(libs.plugins.kotlin.plugin.spring)
 }
 
-apply(plugin = "io.spring.dependency-management")
-
 dependencies {
     ksp(project(":komapper-processor"))
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.jackson.module.kotlin)
     implementation(project(":komapper-spring-boot-starter-jdbc"))
     runtimeOnly(project(":komapper-dialect-h2-jdbc"))
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(libs.spring.boot.starter.test)
 }
 
 ksp {

--- a/example-spring-boot-r2dbc/build.gradle.kts
+++ b/example-spring-boot-r2dbc/build.gradle.kts
@@ -4,15 +4,14 @@ plugins {
     alias(libs.plugins.kotlin.plugin.spring)
 }
 
-apply(plugin = "io.spring.dependency-management")
-
 dependencies {
     ksp(project(":komapper-processor"))
-    implementation("org.springframework.boot:spring-boot-starter-webflux")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+    implementation(libs.spring.boot.starter.webflux)
+    implementation(libs.jackson.module.kotlin)
     implementation(project(":komapper-spring-boot-starter-r2dbc"))
     runtimeOnly(project(":komapper-dialect-h2-r2dbc"))
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(libs.spring.boot.starter.test)
 }
 
 ksp {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ quarkus = "3.28.4"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 
 ksp-symbol-processing = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
@@ -45,6 +46,7 @@ opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version = "
 jts-core = { module = "org.locationtech.jts:jts-core", version = "1.20.0" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version = "2.0.17" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.20" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
 
 spring-beans = { module = "org.springframework:spring-beans", version.ref = "springframework" }
 spring-core = { module = "org.springframework:spring-core", version.ref = "springframework" }
@@ -58,6 +60,8 @@ spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-aut
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "spring-boot" }
 spring-boot-starter-jdbc = { module = "org.springframework.boot:spring-boot-starter-jdbc", version.ref = "spring-boot" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot" }
+spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "spring-boot" }
+spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux", version.ref = "spring-boot" }
 spring-boot-test-autoconfigure = { module = "org.springframework.boot:spring-boot-test-autoconfigure", version.ref = "spring-boot" }
 
 quarkus-bom = { module = "io.quarkus:quarkus-bom", version.ref = "quarkus" }
@@ -70,6 +74,7 @@ quarkus-agroal-deployment = { module = "io.quarkus:quarkus-agroal-deployment", v
 quarkus-datasource-deployment = { module = "io.quarkus:quarkus-datasource-deployment", version.ref = "quarkus" }
 
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "2.0.1" }
+testcontainers-r2dbc = { module = "org.testcontainers:testcontainers-r2dbc" }
 testcontainers-mariadb = { module = "org.testcontainers:testcontainers-mariadb" }
 testcontainers-mysql = { module = "org.testcontainers:testcontainers-mysql" }
 testcontainers-oracle = { module = "org.testcontainers:testcontainers-oracle-xe" }

--- a/integration-test-jdbc/build.gradle.kts
+++ b/integration-test-jdbc/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     ksp(project(":komapper-processor"))
     api(project(":komapper-codegen"))
     api(platform(libs.testcontainers.bom))
-    api("org.jetbrains.kotlin:kotlin-test-junit5")
+    api(libs.kotlin.test.junit5)
 }
 
 ksp {

--- a/integration-test-r2dbc/build.gradle.kts
+++ b/integration-test-r2dbc/build.gradle.kts
@@ -13,8 +13,8 @@ dependencies {
     ksp(project(":komapper-processor"))
     api(libs.r2dbc.pool)
     api(platform(libs.testcontainers.bom))
-    api("org.jetbrains.kotlin:kotlin-test-junit5")
-    api("org.testcontainers:testcontainers-r2dbc")
+    api(libs.kotlin.test.junit5)
+    api(libs.testcontainers.r2dbc)
 }
 
 ksp {


### PR DESCRIPTION
## Summary
- Migrate hardcoded dependency strings to centralized version catalog references
- Remove deprecated `io.spring.dependency-management` plugin usage in Spring Boot examples
- Use Spring Boot BOM platform for consistent dependency management
- Add missing library definitions to `gradle/libs.versions.toml` for better centralization

## Changes
- **Root build.gradle.kts**: Remove workaround `catalog` variable and use `rootProject.libs` directly
- **Spring Boot examples**: Replace hardcoded dependencies with version catalog references and use Spring Boot BOM platform
- **Integration tests**: Use version catalog for test dependencies
- **Version catalog**: Add missing library definitions for Spring Boot starters, Jackson, and Testcontainers

## Test plan
- [x] Verify build still works: `./gradlew build`
- [x] Check code formatting: `./gradlew spotlessCheck`
- [x] Run integration tests to ensure dependency changes don't break functionality

🤖 Generated with [Claude Code](https://claude.ai/code)