### PR TITLE
Short-circuit logical operators in template expression evaluation

### DIFF
--- a/komapper-template/src/main/kotlin/org/komapper/template/ExprEvaluator.kt
+++ b/komapper-template/src/main/kotlin/org/komapper/template/ExprEvaluator.kt
@@ -167,34 +167,6 @@ internal class DefaultExprEvaluator(
         return value
     }
 
-    private fun perform(
-        location: ExprLocation,
-        leftNode: ExprNode,
-        rightNode: ExprNode,
-        ctx: ExprContext,
-        f: (Boolean, Boolean) -> Boolean,
-    ): Value<Boolean> {
-        fun checkNull(location: ExprLocation, value: Any?, which: String) {
-            if (value != null) {
-                return
-            }
-            throw ExprException(
-                "Cannot perform the logical operator because the $which operand is null at $location",
-            )
-        }
-
-        val (left) = visit(leftNode, ctx)
-        val (right) = visit(rightNode, ctx)
-        checkNull(leftNode.location, left, "left")
-        checkNull(rightNode.location, right, "right")
-        if (left !is Boolean || right !is Boolean) {
-            throw ExprException(
-                "Cannot perform the logical operator because either operands is not Boolean at $location",
-            )
-        }
-        return Value(f(left, right), typeOf<Boolean>())
-    }
-
     @Suppress("UNUSED_PARAMETER")
     private fun equal(
         location: ExprLocation,

--- a/komapper-template/src/main/kotlin/org/komapper/template/ExprEvaluator.kt
+++ b/komapper-template/src/main/kotlin/org/komapper/template/ExprEvaluator.kt
@@ -54,9 +54,9 @@ internal class DefaultExprEvaluator(
     private fun visit(node: ExprNode, ctx: ExprContext): Value<*> = when (node) {
         is ExprNode.Not -> perform(node.location, node.operand, ctx) { !it }
 
-        is ExprNode.And -> perform(node.location, node.left, node.right, ctx) { x, y -> x && y }
+        is ExprNode.And -> visitAnd(node.location, node.left, node.right, ctx)
 
-        is ExprNode.Or -> perform(node.location, node.left, node.right, ctx) { x, y -> x || y }
+        is ExprNode.Or -> visitOr(node.location, node.left, node.right, ctx)
 
         is ExprNode.Eq -> equal(node.location, node.left, node.right, ctx) { x, y -> x == y }
 
@@ -121,6 +121,50 @@ internal class DefaultExprEvaluator(
             )
         }
         return Value(f(value), typeOf<Boolean>())
+    }
+
+    private fun visitAnd(
+        location: ExprLocation,
+        leftNode: ExprNode,
+        rightNode: ExprNode,
+        ctx: ExprContext,
+    ): Value<Boolean> {
+        val left = visitLogicalOperand(location, leftNode, ctx, "left")
+        if (!left) return Value(false, typeOf<Boolean>())
+        val right = visitLogicalOperand(location, rightNode, ctx, "right")
+        return Value(right, typeOf<Boolean>())
+    }
+
+    private fun visitOr(
+        location: ExprLocation,
+        leftNode: ExprNode,
+        rightNode: ExprNode,
+        ctx: ExprContext,
+    ): Value<Boolean> {
+        val left = visitLogicalOperand(location, leftNode, ctx, "left")
+        if (left) return Value(true, typeOf<Boolean>())
+        val right = visitLogicalOperand(location, rightNode, ctx, "right")
+        return Value(right, typeOf<Boolean>())
+    }
+
+    private fun visitLogicalOperand(
+        location: ExprLocation,
+        node: ExprNode,
+        ctx: ExprContext,
+        which: String,
+    ): Boolean {
+        val (value) = visit(node, ctx)
+        if (value == null) {
+            throw ExprException(
+                "Cannot perform the logical operator because the $which operand is null at ${node.location}",
+            )
+        }
+        if (value !is Boolean) {
+            throw ExprException(
+                "Cannot perform the logical operator because either operands is not Boolean at $location",
+            )
+        }
+        return value
     }
 
     private fun perform(

--- a/komapper-template/src/test/kotlin/org/komapper/template/ExprEvaluatorTest.kt
+++ b/komapper-template/src/test/kotlin/org/komapper/template/ExprEvaluatorTest.kt
@@ -331,6 +331,16 @@ class ExprEvaluatorTest {
         }
 
         @Test
+        fun and_short_circuit() {
+            val ctx = ExprContext(
+                mapOf("p" to Value(null, typeOf<Person>())),
+                extensions,
+            )
+            val result = evaluator.eval("p != null && p.name == \"aaa\"", ctx)
+            assertEquals(Value(false, typeOf<Boolean>()), result)
+        }
+
+        @Test
         fun or_true() {
             val ctx = ExprContext(mapOf("a" to Value(true, typeOf<Boolean>())), extensions)
             val result = evaluator.eval("a || false", ctx)
@@ -342,6 +352,16 @@ class ExprEvaluatorTest {
             val ctx = ExprContext(mapOf("a" to Value(false, typeOf<Boolean>())), extensions)
             val result = evaluator.eval("a || false", ctx)
             assertEquals(Value(false, typeOf<Boolean>()), result)
+        }
+
+        @Test
+        fun or_short_circuit() {
+            val ctx = ExprContext(
+                mapOf("p" to Value(null, typeOf<Person>())),
+                extensions,
+            )
+            val result = evaluator.eval("p == null || p.name == \"aaa\"", ctx)
+            assertEquals(Value(true, typeOf<Boolean>()), result)
         }
 
         @Test

--- a/komapper-template/src/test/kotlin/org/komapper/template/ExprEvaluatorTest.kt
+++ b/komapper-template/src/test/kotlin/org/komapper/template/ExprEvaluatorTest.kt
@@ -385,11 +385,61 @@ class ExprEvaluatorTest {
         }
 
         @Test
-        fun `Cannot perform the logical operator because either operand is not boolean`() {
+        fun `Cannot perform the logical operator because the left operand is null for or`() {
+            val ctx = ExprContext(mapOf("a" to Value(null, typeOf<Any>())), extensions)
+            val exception = assertFailsWith<ExprException> {
+                evaluator
+                    .eval("a || false", ctx)
+            }
+            println(exception)
+        }
+
+        @Test
+        fun `Cannot perform the logical operator because the right operand is null for or`() {
+            val ctx = ExprContext(mapOf("a" to Value(null, typeOf<Any>())), extensions)
+            val exception = assertFailsWith<ExprException> {
+                evaluator
+                    .eval("false || a", ctx)
+            }
+            println(exception)
+        }
+
+        @Test
+        fun `Cannot perform the logical operator because the left operand is not Boolean`() {
+            val ctx = ExprContext(mapOf("a" to Value("string", typeOf<String>())), extensions)
+            val exception = assertFailsWith<ExprException> {
+                evaluator
+                    .eval("a && true", ctx)
+            }
+            println(exception)
+        }
+
+        @Test
+        fun `Cannot perform the logical operator because the right operand is not Boolean`() {
             val ctx = ExprContext(mapOf("a" to Value("string", typeOf<String>())), extensions)
             val exception = assertFailsWith<ExprException> {
                 evaluator
                     .eval("true && a", ctx)
+            }
+            println(exception)
+        }
+
+        @Test
+        fun `Cannot perform the logical operator because the left operand is not Boolean for or`() {
+            val ctx = ExprContext(mapOf("a" to Value("string", typeOf<String>())), extensions)
+            val exception = assertFailsWith<ExprException> {
+                evaluator
+                    .eval("a || false", ctx)
+            }
+            println(exception)
+        }
+
+        @Test
+        fun `Cannot perform the logical operator because the right operand is not Boolean for or`() {
+            val ctx = ExprContext(mapOf("a" to Value("string", typeOf<String>())), extensions)
+            val exception = assertFailsWith<ExprException> {
+                evaluator
+                    .eval("false || a", ctx)
             }
             println(exception)
         }


### PR DESCRIPTION
Avoid evaluating the right-hand operand when the left-hand operand already determines the result
