### PR TITLE
feat(tx): extend transaction operator APIs with isActive() and transactionProperty

### DIFF
--- a/komapper-quarkus-jdbc/src/main/kotlin/org/komapper/quarkus/jdbc/QuarkusJdbcTransactionOperator.kt
+++ b/komapper-quarkus-jdbc/src/main/kotlin/org/komapper/quarkus/jdbc/QuarkusJdbcTransactionOperator.kt
@@ -2,18 +2,23 @@ package org.komapper.quarkus.jdbc
 
 import jakarta.transaction.Status
 import jakarta.transaction.TransactionManager
+import org.komapper.tx.core.EmptyTransactionProperty
 import org.komapper.tx.core.TransactionOperator
 import org.komapper.tx.core.TransactionProperty
 
-internal class QuarkusJdbcTransactionOperator(private val transactionManager: TransactionManager) : TransactionOperator {
+internal class QuarkusJdbcTransactionOperator(
+    private val transactionManager: TransactionManager,
+    override val transactionProperty: TransactionProperty = EmptyTransactionProperty,
+) : TransactionOperator {
     override fun <R> required(
         transactionProperty: TransactionProperty,
         block: (TransactionOperator) -> R,
     ): R {
         return if (transactionManager.isActive()) {
-            block(this)
+            val operator = QuarkusJdbcTransactionOperator(transactionManager, this.transactionProperty + transactionProperty)
+            block(operator)
         } else {
-            executeInNewTransaction(block)
+            executeInNewTransaction(transactionProperty, block)
         }
     }
 
@@ -24,7 +29,7 @@ internal class QuarkusJdbcTransactionOperator(private val transactionManager: Tr
         return if (transactionManager.isActive()) {
             val tx = transactionManager.suspend()
             runCatching {
-                executeInNewTransaction(block)
+                executeInNewTransaction(transactionProperty, block)
             }.onSuccess {
                 transactionManager.resume(tx)
             }.onFailure { cause ->
@@ -35,14 +40,18 @@ internal class QuarkusJdbcTransactionOperator(private val transactionManager: Tr
                 }
             }.getOrThrow()
         } else {
-            executeInNewTransaction(block)
+            executeInNewTransaction(transactionProperty, block)
         }
     }
 
-    private fun <R> executeInNewTransaction(block: (TransactionOperator) -> R): R {
+    private fun <R> executeInNewTransaction(
+        transactionProperty: TransactionProperty,
+        block: (TransactionOperator) -> R,
+    ): R {
         transactionManager.begin()
         return runCatching {
-            block(this)
+            val operator = QuarkusJdbcTransactionOperator(transactionManager, this.transactionProperty + transactionProperty)
+            block(operator)
         }.onSuccess {
             if (transactionManager.isRollbackOnly()) {
                 transactionManager.rollback()
@@ -64,6 +73,10 @@ internal class QuarkusJdbcTransactionOperator(private val transactionManager: Tr
 
     override fun isRollbackOnly(): Boolean {
         return transactionManager.isRollbackOnly()
+    }
+
+    override fun isActive(): Boolean {
+        return transactionManager.isActive()
     }
 }
 

--- a/komapper-spring-jdbc/src/main/kotlin/org/komapper/spring/jdbc/SpringJdbcTransactionOperator.kt
+++ b/komapper-spring-jdbc/src/main/kotlin/org/komapper/spring/jdbc/SpringJdbcTransactionOperator.kt
@@ -1,37 +1,38 @@
 package org.komapper.spring.jdbc
 
 import org.komapper.spring.SpringTransactionDefinition
+import org.komapper.tx.core.EmptyTransactionProperty
 import org.komapper.tx.core.TransactionAttribute
 import org.komapper.tx.core.TransactionOperator
 import org.komapper.tx.core.TransactionProperty
 import org.springframework.transaction.PlatformTransactionManager
-import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionTemplate
 
 class SpringJdbcTransactionOperator(
     private val transactionManager: PlatformTransactionManager,
     private val status: TransactionStatus? = null,
+    override val transactionProperty: TransactionProperty = EmptyTransactionProperty,
 ) : TransactionOperator {
     override fun <R> required(transactionProperty: TransactionProperty, block: (TransactionOperator) -> R): R {
-        val definition = SpringTransactionDefinition(transactionProperty, TransactionAttribute.REQUIRED)
+        val definition = SpringTransactionDefinition(this.transactionProperty + transactionProperty, TransactionAttribute.REQUIRED)
         return execute(definition, block)
     }
 
     override fun <R> requiresNew(transactionProperty: TransactionProperty, block: (TransactionOperator) -> R): R {
-        val definition = SpringTransactionDefinition(transactionProperty, TransactionAttribute.REQUIRES_NEW)
+        val definition = SpringTransactionDefinition(this.transactionProperty + transactionProperty, TransactionAttribute.REQUIRES_NEW)
         return execute(definition, block)
     }
 
     private fun <R> execute(
-        definition: TransactionDefinition,
+        definition: SpringTransactionDefinition,
         block: (TransactionOperator) -> R,
     ): R {
         val txOp = TransactionTemplate(transactionManager, definition)
 
         @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
         val result: Result<R> = txOp.execute { s ->
-            val operator = SpringJdbcTransactionOperator(transactionManager, s)
+            val operator = SpringJdbcTransactionOperator(transactionManager, s, definition.transactionProperty)
             runCatching {
                 block(operator)
             }.onSuccess {
@@ -65,5 +66,12 @@ class SpringJdbcTransactionOperator(
             error("The status is null.")
         }
         return status.isRollbackOnly
+    }
+
+    override fun isActive(): Boolean {
+        if (status == null) {
+            return false
+        }
+        return status.hasTransaction()
     }
 }

--- a/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/SpringR2dbcCoroutineTransactionOperator.kt
+++ b/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/SpringR2dbcCoroutineTransactionOperator.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.asFlux
 import org.komapper.spring.SpringTransactionDefinition
 import org.komapper.tx.core.CoroutineTransactionOperator
+import org.komapper.tx.core.EmptyTransactionProperty
 import org.komapper.tx.core.TransactionAttribute
 import org.komapper.tx.core.TransactionProperty
 import org.springframework.transaction.ReactiveTransaction
@@ -15,13 +16,16 @@ import org.springframework.transaction.reactive.TransactionalOperator
 import java.util.Optional
 import kotlin.coroutines.coroutineContext
 
-internal class SpringR2dbcCoroutineTransactionOperator(private val transactionManager: ReactiveTransactionManager, private val transaction: ReactiveTransaction? = null) :
-    CoroutineTransactionOperator {
+internal class SpringR2dbcCoroutineTransactionOperator(
+    private val transactionManager: ReactiveTransactionManager,
+    private val transaction: ReactiveTransaction? = null,
+    override val transactionProperty: TransactionProperty = EmptyTransactionProperty,
+) : CoroutineTransactionOperator {
     override suspend fun <R> required(
         transactionProperty: TransactionProperty,
         block: suspend (CoroutineTransactionOperator) -> R,
     ): R {
-        val definition = SpringTransactionDefinition(transactionProperty, TransactionAttribute.REQUIRED)
+        val definition = SpringTransactionDefinition(this.transactionProperty + transactionProperty, TransactionAttribute.REQUIRED)
         return execute(definition, block)
     }
 
@@ -29,19 +33,19 @@ internal class SpringR2dbcCoroutineTransactionOperator(private val transactionMa
         transactionProperty: TransactionProperty,
         block: suspend (CoroutineTransactionOperator) -> R,
     ): R {
-        val definition = SpringTransactionDefinition(transactionProperty, TransactionAttribute.REQUIRES_NEW)
+        val definition = SpringTransactionDefinition(this.transactionProperty + transactionProperty, TransactionAttribute.REQUIRES_NEW)
         return execute(definition, block)
     }
 
     private suspend fun <R> execute(
-        definition: org.springframework.transaction.TransactionDefinition,
+        definition: SpringTransactionDefinition,
         block: suspend (CoroutineTransactionOperator) -> R,
     ): R {
         val context = coroutineContext
         val txOp = TransactionalOperator.create(transactionManager, definition)
         val flux = txOp.execute { tx ->
             flow {
-                val operator = SpringR2dbcCoroutineTransactionOperator(transactionManager, tx)
+                val operator = SpringR2dbcCoroutineTransactionOperator(transactionManager, tx, definition.transactionProperty)
                 try {
                     val value = block(operator)
                     emit(value)
@@ -68,5 +72,12 @@ internal class SpringR2dbcCoroutineTransactionOperator(private val transactionMa
             error("The transaction is null.")
         }
         return transaction.isRollbackOnly
+    }
+
+    override suspend fun isActive(): Boolean {
+        if (transaction == null) {
+            return false
+        }
+        return transaction.hasTransaction()
     }
 }

--- a/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/SpringR2dbcFlowTransactionOperator.kt
+++ b/komapper-spring-r2dbc/src/main/kotlin/org/komapper/spring/r2dbc/SpringR2dbcFlowTransactionOperator.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.asFlux
 import org.komapper.spring.SpringTransactionDefinition
+import org.komapper.tx.core.EmptyTransactionProperty
 import org.komapper.tx.core.FlowTransactionOperator
 import org.komapper.tx.core.TransactionAttribute
 import org.komapper.tx.core.TransactionProperty
@@ -17,13 +18,16 @@ import org.springframework.transaction.reactive.TransactionalOperator
 import java.util.Optional
 import kotlin.coroutines.coroutineContext
 
-internal class SpringR2dbcFlowTransactionOperator(private val transactionManager: ReactiveTransactionManager, private val transaction: ReactiveTransaction? = null) :
-    FlowTransactionOperator {
+internal class SpringR2dbcFlowTransactionOperator(
+    private val transactionManager: ReactiveTransactionManager,
+    private val transaction: ReactiveTransaction? = null,
+    override val transactionProperty: TransactionProperty = EmptyTransactionProperty,
+) : FlowTransactionOperator {
     override fun <R> required(
         transactionProperty: TransactionProperty,
         block: suspend FlowCollector<R>.(FlowTransactionOperator) -> Unit,
     ): Flow<R> {
-        val definition = SpringTransactionDefinition(transactionProperty, TransactionAttribute.REQUIRED)
+        val definition = SpringTransactionDefinition(this.transactionProperty + transactionProperty, TransactionAttribute.REQUIRED)
         return execute(definition, block)
     }
 
@@ -31,12 +35,12 @@ internal class SpringR2dbcFlowTransactionOperator(private val transactionManager
         transactionProperty: TransactionProperty,
         block: suspend FlowCollector<R>.(FlowTransactionOperator) -> Unit,
     ): Flow<R> {
-        val definition = SpringTransactionDefinition(transactionProperty, TransactionAttribute.REQUIRES_NEW)
+        val definition = SpringTransactionDefinition(this.transactionProperty + transactionProperty, TransactionAttribute.REQUIRES_NEW)
         return execute(definition, block)
     }
 
     private fun <R> execute(
-        definition: org.springframework.transaction.TransactionDefinition,
+        definition: SpringTransactionDefinition,
         block: suspend FlowCollector<R>.(FlowTransactionOperator) -> Unit,
     ): Flow<R> {
         return flow {
@@ -44,7 +48,7 @@ internal class SpringR2dbcFlowTransactionOperator(private val transactionManager
             val txOp = TransactionalOperator.create(transactionManager, definition)
             val flux = txOp.execute { tx ->
                 flow {
-                    val operator = SpringR2dbcFlowTransactionOperator(transactionManager, tx)
+                    val operator = SpringR2dbcFlowTransactionOperator(transactionManager, tx, definition.transactionProperty)
                     try {
                         block(operator)
                     } finally {
@@ -72,5 +76,12 @@ internal class SpringR2dbcFlowTransactionOperator(private val transactionManager
             error("The transaction is null.")
         }
         return transaction.isRollbackOnly
+    }
+
+    override suspend fun isActive(): Boolean {
+        if (transaction == null) {
+            return false
+        }
+        return transaction.hasTransaction()
     }
 }

--- a/komapper-spring/src/main/kotlin/org/komapper/spring/SpringTransactionDefinition.kt
+++ b/komapper-spring/src/main/kotlin/org/komapper/spring/SpringTransactionDefinition.kt
@@ -5,7 +5,7 @@ import org.komapper.tx.core.TransactionProperty
 import org.springframework.transaction.TransactionDefinition
 
 class SpringTransactionDefinition(
-    private val transactionProperty: TransactionProperty,
+    val transactionProperty: TransactionProperty,
     private val transactionAttribute: TransactionAttribute,
 ) : TransactionDefinition by TransactionDefinition.withDefaults() {
     override fun getPropagationBehavior(): Int {

--- a/komapper-tx-core/src/main/kotlin/org/komapper/tx/core/CoroutineTransactionOperator.kt
+++ b/komapper-tx-core/src/main/kotlin/org/komapper/tx/core/CoroutineTransactionOperator.kt
@@ -5,6 +5,11 @@ import org.komapper.core.ThreadSafe
 @ThreadSafe
 interface CoroutineTransactionOperator {
     /**
+     * The property of the current transaction.
+     */
+    val transactionProperty: TransactionProperty
+
+    /**
      * Begins a REQUIRED transaction.
      *
      * @param R the return type of the block
@@ -39,4 +44,9 @@ interface CoroutineTransactionOperator {
      * Returns true if the transaction is marked as rollback.
      */
     suspend fun isRollbackOnly(): Boolean
+
+    /**
+     * Returns true if a transaction is currently active.
+     */
+    suspend fun isActive(): Boolean
 }

--- a/komapper-tx-core/src/main/kotlin/org/komapper/tx/core/FlowTransactionOperator.kt
+++ b/komapper-tx-core/src/main/kotlin/org/komapper/tx/core/FlowTransactionOperator.kt
@@ -7,6 +7,11 @@ import org.komapper.core.ThreadSafe
 @ThreadSafe
 interface FlowTransactionOperator {
     /**
+     * The property of the current transaction.
+     */
+    val transactionProperty: TransactionProperty
+
+    /**
      * Build a REQUIRED transactional [Flow].
      *
      * @param R the return type of the flow
@@ -41,4 +46,9 @@ interface FlowTransactionOperator {
      * Returns true if the transaction is marked as rollback.
      */
     suspend fun isRollbackOnly(): Boolean
+
+    /**
+     * Returns true if a transaction is currently active.
+     */
+    suspend fun isActive(): Boolean
 }

--- a/komapper-tx-core/src/main/kotlin/org/komapper/tx/core/TransactionOperator.kt
+++ b/komapper-tx-core/src/main/kotlin/org/komapper/tx/core/TransactionOperator.kt
@@ -5,6 +5,11 @@ import org.komapper.core.ThreadSafe
 @ThreadSafe
 interface TransactionOperator {
     /**
+     * The property of the current transaction.
+     */
+    val transactionProperty: TransactionProperty
+
+    /**
      * Begins a REQUIRED transaction.
      *
      * @param R the return type of the block
@@ -39,4 +44,9 @@ interface TransactionOperator {
      * Returns true if the transaction is marked as rollback.
      */
     fun isRollbackOnly(): Boolean
+
+    /**
+     * Returns true if a transaction is currently active.
+     */
+    fun isActive(): Boolean
 }

--- a/komapper-tx-jdbc/src/main/kotlin/org/komapper/tx/jdbc/JdbcTransactionOperator.kt
+++ b/komapper-tx-jdbc/src/main/kotlin/org/komapper/tx/jdbc/JdbcTransactionOperator.kt
@@ -6,14 +6,15 @@ import org.komapper.tx.core.TransactionProperty
 
 internal class JdbcTransactionOperator(
     private val transactionManager: JdbcTransactionManager,
-    private val defaultTransactionProperty: TransactionProperty = EmptyTransactionProperty,
+    override val transactionProperty: TransactionProperty = EmptyTransactionProperty,
 ) : TransactionOperator {
     override fun <R> required(
         transactionProperty: TransactionProperty,
         block: (TransactionOperator) -> R,
     ): R {
         return if (transactionManager.isActive()) {
-            block(this)
+            val operator = JdbcTransactionOperator(transactionManager, this.transactionProperty + transactionProperty)
+            block(operator)
         } else {
             executeInNewTransaction(transactionProperty, block)
         }
@@ -46,9 +47,11 @@ internal class JdbcTransactionOperator(
         transactionProperty: TransactionProperty,
         block: (TransactionOperator) -> R,
     ): R {
-        transactionManager.begin(defaultTransactionProperty + transactionProperty)
+        val newTransactionProperty = this.transactionProperty + transactionProperty
+        transactionManager.begin(newTransactionProperty)
         return runCatching {
-            block(this)
+            val operator = JdbcTransactionOperator(transactionManager, newTransactionProperty)
+            block(operator)
         }.onSuccess {
             if (transactionManager.isRollbackOnly()) {
                 transactionManager.rollback()
@@ -70,5 +73,9 @@ internal class JdbcTransactionOperator(
 
     override fun isRollbackOnly(): Boolean {
         return transactionManager.isRollbackOnly()
+    }
+
+    override fun isActive(): Boolean {
+        return transactionManager.isActive()
     }
 }

--- a/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcCoroutineTransactionOperator.kt
+++ b/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcCoroutineTransactionOperator.kt
@@ -7,14 +7,15 @@ import org.komapper.tx.core.TransactionProperty
 
 internal class R2dbcCoroutineTransactionOperator(
     private val transactionManager: R2dbcTransactionManager,
-    private val defaultTransactionProperty: TransactionProperty = EmptyTransactionProperty,
+    override val transactionProperty: TransactionProperty = EmptyTransactionProperty,
 ) : CoroutineTransactionOperator {
     override suspend fun <R> required(
         transactionProperty: TransactionProperty,
         block: suspend (CoroutineTransactionOperator) -> R,
     ): R {
         return if (transactionManager.isActive()) {
-            block(this)
+            val operator = R2dbcCoroutineTransactionOperator(transactionManager, this.transactionProperty + transactionProperty)
+            block(operator)
         } else {
             executeInNewTransaction(transactionProperty, block)
         }
@@ -40,10 +41,12 @@ internal class R2dbcCoroutineTransactionOperator(
         transactionProperty: TransactionProperty,
         block: suspend (CoroutineTransactionOperator) -> R,
     ): R {
-        val txContext = transactionManager.begin(defaultTransactionProperty + transactionProperty)
+        val newTransactionProperty = this.transactionProperty + transactionProperty
+        val txContext = transactionManager.begin(newTransactionProperty)
         return withContext(txContext) {
             runCatching {
-                block(this@R2dbcCoroutineTransactionOperator)
+                val operator = R2dbcCoroutineTransactionOperator(transactionManager, newTransactionProperty)
+                block(operator)
             }.onSuccess {
                 if (transactionManager.isRollbackOnly()) {
                     transactionManager.rollback()
@@ -66,5 +69,9 @@ internal class R2dbcCoroutineTransactionOperator(
 
     override suspend fun isRollbackOnly(): Boolean {
         return transactionManager.isRollbackOnly()
+    }
+
+    override suspend fun isActive(): Boolean {
+        return transactionManager.isActive()
     }
 }

--- a/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcFlowTransactionOperator.kt
+++ b/komapper-tx-r2dbc/src/main/kotlin/org/komapper/tx/r2dbc/R2dbcFlowTransactionOperator.kt
@@ -13,7 +13,7 @@ import org.komapper.tx.core.TransactionProperty
 
 internal class R2dbcFlowTransactionOperator(
     private val transactionManager: R2dbcTransactionManager,
-    private val defaultTransactionProperty: TransactionProperty = EmptyTransactionProperty,
+    override val transactionProperty: TransactionProperty = EmptyTransactionProperty,
 ) : FlowTransactionOperator {
     override fun <R> required(
         transactionProperty: TransactionProperty,
@@ -21,7 +21,8 @@ internal class R2dbcFlowTransactionOperator(
     ): Flow<R> {
         return flow {
             if (transactionManager.isActive()) {
-                block(this@R2dbcFlowTransactionOperator)
+                val operator = R2dbcFlowTransactionOperator(transactionManager, this@R2dbcFlowTransactionOperator.transactionProperty + transactionProperty)
+                block(operator)
             } else {
                 val value = executeInNewTransaction(transactionProperty, block)
                 emitAll(value)
@@ -52,10 +53,12 @@ internal class R2dbcFlowTransactionOperator(
         transactionProperty: TransactionProperty,
         block: suspend FlowCollector<R>.(FlowTransactionOperator) -> Unit,
     ): Flow<R> {
-        val txContext = transactionManager.begin(defaultTransactionProperty + transactionProperty)
+        val newTransactionProperty = this.transactionProperty + transactionProperty
+        val txContext = transactionManager.begin(newTransactionProperty)
+        val operator = R2dbcFlowTransactionOperator(transactionManager, newTransactionProperty)
         return flow {
             kotlin.runCatching {
-                block(this@R2dbcFlowTransactionOperator)
+                block(operator)
             }.onSuccess {
                 if (transactionManager.isRollbackOnly()) {
                     transactionManager.rollback()
@@ -78,5 +81,9 @@ internal class R2dbcFlowTransactionOperator(
 
     override suspend fun isRollbackOnly(): Boolean {
         return transactionManager.isRollbackOnly()
+    }
+
+    override suspend fun isActive(): Boolean {
+        return transactionManager.isActive()
     }
 }


### PR DESCRIPTION
## Summary

- Add `isActive()` and `transactionProperty` to `TransactionOperator`, `CoroutineTransactionOperator`, and `FlowTransactionOperator` interfaces
- Implement the new members in all concrete implementations: `JdbcTransactionOperator`, `QuarkusJdbcTransactionOperator`, `SpringJdbcTransactionOperator`, `R2dbcCoroutineTransactionOperator`, `SpringR2dbcCoroutineTransactionOperator`, `R2dbcFlowTransactionOperator`, and `SpringR2dbcFlowTransactionOperator`
- Propagate `transactionProperty` through nested `required`/`requiresNew` calls so child operators inherit the parent's combined property

Closes #1838

## Test plan

- [ ] Verify `isActive()` returns `true` inside a transaction block and `false` outside
- [ ] Verify `transactionProperty` reflects the combined property when nesting `required`/`requiresNew` calls
- [ ] Run `./gradlew h2` to confirm existing integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)