### PR TITLE
ci: use pull_request_target for autolabeler to support fork PRs

### DIFF
--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -1,7 +1,7 @@
 name: Autolabeler
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Summary

- Switch the Autolabeler workflow trigger from `pull_request` to `pull_request_target` so it works for PRs from forks.
- For cross-repository PRs, `pull_request` uses a read-only `GITHUB_TOKEN`, which makes `release-drafter/autolabeler` fail with `Resource not accessible by integration` when adding labels (e.g. [run on #1844](https://github.com/komapper/komapper/actions/runs/24299358733/job/70961424721?pr=1844)).
- `pull_request_target` runs in the base repository context with a write-scoped token, matching the approach already used in `.github/workflows/labeler.yml`.

## Security note

`pull_request_target` runs with the base repo's token, so extra care is usually required. This workflow is safe because it does **not** check out or execute any code from the PR — it only runs `release-drafter/autolabeler`, which reads PR metadata (title, branch name) to decide labels.

## Test plan

- [ ] On merge, verify a subsequent fork PR (or re-run on #1844 after rebase) gets autolabeled successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)