### PR TITLE
Raise the documented Gradle prerequisite to 7.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For more documentation, go to our site:
 
 - Kotlin 2.2.0 or later
 - JRE 11 or later
-- Gradle 6.8.3 or later
+- Gradle 7.6.4 or later
 
 ## Supported Databases
 


### PR DESCRIPTION
## Summary

Follow-up to #1883. The README prerequisite still said "Gradle 6.8.3 or later", a value from the Kotlin 1.9.24 era.

With the Kotlin prerequisite now at 2.2.0, the Kotlin Gradle plugin officially requires Gradle 7.6.3 or later (per the JetBrains KGP/Gradle compatibility table, all of KGP 2.1–2.4 share the 7.6.3 minimum). This PR raises the documented minimum to **7.6.4**, matching both the compatibility matrix rows for Komapper 5.x and the Gradle version actually verified for Kotlin 2.x in the komapper/compatibility-test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)