### PR TITLE
test: switch to testcontainers-oracle-free for Oracle integration tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,7 +83,7 @@ testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version
 testcontainers-r2dbc = { module = "org.testcontainers:testcontainers-r2dbc" }
 testcontainers-mariadb = { module = "org.testcontainers:testcontainers-mariadb" }
 testcontainers-mysql = { module = "org.testcontainers:testcontainers-mysql" }
-testcontainers-oracle = { module = "org.testcontainers:testcontainers-oracle-xe" }
+testcontainers-oracle = { module = "org.testcontainers:testcontainers-oracle-free" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
 testcontainers-sqlserver = { module = "org.testcontainers:testcontainers-mssqlserver" }
 

--- a/integration-test-jdbc/build.gradle.kts
+++ b/integration-test-jdbc/build.gradle.kts
@@ -129,6 +129,10 @@ fun JvmTestSuite.setup(identifier: String) {
                 val url = project.property(urlKey) ?: throw GradleException("The $urlKey property is not found.")
                 systemProperty("identifier", identifier)
                 systemProperty("url", url)
+                if (identifier == "oracle") {
+                    systemProperty("user.language", "en")
+                    systemProperty("user.country", "US")
+                }
             }
         }
     }

--- a/integration-test-jdbc/gradle.properties
+++ b/integration-test-jdbc/gradle.properties
@@ -4,6 +4,6 @@ h2.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
 mariadb.url=jdbc:tc:mariadb:10.6.3:///test?TC_DAEMON=true
 mysql.url=jdbc:tc:mysql:8.0.25:///test?TC_DAEMON=true
 mysql5.url=jdbc:tc:mysql:5.7.44:///test?TC_DAEMON=true
-oracle.url=jdbc:tc:oracle:thin:@test?TC_DAEMON=true
+oracle.url=jdbc:tc:oracle:23.26.1-slim-faststart:thin:@test?TC_DAEMON=true
 postgresql.url=jdbc:tc:postgis:12-3.4:///test?TC_DAEMON=true
 sqlserver.url=jdbc:tc:sqlserver:2019-CU28-ubuntu-20.04:///test?TC_DAEMON=true

--- a/integration-test-r2dbc/build.gradle.kts
+++ b/integration-test-r2dbc/build.gradle.kts
@@ -127,6 +127,10 @@ fun JvmTestSuite.setup(identifier: String) {
                 val url = project.property(urlKey) ?: throw GradleException("The $urlKey property is not found.")
                 systemProperty("identifier", identifier)
                 systemProperty("url", url)
+                if (identifier == "oracle") {
+                    systemProperty("user.language", "en")
+                    systemProperty("user.country", "US")
+                }
             }
         }
     }

--- a/integration-test-r2dbc/gradle.properties
+++ b/integration-test-r2dbc/gradle.properties
@@ -4,6 +4,6 @@ h2.url=r2dbc:h2:mem:///test?DB_CLOSE_DELAY=-1
 mariadb.url=jdbc:tc:mariadb:10.6.3:///test?TC_DAEMON=true
 mysql.url=jdbc:tc:mysql:8.0.25:///test?TC_DAEMON=true
 mysql5.url=jdbc:tc:mysql:5.7.44:///test?TC_DAEMON=true
-oracle.url=jdbc:tc:oracle:thin:@test?TC_DAEMON=true
+oracle.url=jdbc:tc:oracle:23.26.1-slim-faststart:thin:@test?TC_DAEMON=true
 postgresql.url=jdbc:tc:postgis:12-3.4:///test?TC_DAEMON=true
 sqlserver.url=jdbc:tc:sqlserver:2019-CU28-ubuntu-20.04:///test?TC_DAEMON=true

--- a/integration-test-r2dbc/src/oracle/kotlin/integration/r2dbc/oracle/R2dbcOracleSetting.kt
+++ b/integration-test-r2dbc/src/oracle/kotlin/integration/r2dbc/oracle/R2dbcOracleSetting.kt
@@ -5,10 +5,10 @@ import io.r2dbc.spi.ConnectionFactoryOptions
 import io.r2dbc.spi.Option
 import org.komapper.core.ExecutionOptions
 import org.komapper.r2dbc.R2dbcDatabase
-import org.testcontainers.containers.OracleContainer
-import org.testcontainers.containers.OracleContainerProvider
 import org.testcontainers.jdbc.ConnectionUrl
 import org.testcontainers.lifecycle.Startable
+import org.testcontainers.oracle.OracleContainer
+import org.testcontainers.oracle.OracleContainerProvider
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer
 
 @Suppress("unused")


### PR DESCRIPTION
## Summary
- Replace the discontinued `testcontainers-oracle-xe` module with `testcontainers-oracle-free` and update the `OracleContainer` / `OracleContainerProvider` imports in `R2dbcOracleSetting` to the new `org.testcontainers.oracle` package.
- Force `user.language=en` / `user.country=US` for the Oracle test JVMs in both `integration-test-jdbc` and `integration-test-r2dbc`. Without this, the Oracle JDBC driver propagates the host locale to the session `NLS_DATE_LANGUAGE`, and the driver-generated `TO_DATE('1-JAN-1970 ...','DD-MON-YYYY ...')` for `{t '...'}` JDBC time escapes fails with `ORA-01843` on a Japanese locale.

## Test plan
- [ ] `./gradlew oracle` (JDBC suite) passes locally
- [ ] `./gradlew :integration-test-r2dbc:oracle` passes locally
- [ ] CI Oracle suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)