### PR TITLE
refactor: introduce ValuesDeclaration typealias for VALUES subquery

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/QueryDsl.kt
@@ -16,6 +16,7 @@ import org.komapper.core.dsl.expression.ColumnExpression
 import org.komapper.core.dsl.expression.Operand
 import org.komapper.core.dsl.expression.ScalarExpression
 import org.komapper.core.dsl.expression.SubqueryExpression
+import org.komapper.core.dsl.expression.ValuesDeclaration
 import org.komapper.core.dsl.expression.ValuesExpression
 import org.komapper.core.dsl.metamodel.EmptyMetamodel
 import org.komapper.core.dsl.metamodel.EntityMetamodel
@@ -262,7 +263,7 @@ interface QueryDsl {
      * @param ID the entity id type
      * @param META the entity metamodel type
      * @param metamodel the entity metamodel that defines the column shape of the VALUES rows
-     * @param declaration the row declarations
+     * @param declaration the values declaration
      * @return the subquery expression representing the VALUES table constructor
      */
     fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> values(
@@ -685,7 +686,7 @@ internal class QueryDslImpl(
 
     override fun <ENTITY : Any, ID : Any, META : EntityMetamodel<ENTITY, ID, META>> values(
         metamodel: META,
-        declaration: ValuesScope<ENTITY, ID, META>.() -> Unit,
+        declaration: ValuesDeclaration<ENTITY, ID, META>,
     ): SubqueryExpression<ENTITY> {
         val rows = mutableListOf<List<Pair<PropertyMetamodel<ENTITY, *, *>, Operand>>>()
         val scope = ValuesScope(metamodel, rows)

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/Declarations.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/expression/Declarations.kt
@@ -5,6 +5,7 @@ import org.komapper.core.dsl.scope.ForUpdateScope
 import org.komapper.core.dsl.scope.HavingScope
 import org.komapper.core.dsl.scope.OnScope
 import org.komapper.core.dsl.scope.OverScope
+import org.komapper.core.dsl.scope.ValuesScope
 import org.komapper.core.dsl.scope.WhenScope
 import org.komapper.core.dsl.scope.WhereScope
 
@@ -15,3 +16,4 @@ typealias AssignmentDeclaration<ENTITY, META> = AssignmentScope<ENTITY>.(META) -
 typealias WhenDeclaration = WhenScope.() -> Unit
 typealias ForUpdateDeclaration = ForUpdateScope.() -> Unit
 typealias OverDeclaration = OverScope.() -> Unit
+typealias ValuesDeclaration<ENTITY, ID, META> = ValuesScope<ENTITY, ID, META>.() -> Unit


### PR DESCRIPTION
## Summary
- Add `ValuesDeclaration<ENTITY, ID, META>` typealias alongside the other `*Declaration` aliases in `Declarations.kt`.
- Use it for the `declaration` parameter of `QueryDsl.values(...)` so the VALUES subquery API matches the convention used by other DSL entry points.

## Test plan
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew h2`