### PR TITLE
Support VALUES table value constructor as subquery / CTE body

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectSubqueryTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectSubqueryTest.kt
@@ -97,4 +97,53 @@ class JdbcSelectSubqueryTest(private val db: JdbcDatabase) {
         )
         assertEquals(expected, list)
     }
+
+    @Test
+    fun values_as_derived_table() {
+        val t = Meta.nameAndAmount
+
+        val rows = QueryDsl.values(t) {
+            row {
+                t.name eq "alice"
+                t.amount eq BigDecimal("100")
+            }
+            row {
+                t.name eq "bob"
+                t.amount eq BigDecimal("200")
+            }
+            row {
+                t.name eq "carol"
+                t.amount eq BigDecimal("300")
+            }
+        }
+
+        val query = QueryDsl.from(t, rows).orderBy(t.name)
+        val list = db.runQuery { query }
+        val expected = listOf(
+            NameAndAmount("alice", BigDecimal("100")),
+            NameAndAmount("bob", BigDecimal("200")),
+            NameAndAmount("carol", BigDecimal("300")),
+        )
+        assertEquals(expected, list)
+    }
+
+    @Test
+    fun values_as_derived_table_with_where() {
+        val t = Meta.nameAndAmount
+
+        val rows = QueryDsl.values(t) {
+            row {
+                t.name eq "alice"
+                t.amount eq BigDecimal("100")
+            }
+            row {
+                t.name eq "bob"
+                t.amount eq BigDecimal("200")
+            }
+        }
+
+        val query = QueryDsl.from(t, rows).where { t.amount greater BigDecimal("150") }
+        val list = db.runQuery { query }
+        assertEquals(listOf(NameAndAmount("bob", BigDecimal("200"))), list)
+    }
 }

--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWithTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWithTest.kt
@@ -110,4 +110,17 @@ class JdbcSelectWithTest(private val db: JdbcDatabase) {
         val result = db.runQuery(query)
         assertEquals(55, result)
     }
+
+    @Test
+    fun withValues() {
+        val t = Meta.t
+        val rows = QueryDsl.values(t) {
+            row { t.n eq 1 }
+            row { t.n eq 2 }
+            row { t.n eq 3 }
+        }
+        val query = QueryDsl.with(t, rows).from(t).orderBy(t.n).select(t.n)
+        val list = db.runQuery(query)
+        assertEquals(listOf(1, 2, 3), list)
+    }
 }

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -377,6 +377,25 @@ interface Dialect {
 
     fun supportsRecursiveKeywordInCommonTableExpression(): Boolean = true
 
+    /**
+     * Returns whether the `VALUES` table value constructor used as a derived table
+     * (e.g. `(VALUES (1, 'a'), (2, 'b')) AS t(c1, c2)`) is supported.
+     */
+    fun supportsTableValueConstructor(): Boolean = true
+
+    /**
+     * Returns whether each row in the `VALUES` table value constructor must be prefixed with the `ROW` keyword
+     * (e.g. `VALUES ROW(1, 'a'), ROW(2, 'b')`). MySQL 8.0.19+ requires this form for the table value constructor.
+     */
+    fun supportsRowKeywordInTableValueConstructor(): Boolean = false
+
+    /**
+     * Returns whether a derived table can be aliased with a column name list
+     * (e.g. `(SELECT ...) AS t(c1, c2)`). When `false`, callers must alias the columns inside the derived
+     * table itself (e.g. `(SELECT v AS c1, v AS c2 UNION ALL ...) AS t`). MariaDB does not support this syntax.
+     */
+    fun supportsAliasColumnListInDerivedTable(): Boolean = true
+
     fun supportsSelectStatementWithoutFromClause(): Boolean = true
 
     /**

--- a/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/Dialect.kt
@@ -396,6 +396,13 @@ interface Dialect {
      */
     fun supportsAliasColumnListInDerivedTable(): Boolean = true
 
+    /**
+     * Returns whether the `VALUES` table value constructor is accepted directly as the body of a CTE
+     * definition (e.g. `WITH t (c) AS (VALUES (1), (2))`). When `false`, the equivalent
+     * `SELECT v AS c UNION ALL SELECT v` form must be emitted instead. SQL Server requires this fallback.
+     */
+    fun supportsValuesClauseAsCteBody(): Boolean = true
+
     fun supportsSelectStatementWithoutFromClause(): Boolean = true
 
     /**

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
@@ -10,12 +10,16 @@ import org.komapper.core.dsl.context.ScriptContext
 import org.komapper.core.dsl.context.SelectContext
 import org.komapper.core.dsl.context.TemplateExecuteContext
 import org.komapper.core.dsl.context.TemplateSelectContext
+import org.komapper.core.dsl.context.ValuesContext
 import org.komapper.core.dsl.element.With
 import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.ScalarExpression
 import org.komapper.core.dsl.expression.SubqueryExpression
+import org.komapper.core.dsl.expression.ValuesExpression
 import org.komapper.core.dsl.metamodel.EmptyMetamodel
 import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
 import org.komapper.core.dsl.options.DeleteOptions
 import org.komapper.core.dsl.options.InsertOptions
 import org.komapper.core.dsl.options.SchemaOptions
@@ -44,6 +48,7 @@ import org.komapper.core.dsl.query.TemplateSelectQueryBuilder
 import org.komapper.core.dsl.query.TemplateSelectQueryBuilderImpl
 import org.komapper.core.dsl.query.UpdateQueryBuilder
 import org.komapper.core.dsl.query.UpdateQueryBuilderImpl
+import org.komapper.core.dsl.scope.ValuesScope
 
 /**
  * The entry point for constructing queries.
@@ -121,6 +126,21 @@ interface QueryDsl {
         metamodel: META,
         subquery: SubqueryExpression<*>,
     ): SelectQueryBuilder<ENTITY, ID, META>
+
+    /**
+     * Creates a VALUES table constructor that can be used as a derived table.
+     *
+     * @param ENTITY the entity type
+     * @param ID the entity id type
+     * @param META the entity metamodel type
+     * @param metamodel the entity metamodel that defines the column shape of the VALUES rows
+     * @param declaration the row declarations
+     * @return the subquery expression representing the VALUES table constructor
+     */
+    fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> values(
+        metamodel: META,
+        declaration: ValuesScope<ENTITY, ID, META>.() -> Unit,
+    ): SubqueryExpression<ENTITY>
 
     /**
      * Creates a SELECT query for a single column expression.
@@ -327,6 +347,17 @@ internal class QueryDslImpl(
         subquery: SubqueryExpression<*>,
     ): SelectQueryBuilder<ENTITY, ID, META> {
         return SelectQueryBuilderImpl(SelectContext(metamodel, subquery, options = selectOptions))
+    }
+
+    override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> values(
+        metamodel: META,
+        declaration: ValuesScope<ENTITY, ID, META>.() -> Unit,
+    ): SubqueryExpression<ENTITY> {
+        val rows = mutableListOf<List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>>()
+        val scope = ValuesScope(metamodel, rows)
+        scope.declaration()
+        val context = ValuesContext(metamodel, rows, selectOptions)
+        return ValuesExpression(context)
     }
 
     override fun <A : Any> select(expression: ColumnExpression<A, *>): FlowSubquery<A?> {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
@@ -8,6 +8,7 @@ import org.komapper.core.Value
 import org.komapper.core.dsl.context.SelectContext
 import org.komapper.core.dsl.context.SetOperationContext
 import org.komapper.core.dsl.context.SubqueryContext
+import org.komapper.core.dsl.context.ValuesContext
 import org.komapper.core.dsl.expression.AggregateFunction
 import org.komapper.core.dsl.expression.AliasExpression
 import org.komapper.core.dsl.expression.ArithmeticExpression
@@ -352,6 +353,11 @@ class BuilderSupport(
 
             is SetOperationContext -> {
                 val builder = SetOperationStatementBuilder(dialect, context, aliasManager, projectionPredicate)
+                builder.build()
+            }
+
+            is ValuesContext<*, *, *> -> {
+                val builder = ValuesStatementBuilder(dialect, context, aliasManager)
                 builder.build()
             }
         }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilder.kt
@@ -60,13 +60,13 @@ class SelectStatementBuilder(
                     }
                     buf.cutBack(2)
                     buf.append(") as (")
-                    val statement = support.buildSubqueryStatement(subquery.context)
+                    val statement = buildCteBodyStatement(subquery.context)
                     buf.append(statement)
                     buf.append("), ")
                 } else {
                     buf.append(" as (")
                     val subqueryContext = assignAliasesToSubqueryColumns(subquery.context, table.properties())
-                    val statement = support.buildSubqueryStatement(subqueryContext)
+                    val statement = buildCteBodyStatement(subqueryContext)
                     buf.append(statement)
                     buf.append("), ")
                 }
@@ -327,6 +327,40 @@ class SelectStatementBuilder(
                 raiseError("wait")
             }
         }
+    }
+
+    private fun buildCteBodyStatement(subqueryContext: SubqueryContext): Statement {
+        if (subqueryContext is ValuesContext<*, *, *> && !dialect.supportsValuesClauseAsCteBody()) {
+            return wrapValuesInSelectStatement(subqueryContext)
+        }
+        return support.buildSubqueryStatement(subqueryContext)
+    }
+
+    private fun wrapValuesInSelectStatement(valuesContext: ValuesContext<*, *, *>): Statement {
+        val properties = valuesContext.target.properties()
+        val innerAlias = "v_"
+        val sb = StatementBuffer()
+        sb.append("select ")
+        for (p in properties) {
+            sb.append("$innerAlias.")
+            sb.append(p.getCanonicalColumnName(dialect::enquote))
+            sb.append(", ")
+        }
+        sb.cutBack(2)
+        sb.append(" from (")
+        sb.append(ValuesStatementBuilder(dialect, valuesContext, aliasManager).build())
+        sb.append(") ")
+        if (dialect.supportsAsKeywordForTableAlias()) {
+            sb.append("as ")
+        }
+        sb.append("$innerAlias (")
+        for (p in properties) {
+            sb.append(p.getCanonicalColumnName(dialect::enquote))
+            sb.append(", ")
+        }
+        sb.cutBack(2)
+        sb.append(")")
+        return sb.toStatement()
     }
 
     private fun assignAliasesToSubqueryColumns(subqueryContext: SubqueryContext, outerColumns: List<ColumnExpression<*, *>>): SubqueryContext {

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SelectStatementBuilder.kt
@@ -6,6 +6,7 @@ import org.komapper.core.StatementBuffer
 import org.komapper.core.dsl.context.SelectContext
 import org.komapper.core.dsl.context.SetOperationContext
 import org.komapper.core.dsl.context.SubqueryContext
+import org.komapper.core.dsl.context.ValuesContext
 import org.komapper.core.dsl.element.FullJoin
 import org.komapper.core.dsl.element.InnerJoin
 import org.komapper.core.dsl.element.LeftJoin
@@ -125,6 +126,17 @@ class SelectStatementBuilder(
                     buf.append(" as")
                 }
                 buf.append(" $alias")
+            }
+            if (context.derivedTable.context is ValuesContext<*, *, *> &&
+                dialect.supportsAliasColumnListInDerivedTable()
+            ) {
+                buf.append(" (")
+                for (p in context.target.properties()) {
+                    buf.append(p.getCanonicalColumnName(dialect::enquote))
+                    buf.append(", ")
+                }
+                buf.cutBack(2)
+                buf.append(")")
             }
         }
 
@@ -336,6 +348,10 @@ class SelectStatementBuilder(
                     left = assignAliasesToSubqueryColumns(subqueryContext.left, outerColumns),
                     right = assignAliasesToSubqueryColumns(subqueryContext.right, outerColumns),
                 )
+            }
+
+            is ValuesContext<*, *, *> -> {
+                subqueryContext
             }
         }
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SetOperationStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/SetOperationStatementBuilder.kt
@@ -7,6 +7,7 @@ import org.komapper.core.dsl.context.SelectContext
 import org.komapper.core.dsl.context.SetOperationContext
 import org.komapper.core.dsl.context.SetOperationKind
 import org.komapper.core.dsl.context.SubqueryContext
+import org.komapper.core.dsl.context.ValuesContext
 import org.komapper.core.dsl.expression.ColumnExpression
 
 class SetOperationStatementBuilder(
@@ -28,6 +29,10 @@ class SetOperationStatementBuilder(
         when (subqueryContext) {
             is SelectContext<*, *, *> -> {
                 visitSelectContext(subqueryContext)
+            }
+
+            is ValuesContext<*, *, *> -> {
+                visitValuesContext(subqueryContext)
             }
 
             is SetOperationContext -> {
@@ -72,6 +77,14 @@ class SetOperationStatementBuilder(
     private fun visitSelectContext(selectContext: SelectContext<*, *, *>) {
         val childAliasManager = DefaultAliasManager(selectContext, aliasManager)
         val builder = SelectStatementBuilder(dialect, selectContext, childAliasManager, projectionPredicate)
+        val statement = builder.build()
+        buf.append("(")
+        buf.append(statement)
+        buf.append(")")
+    }
+
+    private fun visitValuesContext(valuesContext: ValuesContext<*, *, *>) {
+        val builder = ValuesStatementBuilder(dialect, valuesContext, aliasManager)
         val statement = builder.build()
         buf.append("(")
         buf.append(statement)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/ValuesStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/ValuesStatementBuilder.kt
@@ -9,6 +9,7 @@ class ValuesStatementBuilder(
     private val dialect: BuilderDialect,
     private val context: ValuesContext<*, *, *>,
     private val aliasManager: AliasManager,
+    private val useSelectUnionForm: Boolean = !dialect.supportsAliasColumnListInDerivedTable(),
 ) {
     private val buf = StatementBuffer()
     private val support = BuilderSupport(dialect, aliasManager, buf)
@@ -22,10 +23,10 @@ class ValuesStatementBuilder(
         require(context.rows.isNotEmpty()) {
             "The VALUES clause requires at least one row."
         }
-        if (dialect.supportsAliasColumnListInDerivedTable()) {
-            buildValuesForm()
-        } else {
+        if (useSelectUnionForm) {
             buildSelectUnionForm()
+        } else {
+            buildValuesForm()
         }
         return buf.toStatement()
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/ValuesStatementBuilder.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/ValuesStatementBuilder.kt
@@ -1,0 +1,73 @@
+package org.komapper.core.dsl.builder
+
+import org.komapper.core.BuilderDialect
+import org.komapper.core.Statement
+import org.komapper.core.StatementBuffer
+import org.komapper.core.dsl.context.ValuesContext
+
+class ValuesStatementBuilder(
+    private val dialect: BuilderDialect,
+    private val context: ValuesContext<*, *, *>,
+    private val aliasManager: AliasManager,
+) {
+    private val buf = StatementBuffer()
+    private val support = BuilderSupport(dialect, aliasManager, buf)
+
+    fun build(): Statement {
+        if (!dialect.supportsTableValueConstructor()) {
+            throw UnsupportedOperationException(
+                "The dialect(driver=${dialect.driver}) does not support the VALUES table value constructor."
+            )
+        }
+        require(context.rows.isNotEmpty()) {
+            "The VALUES clause requires at least one row."
+        }
+        if (dialect.supportsAliasColumnListInDerivedTable()) {
+            buildValuesForm()
+        } else {
+            buildSelectUnionForm()
+        }
+        return buf.toStatement()
+    }
+
+    private fun buildValuesForm() {
+        val properties = context.target.properties()
+        val rowOpen = if (dialect.supportsRowKeywordInTableValueConstructor()) "row(" else "("
+        buf.append("values ")
+        for (row in context.rows) {
+            val byProperty = row.toMap()
+            buf.append(rowOpen)
+            for (p in properties) {
+                val operand = byProperty[p]
+                    ?: error("Row is missing assignment for property '${p.name}'.")
+                support.visitOperand(operand)
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+            buf.append("), ")
+        }
+        buf.cutBack(2)
+    }
+
+    private fun buildSelectUnionForm() {
+        val properties = context.target.properties()
+        for ((rowIndex, row) in context.rows.withIndex()) {
+            if (rowIndex > 0) {
+                buf.append(" union all ")
+            }
+            buf.append("select ")
+            val byProperty = row.toMap()
+            for (p in properties) {
+                val operand = byProperty[p]
+                    ?: error("Row is missing assignment for property '${p.name}'.")
+                support.visitOperand(operand)
+                if (rowIndex == 0) {
+                    buf.append(" as ")
+                    buf.append(p.getCanonicalColumnName(dialect::enquote))
+                }
+                buf.append(", ")
+            }
+            buf.cutBack(2)
+        }
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SetOperationContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/SetOperationContext.kt
@@ -19,6 +19,7 @@ data class SetOperationContext(
             return when (subqueryContext) {
                 is SelectContext<*, *, *> -> subqueryContext.getProjection()
                 is SetOperationContext -> visitSubqueryContext(subqueryContext.left)
+                is ValuesContext<*, *, *> -> Projection.Metamodels(setOf(subqueryContext.target))
             }
         }
         return visitSubqueryContext(left)
@@ -33,6 +34,10 @@ data class SetOperationContext(
 
                 is SetOperationContext -> {
                     visitSubqueryContext(subqueryContext.left) + visitSubqueryContext(subqueryContext.right)
+                }
+
+                is ValuesContext<*, *, *> -> {
+                    setOf(subqueryContext.target)
                 }
             }
         }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/ValuesContext.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/context/ValuesContext.kt
@@ -1,0 +1,14 @@
+package org.komapper.core.dsl.context
+
+import org.komapper.core.ThreadSafe
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+import org.komapper.core.dsl.options.SelectOptions
+
+@ThreadSafe
+data class ValuesContext<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    val target: META,
+    val rows: List<List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>>,
+    override val options: SelectOptions,
+) : SubqueryContext

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ValuesExpression.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/ValuesExpression.kt
@@ -1,0 +1,8 @@
+package org.komapper.core.dsl.expression
+
+import org.komapper.core.dsl.context.ValuesContext
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+
+class ValuesExpression<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    override val context: ValuesContext<ENTITY, ID, META>,
+) : SubqueryExpression<ENTITY>

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/SetOperationRunner.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/runner/SetOperationRunner.kt
@@ -9,6 +9,7 @@ import org.komapper.core.dsl.builder.SetOperationStatementBuilder
 import org.komapper.core.dsl.context.SelectContext
 import org.komapper.core.dsl.context.SetOperationContext
 import org.komapper.core.dsl.context.SubqueryContext
+import org.komapper.core.dsl.context.ValuesContext
 
 class SetOperationRunner(
     private val context: SetOperationContext,
@@ -37,6 +38,10 @@ class SetOperationRunner(
             is SetOperationContext -> {
                 checkWhereClauses(subqueryContext.left)
                 checkWhereClauses(subqueryContext.right)
+            }
+
+            is ValuesContext<*, *, *> -> {
+                Unit
             }
         }
     }

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/ValuesScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/ValuesScope.kt
@@ -1,0 +1,28 @@
+package org.komapper.core.dsl.scope
+
+import org.komapper.core.Scope
+import org.komapper.core.dsl.expression.AssignmentDeclaration
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.metamodel.EntityMetamodel
+import org.komapper.core.dsl.metamodel.PropertyMetamodel
+
+/**
+ * Provides operators for the VALUES table constructor used as a derived table.
+ */
+@Scope
+class ValuesScope<ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>>(
+    private val target: META,
+    private val rows: MutableList<List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>>,
+) {
+    /**
+     * Adds a single row to the VALUES table constructor.
+     *
+     * @param declaration the per-row property assignments
+     */
+    fun row(declaration: AssignmentDeclaration<ENTITY, META>) {
+        val assignments = mutableListOf<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>()
+        val meta = target
+        AssignmentScope(assignments).apply { declaration(meta) }
+        rows.add(assignments)
+    }
+}

--- a/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
+++ b/komapper-dialect-mariadb/src/main/kotlin/org/komapper/dialect/mariadb/MariaDbDialect.kt
@@ -81,6 +81,8 @@ interface MariaDbDialect : Dialect {
         return MariaDbRelationInsertValuesStatementBuilder(dialect, context)
     }
 
+    override fun supportsAliasColumnListInDerivedTable(): Boolean = false
+
     override fun supportsAliasForDeleteStatement() = false
 
     override fun supportsConflictTargetInUpsertStatement(): Boolean = false

--- a/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
+++ b/komapper-dialect-mysql/src/main/kotlin/org/komapper/dialect/mysql/MySqlDialect.kt
@@ -85,4 +85,14 @@ interface MySqlDialect : Dialect {
     override fun supportsSetOperationIntersect(): Boolean = false
 
     override fun supportsSetOperationExcept(): Boolean = false
+
+    override fun supportsRowKeywordInTableValueConstructor(): Boolean = when (version) {
+        MySqlVersion.V5 -> false
+        MySqlVersion.V8 -> true
+    }
+
+    override fun supportsAliasColumnListInDerivedTable(): Boolean = when (version) {
+        MySqlVersion.V5 -> false
+        MySqlVersion.V8 -> true
+    }
 }

--- a/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
+++ b/komapper-dialect-sqlserver/src/main/kotlin/org/komapper/dialect/sqlserver/SqlServerDialect.kt
@@ -156,4 +156,6 @@ interface SqlServerDialect : Dialect {
     override fun supportsUpsertMultipleReturning(): Boolean = true
 
     override fun supportsUpsertSingleReturning(): Boolean = true
+
+    override fun supportsValuesClauseAsCteBody(): Boolean = false
 }


### PR DESCRIPTION
## Summary

Adds `QueryDsl.values(metamodel) { row { ... } }` so a `VALUES` table value constructor can be used wherever a `SubqueryExpression` is accepted — most importantly as a derived table (`from(metamodel, subquery)`) and as a CTE body (`with(metamodel, subquery)`).

This subsumes the use case in #1844 (and discussion #1804), and works on every supported database including MySQL 5/8, MariaDB, SQL Server, and Oracle 23ai via dialect-specific emission strategies.

## DSL

```kotlin
val t = Meta.nameAndAmount

val rows = QueryDsl.values(t) {
    row {
        t.name eq "alice"
        t.amount eq BigDecimal("100")
    }
    row {
        t.name eq "bob"
        t.amount eq BigDecimal("200")
    }
}
```

`rows` is a `SubqueryExpression<NameAndAmount>` and can be passed anywhere komapper accepts a subquery.

### Use as a derived table

```kotlin
val query = QueryDsl.from(t, rows).where { t.amount greater BigDecimal("150") }
```

### Use as a CTE body

```kotlin
val t = Meta.t
val rows = QueryDsl.values(t) {
    row { t.n eq 1 }
    row { t.n eq 2 }
    row { t.n eq 3 }
}
val query = QueryDsl.with(t, rows).from(t).orderBy(t.n).select(t.n)
```

## Generated SQL by dialect

The emitter picks the best form per dialect using three new `Dialect` capability flags:

| Flag | Default | Overridden by |
|---|---|---|
| `supportsTableValueConstructor()` | `true` | — |
| `supportsRowKeywordInTableValueConstructor()` | `false` | MySQL 8 → `true` |
| `supportsAliasColumnListInDerivedTable()` | `true` | MariaDB → `false`, MySQL 5 → `false` |
| `supportsValuesClauseAsCteBody()` | `true` | SQL Server → `false` |

### Derived table (`from(t, rows)`)

| Database | Generated SQL |
|---|---|
| **H2 / PostgreSQL / Oracle 23ai / SQL Server** | `select t0_.name, t0_.amount from (values (?, ?), (?, ?)) as t0_ (name, amount) where ...` |
| **MySQL 8** | `select t0_.name, t0_.amount from (values row(?, ?), row(?, ?)) as t0_ (name, amount) where ...` |
| **MariaDB / MySQL 5** | `select t0_.name, t0_.amount from (select ? as name, ? as amount union all select ?, ?) as t0_ where ...` |

### CTE body (`with(t, rows).from(t).select(...)`)

| Database | Generated SQL |
|---|---|
| **H2 / PostgreSQL / Oracle 23ai** | `with t (n) as (values (?), (?), (?)) select t0_.n from t as t0_ ...` |
| **MySQL 8** | `with t (n) as (values row(?), row(?), row(?)) select t0_.n from t as t0_ ...` |
| **MariaDB** | `with t (n) as (select ? as n union all select ? union all select ?) select t0_.n from t as t0_ ...` |
| **SQL Server** | `with t (n) as (select v_.n from (values (?), (?), (?)) as v_ (n)) select t0_.n from t as t0_ ...` |
| **MySQL 5** | not applicable — MySQL 5 has no CTE support |

The SQL Server form follows MS Learn's documented requirement that a CTE body must be a `SELECT` statement; the `VALUES` is wrapped in `SELECT ... FROM (VALUES ...) AS v_(...)` so the native `VALUES` syntax is preserved.

## Support matrix

| Database | Derived table | CTE body |
|---|---|---|
| H2 | ✅ | ✅ |
| PostgreSQL | ✅ | ✅ |
| MySQL 8 | ✅ | ✅ |
| MySQL 5 | ✅ (UNION ALL fallback) | ❌ (no CTE support in DB) |
| MariaDB | ✅ (UNION ALL fallback) | ✅ |
| SQL Server | ✅ | ✅ (SELECT-FROM-VALUES wrapper) |
| Oracle 23ai | ✅ | ✅ |

## Test plan

- [x] `./gradlew h2` — JDBC + R2DBC integration suites
- [x] `./gradlew :integration-test-jdbc:postgresql --tests JdbcSelectWithTest.withValues`
- [x] `./gradlew :integration-test-jdbc:mysql --tests "integration.jdbc.JdbcSelectSubqueryTest"` (MySQL 8)
- [x] `./gradlew :integration-test-jdbc:mysql5 --tests "integration.jdbc.JdbcSelectSubqueryTest"`
- [x] `./gradlew :integration-test-jdbc:mariadb --tests "integration.jdbc.JdbcSelectSubqueryTest"`
- [x] `./gradlew :integration-test-jdbc:oracle --tests JdbcSelectWithTest.withValues`
- [x] `./gradlew :integration-test-jdbc:sqlserver --tests JdbcSelectWithTest.withValues`

Closes #1844 (alternative implementation).