### PR TITLE
Fix warnings newly reported by the Kotlin 2.4 compiler

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/builder/BuilderSupport.kt
@@ -670,7 +670,7 @@ class BuilderSupport(
                 }
 
                 is EscapeExpression.Escape -> {
-                    val escaped = dialect.escape(e.value.toString(), finalEscapeSequence)
+                    val escaped = dialect.escape(e.value, finalEscapeSequence)
                     patternBuf.append(escaped)
                 }
 

--- a/komapper-processor/src/main/kotlin/org/komapper/processor/entity/AnnotationSupport.kt
+++ b/komapper-processor/src/main/kotlin/org/komapper/processor/entity/AnnotationSupport.kt
@@ -235,7 +235,7 @@ internal class AnnotationSupport(
                             columnAnnotation,
                         )
                     }
-                    val parameter = constructor?.parameters?.firstOrNull()
+                    val parameter = constructor.parameters.firstOrNull()
                         ?: error("No parameter is found in the class \"${classDeclaration.qualifiedName?.asString()}\"")
                     val declaration =
                         classDeclaration.getDeclaredProperties().firstOrNull { it.simpleName == parameter.name }

--- a/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcExecutor.kt
+++ b/komapper-r2dbc/src/main/kotlin/org/komapper/r2dbc/R2dbcExecutor.kt
@@ -230,6 +230,10 @@ internal class R2dbcExecutor(
             when (val value = row.get(0)) {
                 is Number -> value.toLong()
 
+                null -> error(
+                    "Generated value is null. generatedColumn=$generatedColumn"
+                )
+
                 else -> error(
                     "Generated value is not Number. generatedColumn=$generatedColumn, value=$value, valueType=${value::class.qualifiedName}"
                 )


### PR DESCRIPTION
## Summary

Follow-up to #1883. The Kotlin 2.4 compiler reports new diagnostics in the main sources; this PR fixes three of them.

## What changed

- **`BuilderSupport`** ("Redundant call of conversion method"): `EscapeExpression.Escape.value` is already a `String`, so the `toString()` call before `dialect.escape` was a no-op. Behavior unchanged.
- **`AnnotationSupport`** ("Unnecessary safe call on a non-null receiver"): the constructor reference is a non-null `KSFunctionDeclaration`, so the safe call is dropped. The elvis `error(...)` still covers the no-parameter case. Behavior unchanged.
- **`R2dbcExecutor`** ("'when' expression over a subject of type 'Any?' is not exhaustive"): added an explicit `null` branch when reading a generated key. Previously a null value would fall into the `else` branch and hit `value::class` in the error message; now it fails with a clear "Generated value is null" error instead.

## Notes for reviewers

The remaining "Expression is unused" warnings in other files (e.g. `SelectStatementBuilder`, `EntityFactory`, and the trailing `Unit` in `JdbcSelectJoinTest`/`R2dbcSelectJoinTest`) are intentionally not touched — in the test files the trailing `Unit` is load-bearing for type inference.

## Verification

`./gradlew spotlessApply :komapper-core:test :komapper-processor:test :komapper-r2dbc:test h2` passes, including both JDBC/R2DBC H2 integration suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)