### PR TITLE
Adapt the build and toolchain to Kotlin 2.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ The project follows a modular architecture with clear separation of concerns:
 ### Build Configuration
 - Uses Gradle with Kotlin DSL
 - JVM target: 11 (17 for Spring modules)
-- Kotlin API version: 1.8
+- Kotlin API version: 2.2
 - KSP2 enabled for better performance
 - Automatic code formatting with Spotless (ktlint for Kotlin, Google Java Format for Java)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more documentation, go to our site:
 
 ## Prerequisite
 
-- Kotlin 1.9.24 or later
+- Kotlin 2.2.0 or later
 - JRE 11 or later
 - Gradle 6.8.3 or later
 
@@ -58,8 +58,8 @@ Add the following code to the Gradle build script (gradle.build.kts).
 
 ```kotlin
 plugins {
-    kotlin("jvm") version "2.2.21"
-    id("com.google.devtools.ksp") version "2.3.0"
+    kotlin("jvm") version "2.4.0"
+    id("com.google.devtools.ksp") version "2.3.9"
 }
 
 val komapperVersion = "6.1.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ configure(libraryProjects + gradlePluginProject + exampleProjects + integrationT
             compilerOptions {
                 freeCompilerArgs.add("-Xjdk-release=$jvmTargetVersion")
                 jvmTarget.set(JvmTarget.fromTarget(jvmTargetVersion.toString()))
-                apiVersion.set(KotlinVersion.KOTLIN_2_1)
+                apiVersion.set(KotlinVersion.KOTLIN_2_2)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 
 ksp-symbol-processing = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 ksp-symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
-ksp-test = { module = "dev.zacsweers.kctfork:ksp", version = "0.12.1" }
+ksp-test = { module = "dev.zacsweers.kctfork:ksp", version = "0.13.0" }
 
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-reactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive", version.ref = "kotlinx-coroutines" }

--- a/integration-test-core/build.gradle.kts
+++ b/integration-test-core/build.gradle.kts
@@ -26,7 +26,6 @@ tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         compilerOptions {
             freeCompilerArgs.add("-opt-in=org.komapper.annotation.KomapperExperimentalAssociation")
-            freeCompilerArgs.add("-Xcontext-parameters")
         }
     }
 }

--- a/integration-test-jdbc/build.gradle.kts
+++ b/integration-test-jdbc/build.gradle.kts
@@ -41,7 +41,6 @@ tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         compilerOptions {
             freeCompilerArgs.add("-opt-in=org.komapper.annotation.KomapperExperimentalAssociation")
-            freeCompilerArgs.add("-Xcontext-parameters")
         }
     }
 }

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/AbstractKspTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/AbstractKspTest.kt
@@ -30,7 +30,7 @@ abstract class AbstractKspTest(private vararg val providers: SymbolProcessorProv
             .apply {
                 useKsp2()
                 languageVersion = "2.1"
-                apiVersion = "1.9"
+                apiVersion = "2.0"
                 workingDir = tempDir!!.toFile()
                 inheritClassPath = true
                 symbolProcessorProviders = providers.toMutableList()

--- a/komapper-tx-context-jdbc/build.gradle.kts
+++ b/komapper-tx-context-jdbc/build.gradle.kts
@@ -12,14 +12,6 @@ dependencies {
     kspTest(project(":komapper-processor"))
 }
 
-tasks {
-    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        compilerOptions {
-            freeCompilerArgs.add("-Xcontext-parameters")
-        }
-    }
-}
-
 ksp {
     arg("komapper.namingStrategy", "UPPER_SNAKE_CASE")
 }

--- a/komapper-tx-context-r2dbc/build.gradle.kts
+++ b/komapper-tx-context-r2dbc/build.gradle.kts
@@ -12,14 +12,6 @@ dependencies {
     kspTest(project(":komapper-processor"))
 }
 
-tasks {
-    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        compilerOptions {
-            freeCompilerArgs.add("-Xcontext-parameters")
-        }
-    }
-}
-
 ksp {
     arg("komapper.namingStrategy", "UPPER_SNAKE_CASE")
 }


### PR DESCRIPTION
## Summary

Kotlin itself was already bumped to 2.4.0 by Renovate in #1875, but the surrounding toolchain still targeted older compilers. This PR completes the Kotlin 2.4 migration.

## What changed

- **kctfork (kotlin-compile-testing) 0.12.1 → 0.13.0**: 0.12.1 embeds the Kotlin 2.3.0 compiler, so the KSP processor tests were not actually exercising Kotlin 2.4 at all. 0.13.0 embeds Kotlin 2.4.0 and aligns the transitive KSP artifacts with 2.3.9.
- **`AbstractKspTest` apiVersion 1.9 → 2.0**: the Kotlin 2.4 compiler removed support for API version 1.9 (`API version 1.9 is no longer supported; use version 2.0 or greater instead`), which made 61 processor tests fail once the real 2.4 compiler was in use. 2.0 is the lowest accepted version, preserving the minimum-compatibility intent of the test.
- **Project-wide apiVersion 2.1 → 2.2**: the 2.4 compiler deprecates 2.1 with an explicit warning to move to 2.2, consistent with how this setting has been raised on past Kotlin upgrades.
- **Removed `-Xcontext-parameters`** from 4 build scripts: context parameters are stable in Kotlin 2.4 and the flag now triggers a "redundant argument" warning.
- **Docs**: README installation snippet updated to Kotlin 2.4.0 / KSP 2.3.9, the Kotlin prerequisite raised to 2.2.0 to match the new apiVersion, and the stale API version note in CLAUDE.md refreshed.

## Notes for reviewers

- KSP 2.3.9 is the latest release and works with Kotlin 2.4; no change needed there.
- The trailing `Unit` in `JdbcSelectJoinTest`/`R2dbcSelectJoinTest` is deliberately left alone even though the 2.4 compiler flags it as an unused expression: removing it makes type inference bind `runQuery`'s type parameter to `Unit` and compilation fails.
- The 2.4 compiler surfaces a number of new warnings in pre-existing main sources (unused expressions, a non-exhaustive `when` in `R2dbcExecutor`, etc.); cleaning those up is intentionally left to a separate change.
- The README compatibility matrix is left untouched, as it is validated via the komapper/compatibility-test repository.

## Verification

`./gradlew clean test h2 spotlessCheck` passes: all module unit tests, processor tests (now compiling with the real 2.4 compiler), and both JDBC/R2DBC H2 integration suites, confirmed with a forced `--rerun-tasks` pass to rule out caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)