### PR TITLE
Update Quarkus to v3.36.2 and prepare the build for Gradle 9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ configure(libraryProjects + gradlePluginProject + exampleProjects + integrationT
         }
     }
 
-    val jvmTargetVersion = if (project.name.contains("spring")) 17 else 11
+    val jvmTargetVersion = if (project.name.contains("spring") || project.name.contains("quarkus")) 17 else 11
 
     tasks {
         withType<Test>().configureEach {

--- a/gradle-plugin/src/main/java/org/komapper/gradle/codegen/GenerateTask.java
+++ b/gradle-plugin/src/main/java/org/komapper/gradle/codegen/GenerateTask.java
@@ -9,10 +9,12 @@ import java.util.Objects;
 import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import org.komapper.codegen.CodeGenerator;
 import org.komapper.codegen.MetadataReader;
 import org.komapper.codegen.Table;
 
+@DisableCachingByDefault(because = "Reads metadata from a live database")
 public class GenerateTask extends DefaultTask {
 
   private final Generator settings;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ ksp = "2.3.9"
 kotlinx-coroutines = "1.11.0"
 springframework = "7.0.8"
 spring-boot = "4.1.0"
-quarkus = "3.30.6"
+quarkus = "3.36.2"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

This PR unblocks the Gradle 9 update (#1675) and supersedes the Quarkus update (#1786).

- **Update Quarkus to 3.36.2** (includes Renovate's commit from #1786). The `validateExtension` task of the `io.quarkus.extension` plugin was incompatible with Gradle 9 (quarkusio/quarkus#49115); the fix landed in Quarkus 3.35.0.
- **Build the Quarkus modules with JVM target 17.** The Quarkus 3.36 deployment artifacts depend on JUnit 6, which requires Java 17, so resolving the deployment classpath with JVM target 11 fails. Quarkus 3.x has required Java 17 at runtime all along.
- **Annotate `GenerateTask` with `@DisableCachingByDefault`.** Gradle 9's `validatePlugins` requires task types to declare their cacheability. This task reads metadata from a live database, so it must not be cached.

## Verification

Ran `./gradlew javatoolchain check -x h2 -x :integration-test-jdbc:check -x :integration-test-r2dbc:check` (the CI build job command) locally with both:

- Gradle 8.14.5 (current wrapper): BUILD SUCCESSFUL
- Gradle 9.5.1 (simulating #1675 after rebase): BUILD SUCCESSFUL

## Merge order

1. Merge this PR. Renovate should then auto-close #1786 as up to date.
2. Rebase #1675 (tick the rebase checkbox); its CI should pass afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)