### PR TITLE
fix: use formatValueToLiteral for literal value directive in SQL templates

### DIFF
--- a/komapper-template/src/main/kotlin/org/komapper/template/TwoWayTemplateStatementBuilder.kt
+++ b/komapper-template/src/main/kotlin/org/komapper/template/TwoWayTemplateStatementBuilder.kt
@@ -185,7 +185,7 @@ internal class TwoWayTemplateStatementBuilder(
 
         is SqlNode.LiteralValueDirective -> {
             val (obj, type) = eval(node.location, node.expression, state.asExprContext())
-            val literal = dialect.formatValue(obj, type, false)
+            val literal = dialect.formatValueToLiteral(obj, type)
             state.append(literal)
             node.nodeList.fold(state, ::visit)
         }


### PR DESCRIPTION
## Summary
- Updated `TwoWayTemplateStatementBuilder` to use `formatValueToLiteral` method instead of `formatValue(obj, type, false)` for proper literal value formatting in SQL templates
- Added PostgreSQL-specific test case to verify literal value handling with the `/*^value*/` directive

## Test plan
- [x] Run `./gradlew test` to verify unit tests pass
- [x] Verify the new `literal()` test case in `JdbcTemplateTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)