### PR TITLE
Add support for `LocalDate`, `LocalDateTime`, and `LocalTime` literals

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcLiteralTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcLiteralTest.kt
@@ -12,18 +12,29 @@ import integration.core.enumPropertyData
 import integration.core.enumclass.Color
 import integration.core.enumclass.Direction
 import integration.core.intData
+import integration.core.kotlinLocalDateData
+import integration.core.kotlinLocalDateTimeData
+import integration.core.localDateData
+import integration.core.localDateTimeData
+import integration.core.localTimeData
 import integration.core.longData
 import integration.core.offsetDateTimeData
 import integration.core.stringData
 import integration.core.userDefinedDoubleData
 import integration.core.userDefinedIntData
+import kotlinx.datetime.toKotlinLocalDate
+import kotlinx.datetime.toKotlinLocalDateTime
 import org.junit.jupiter.api.extension.ExtendWith
 import org.komapper.core.dsl.Meta
 import org.komapper.core.dsl.QueryDsl
 import org.komapper.core.dsl.operator.literal
 import org.komapper.core.dsl.operator.nullLiteral
 import org.komapper.core.dsl.query.first
+import org.komapper.datetime.jdbc.literal
 import org.komapper.jdbc.JdbcDatabase
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.OffsetDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -118,6 +129,160 @@ class JdbcLiteralTest(val db: JdbcDatabase) {
         }
         val result = db.runQuery {
             QueryDsl.from(m).select(m.value, literal(null as Int?)).first()
+        }
+        assertEquals(null to null, result)
+    }
+
+    @Test
+    fun test_literal_kotlinLocalDate() {
+        val m = Meta.kotlinLocalDateData
+        val date1 = LocalDate.of(2020, 12, 31).toKotlinLocalDate()
+        val date2 = LocalDate.of(2021, 6, 15).toKotlinLocalDate()
+        db.runQuery {
+            QueryDsl.insert(m).values {
+                m.id eq 1
+                m.value eq literal(date1)
+            }
+        }
+        val result = db.runQuery {
+            QueryDsl.from(m).select(m.value, literal(date2)).first()
+        }
+        assertEquals(date1 to date2, result)
+    }
+
+    @Test
+    fun test_literal_kotlinLocalDate_null() {
+        val m = Meta.kotlinLocalDateData
+        db.runQuery {
+            QueryDsl.insert(m).values {
+                m.id eq 1
+                m.value eq literal(null as kotlinx.datetime.LocalDate?)
+            }
+        }
+        val result = db.runQuery {
+            QueryDsl.from(m).select(m.value, literal(null as kotlinx.datetime.LocalDate?)).first()
+        }
+        assertEquals(null to null, result)
+    }
+
+    @Test
+    fun test_literal_kotlinLocalDateTime() {
+        val m = Meta.kotlinLocalDateTimeData
+        val date1 = LocalDateTime.of(2020, 12, 31, 13, 30, 20).toKotlinLocalDateTime()
+        val date2 = LocalDateTime.of(2021, 6, 15, 1, 2, 3).toKotlinLocalDateTime()
+        db.runQuery {
+            QueryDsl.insert(m).values {
+                m.id eq 1
+                m.value eq literal(date1)
+            }
+        }
+        val result = db.runQuery {
+            QueryDsl.from(m).select(m.value, literal(date2)).first()
+        }
+        assertEquals(date1 to date2, result)
+    }
+
+    @Test
+    fun test_literal_kotlinLocalDateTime_null() {
+        val m = Meta.kotlinLocalDateTimeData
+        db.runQuery {
+            QueryDsl.insert(m).values {
+                m.id eq 1
+                m.value eq literal(null as kotlinx.datetime.LocalDateTime?)
+            }
+        }
+        val result = db.runQuery {
+            QueryDsl.from(m).select(m.value, literal(null as kotlinx.datetime.LocalDateTime?)).first()
+        }
+        assertEquals(null to null, result)
+    }
+
+    @Test
+    fun test_literal_localDate() {
+        val m = Meta.localDateData
+        db.runQuery {
+            QueryDsl.insert(m).values {
+                m.id eq 1
+                m.value eq literal(LocalDate.of(2020, 12, 31))
+            }
+        }
+        val result = db.runQuery {
+            QueryDsl.from(m).select(m.value, literal(LocalDate.of(2021, 6, 15))).first()
+        }
+        assertEquals(LocalDate.of(2020, 12, 31) to LocalDate.of(2021, 6, 15), result)
+    }
+
+    @Test
+    fun test_literal_localDate_null() {
+        val m = Meta.localDateData
+        db.runQuery {
+            QueryDsl.insert(m).values {
+                m.id eq 1
+                m.value eq literal(null as LocalDate?)
+            }
+        }
+        val result = db.runQuery {
+            QueryDsl.from(m).select(m.value, literal(null as LocalDate?)).first()
+        }
+        assertEquals(null to null, result)
+    }
+
+    @Test
+    fun test_literal_localDateTime() {
+        val m = Meta.localDateTimeData
+        db.runQuery {
+            QueryDsl.insert(m).values {
+                m.id eq 1
+                m.value eq literal(LocalDateTime.of(2020, 12, 31, 14, 30, 20))
+            }
+        }
+        val result = db.runQuery {
+            QueryDsl.from(m).select(m.value, literal(LocalDateTime.of(2021, 6, 15, 1, 2, 3))).first()
+        }
+        assertEquals(LocalDateTime.of(2020, 12, 31, 14, 30, 20) to LocalDateTime.of(2021, 6, 15, 1, 2, 3), result)
+    }
+
+    @Test
+    fun test_literal_localDateTime_null() {
+        val m = Meta.localDateTimeData
+        db.runQuery {
+            QueryDsl.insert(m).values {
+                m.id eq 1
+                m.value eq literal(null as LocalDateTime?)
+            }
+        }
+        val result = db.runQuery {
+            QueryDsl.from(m).select(m.value, literal(null as LocalDateTime?)).first()
+        }
+        assertEquals(null to null, result)
+    }
+
+    @Test
+    fun test_literal_localTime() {
+        val m = Meta.localTimeData
+        db.runQuery {
+            QueryDsl.insert(m).values {
+                m.id eq 1
+                m.value eq literal(LocalTime.of(14, 30, 20))
+            }
+        }
+        val result = db.runQuery {
+            QueryDsl.from(m).select(m.value, literal(LocalTime.of(1, 2, 3))).first()
+        }
+        assertEquals(LocalTime.of(14, 30, 20) to LocalTime.of(1, 2, 3), result)
+    }
+
+    @Test
+    fun test_literal_localTime_null() {
+        val m = Meta.localTimeData
+        db.runQuery {
+            QueryDsl.insert(m).values {
+                m.id eq 1
+                m.value eq literal(null as LocalTime?)
+            }
+        }
+        val result = db.runQuery {
+            QueryDsl.from(m).select(m.value, literal(null as LocalTime?)).first()
         }
         assertEquals(null to null, result)
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/LiteralExpressions.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/operator/LiteralExpressions.kt
@@ -5,6 +5,9 @@ import org.komapper.core.dsl.expression.NullLiteralExpression
 import org.komapper.core.dsl.expression.NullableLiteralExpression
 import org.komapper.core.dsl.expression.createSimpleNullableLiteralExpression
 import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.OffsetDateTime
 import kotlin.reflect.typeOf
 
@@ -34,6 +37,27 @@ fun literal(value: Boolean?): ColumnExpression<Boolean, Boolean> {
  */
 fun literal(value: Int?): ColumnExpression<Int, Int> {
     return createSimpleNullableLiteralExpression(value, typeOf<Int>())
+}
+
+/**
+ * Builds a [LocalDate] literal.
+ */
+fun literal(value: LocalDate?): ColumnExpression<LocalDate, LocalDate> {
+    return createSimpleNullableLiteralExpression(value, typeOf<LocalDate>())
+}
+
+/**
+ * Builds a [LocalDateTime] literal.
+ */
+fun literal(value: LocalDateTime?): ColumnExpression<LocalDateTime, LocalDateTime> {
+    return createSimpleNullableLiteralExpression(value, typeOf<LocalDateTime>())
+}
+
+/**
+ * Builds a [LocalTime] literal.
+ */
+fun literal(value: LocalTime?): ColumnExpression<LocalTime, LocalTime> {
+    return createSimpleNullableLiteralExpression(value, typeOf<LocalTime>())
 }
 
 /**

--- a/komapper-datetime-jdbc/src/main/kotlin/org/komapper/datetime/jdbc/JdbcDatetimeExpressions.kt
+++ b/komapper-datetime-jdbc/src/main/kotlin/org/komapper/datetime/jdbc/JdbcDatetimeExpressions.kt
@@ -1,0 +1,21 @@
+package org.komapper.datetime.jdbc
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.createSimpleNullableLiteralExpression
+import kotlin.reflect.typeOf
+
+/**
+ * Builds a [LocalDate] literal.
+ */
+fun literal(value: LocalDate?): ColumnExpression<LocalDate, LocalDate> {
+    return createSimpleNullableLiteralExpression(value, typeOf<LocalDate>())
+}
+
+/**
+ * Builds a [LocalDateTime] literal.
+ */
+fun literal(value: LocalDateTime?): ColumnExpression<LocalDateTime, LocalDateTime> {
+    return createSimpleNullableLiteralExpression(value, typeOf<LocalDateTime>())
+}

--- a/komapper-datetime-jdbc/src/main/kotlin/org/komapper/datetime/jdbc/JdbcDatetimeTypeProvider.kt
+++ b/komapper-datetime-jdbc/src/main/kotlin/org/komapper/datetime/jdbc/JdbcDatetimeTypeProvider.kt
@@ -51,6 +51,10 @@ internal class JdbcKotlinLocalDateType(private val dataType: JdbcDataType<java.t
     override fun doSetValue(ps: PreparedStatement, index: Int, value: LocalDate) {
         dataType.setValue(ps, index, value.toJavaLocalDate())
     }
+
+    override fun toLiteral(value: LocalDate?): String {
+        return if (value == null) "null" else dataType.toLiteral(value.toJavaLocalDate())
+    }
 }
 
 internal class JdbcKotlinLocalDateTimeType(private val dataType: JdbcDataType<java.time.LocalDateTime>) :
@@ -69,5 +73,9 @@ internal class JdbcKotlinLocalDateTimeType(private val dataType: JdbcDataType<ja
 
     override fun doSetValue(ps: PreparedStatement, index: Int, value: LocalDateTime) {
         dataType.setValue(ps, index, value.toJavaLocalDateTime())
+    }
+
+    override fun toLiteral(value: LocalDateTime?): String {
+        return if (value == null) "null" else dataType.toLiteral(value.toJavaLocalDateTime())
     }
 }

--- a/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataType.kt
+++ b/komapper-jdbc/src/main/kotlin/org/komapper/jdbc/JdbcDataType.kt
@@ -23,6 +23,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 import kotlin.time.ExperimentalTime
@@ -519,7 +520,10 @@ class JdbcKotlinInstantAsTimestampWithTimezoneType(
     }
 }
 
-class JdbcLocalDateTimeType(override val name: String, toLiteral: (DataType.(LocalDateTime?) -> String)? = null) :
+class JdbcLocalDateTimeType(
+    override val name: String,
+    toLiteral: (DataType.(LocalDateTime?) -> String)? = DataType::toLocalDateTimeLiteral,
+) :
     AbstractJdbcDataType<LocalDateTime>(typeOf<LocalDateTime>(), JDBCType.TIMESTAMP, toLiteral) {
     override fun doGetValue(rs: ResultSet, index: Int): LocalDateTime? {
         return rs.getObject(index, LocalDateTime::class.java)
@@ -538,7 +542,16 @@ class JdbcLocalDateTimeType(override val name: String, toLiteral: (DataType.(Loc
     }
 }
 
-class JdbcLocalDateType(override val name: String, toLiteral: (DataType.(LocalDate?) -> String)? = null) :
+private fun DataType.toLocalDateTimeLiteral(value: LocalDateTime?): String {
+    if (value == null) return "null"
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    return "{ts '${value.format(formatter)}'}"
+}
+
+class JdbcLocalDateType(
+    override val name: String,
+    toLiteral: (DataType.(LocalDate?) -> String)? = DataType::toLocalDateLiteral,
+) :
     AbstractJdbcDataType<LocalDate>(typeOf<LocalDate>(), JDBCType.DATE, toLiteral) {
     override fun doGetValue(rs: ResultSet, index: Int): LocalDate? {
         return rs.getObject(index, LocalDate::class.java)
@@ -557,7 +570,16 @@ class JdbcLocalDateType(override val name: String, toLiteral: (DataType.(LocalDa
     }
 }
 
-class JdbcLocalTimeType(override val name: String, toLiteral: (DataType.(LocalTime?) -> String)? = null) :
+private fun DataType.toLocalDateLiteral(value: LocalDate?): String {
+    if (value == null) return "null"
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    return "{d '${value.format(formatter)}'}"
+}
+
+class JdbcLocalTimeType(
+    override val name: String,
+    toLiteral: (DataType.(LocalTime?) -> String)? = DataType::toLocalTimeLiteral,
+) :
     AbstractJdbcDataType<LocalTime>(typeOf<LocalTime>(), JDBCType.TIME, toLiteral) {
     override fun doGetValue(rs: ResultSet, index: Int): LocalTime? {
         return rs.getObject(index, LocalTime::class.java)
@@ -574,6 +596,12 @@ class JdbcLocalTimeType(override val name: String, toLiteral: (DataType.(LocalTi
     override fun doToString(value: LocalTime): String {
         return "'$value'"
     }
+}
+
+private fun DataType.toLocalTimeLiteral(value: LocalTime?): String {
+    if (value == null) return "null"
+    val formatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+    return "{t '${value.format(formatter)}'}"
 }
 
 class JdbcLongType(override val name: String, toLiteral: (DataType.(Long?) -> String)? = null) :

--- a/komapper-jdbc/src/test/kotlin/org/komapper/jdbc/JdbcDateTypeTest.kt
+++ b/komapper-jdbc/src/test/kotlin/org/komapper/jdbc/JdbcDateTypeTest.kt
@@ -1,0 +1,30 @@
+package org.komapper.jdbc
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JdbcDateTypeTest {
+    @Test
+    fun localDateLiteral() {
+        val dataType = JdbcLocalDateType("date")
+        assertEquals("{d '1234-01-02'}", dataType.toLiteral(java.time.LocalDate.of(1234, 1, 2)))
+        assertEquals("{d '2020-12-25'}", dataType.toLiteral(java.time.LocalDate.of(2020, 12, 25)))
+        assertEquals("null", dataType.toLiteral(null))
+    }
+
+    @Test
+    fun localDateTimeLiteral() {
+        val dataType = JdbcLocalDateTimeType("timestamp")
+        assertEquals("{ts '1234-01-02 03:04:05'}", dataType.toLiteral(java.time.LocalDateTime.of(1234, 1, 2, 3, 4, 5)))
+        assertEquals("{ts '2020-12-25 13:34:56'}", dataType.toLiteral(java.time.LocalDateTime.of(2020, 12, 25, 13, 34, 56)))
+        assertEquals("null", dataType.toLiteral(null))
+    }
+
+    @Test
+    fun localTimeLiteral() {
+        val dataType = JdbcLocalTimeType("time")
+        assertEquals("{t '03:04:05'}", dataType.toLiteral(java.time.LocalTime.of(3, 4, 5)))
+        assertEquals("{t '13:34:56'}", dataType.toLiteral(java.time.LocalTime.of(13, 34, 56)))
+        assertEquals("null", dataType.toLiteral(null))
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces support for `LocalDate`, `LocalDateTime`, and `LocalTime` literal expressions in both the core and datetime JDBC modules. Key changes include:

- Implementation of `literal` functions for `LocalDate`, `LocalDateTime`, and `LocalTime`.
- Enhancements to `JdbcDataType` for formatting date and time literals using `DateTimeFormatter`.
- Addition of tests to verify correct handling of literals for both nullable and non-nullable scenarios.

### Checklist

- [x] Unit tests added/modified for new functionality.
- [x] Documentation updated (if required).
- [x] All code changes follow coding standards.