### PR TITLE
Raise the minimum supported JVM target from 11 to 17

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ The project follows a modular architecture with clear separation of concerns:
 
 ### Build Configuration
 - Uses Gradle with Kotlin DSL
-- JVM target: 11 (17 for Spring modules)
+- JVM target: 17
 - Kotlin API version: 2.2
 - KSP2 enabled for better performance
 - Automatic code formatting with Spotless (ktlint for Kotlin, Google Java Format for Java)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ The project follows a modular architecture with clear separation of concerns:
 ### Build Configuration
 - Uses Gradle with Kotlin DSL
 - JVM target: 17
-- Kotlin API and language version: 2.3
+- Kotlin API version: 2.3; language version: 2.3 (2.4 for modules using context parameters)
 - KSP2 enabled for better performance
 - Automatic code formatting with Spotless (ktlint for Kotlin, Google Java Format for Java)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ The project follows a modular architecture with clear separation of concerns:
 ### Build Configuration
 - Uses Gradle with Kotlin DSL
 - JVM target: 17
-- Kotlin API version: 2.2
+- Kotlin API and language version: 2.3
 - KSP2 enabled for better performance
 - Automatic code formatting with Spotless (ktlint for Kotlin, Google Java Format for Java)
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ See [DESIGN_DOC](DESIGN_DOC.md) for the design policy of this project.
 | 2.1.21-2.0.2           | 5.x              | Yes           | 11              | 7.6.4              |
 | 2.2.20-2.0.3           | 5.x              | Yes           | 11              | 7.6.4              |
 | 2.3.0                  | 5.x - 6.1.0      | Yes           | 11              | 7.6.4              |
-| 2.4.0-2.3.9            | 6.2.0 or later   | Yes           | 17              | 7.6.4              |
+| 2.4.0-2.3.9            | 7.0.0 or later   | Yes           | 17              | 7.6.4              |
 
 Compatibility testing is performed in the [komapper/compatibility-test](https://github.com/komapper/compatibility-test/) repository.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more documentation, go to our site:
 
 ## Prerequisite
 
-- Kotlin 2.2.0 or later
+- Kotlin 2.3.0 or later
 - JRE 17 or later
 - Gradle 7.6.4 or later
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more documentation, go to our site:
 
 ## Prerequisite
 
-- Kotlin 2.3.0 or later
+- Kotlin 2.3.21 or later
 - JRE 17 or later
 - Gradle 7.6.4 or later
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more documentation, go to our site:
 ## Prerequisite
 
 - Kotlin 2.2.0 or later
-- JRE 11 or later
+- JRE 17 or later
 - Gradle 7.6.4 or later
 
 ## Supported Databases
@@ -173,7 +173,8 @@ See [DESIGN_DOC](DESIGN_DOC.md) for the design policy of this project.
 | 2.0.21-1.0.28          | 2.x - 5.x        | Yes           | 11              | 7.6.4              |
 | 2.1.21-2.0.2           | 5.x              | Yes           | 11              | 7.6.4              |
 | 2.2.20-2.0.3           | 5.x              | Yes           | 11              | 7.6.4              |
-| 2.3.0                  | 5.x              | Yes           | 11              | 7.6.4              |
+| 2.3.0                  | 5.x - 6.1.0      | Yes           | 11              | 7.6.4              |
+| 2.4.0-2.3.9            | 6.2.0 or later   | Yes           | 17              | 7.6.4              |
 
 Compatibility testing is performed in the [komapper/compatibility-test](https://github.com/komapper/compatibility-test/) repository.
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ See [DESIGN_DOC](DESIGN_DOC.md) for the design policy of this project.
 | 2.1.21-2.0.2           | 5.x              | Yes           | 11              | 7.6.4              |
 | 2.2.20-2.0.3           | 5.x              | Yes           | 11              | 7.6.4              |
 | 2.3.0                  | 5.x - 6.1.0      | Yes           | 11              | 7.6.4              |
-| 2.4.0-2.3.9            | 7.0.0 or later   | Yes           | 17              | 7.6.4              |
+| 2.3.21                 | 7.0.0 or later   | Yes           | 17              | 7.6.4              |
 
 Compatibility testing is performed in the [komapper/compatibility-test](https://github.com/komapper/compatibility-test/) repository.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,10 @@ configure(libraryProjects + gradlePluginProject + exampleProjects + integrationT
 
     val jvmTargetVersion = 17
 
+    // Context parameters require Kotlin language version 2.4
+    val usesContextParameters = project.name.contains("tx-context") || project.name.startsWith("integration-test")
+    val kotlinLanguageVersion = if (usesContextParameters) KotlinVersion.KOTLIN_2_4 else KotlinVersion.KOTLIN_2_3
+
     tasks {
         withType<Test>().configureEach {
             useJUnitPlatform {
@@ -90,7 +94,7 @@ configure(libraryProjects + gradlePluginProject + exampleProjects + integrationT
                 freeCompilerArgs.add("-Xjdk-release=$jvmTargetVersion")
                 jvmTarget.set(JvmTarget.fromTarget(jvmTargetVersion.toString()))
                 apiVersion.set(KotlinVersion.KOTLIN_2_3)
-                languageVersion.set(KotlinVersion.KOTLIN_2_3)
+                languageVersion.set(kotlinLanguageVersion)
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,8 @@ configure(libraryProjects + gradlePluginProject + exampleProjects + integrationT
             compilerOptions {
                 freeCompilerArgs.add("-Xjdk-release=$jvmTargetVersion")
                 jvmTarget.set(JvmTarget.fromTarget(jvmTargetVersion.toString()))
-                apiVersion.set(KotlinVersion.KOTLIN_2_2)
+                apiVersion.set(KotlinVersion.KOTLIN_2_3)
+                languageVersion.set(KotlinVersion.KOTLIN_2_3)
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ configure(libraryProjects + gradlePluginProject + exampleProjects + integrationT
         }
     }
 
-    val jvmTargetVersion = if (project.name.contains("spring") || project.name.contains("quarkus")) 17 else 11
+    val jvmTargetVersion = 17
 
     tasks {
         withType<Test>().configureEach {

--- a/komapper-processor/src/test/kotlin/org/komapper/processor/AbstractKspTest.kt
+++ b/komapper-processor/src/test/kotlin/org/komapper/processor/AbstractKspTest.kt
@@ -29,8 +29,8 @@ abstract class AbstractKspTest(private vararg val providers: SymbolProcessorProv
         val compilation = KotlinCompilation()
             .apply {
                 useKsp2()
-                languageVersion = "2.1"
-                apiVersion = "2.0"
+                languageVersion = "2.3"
+                apiVersion = "2.3"
                 workingDir = tempDir!!.toFile()
                 inheritClassPath = true
                 symbolProcessorProviders = providers.toMutableList()


### PR DESCRIPTION
## What changed

- `build.gradle.kts`:
  - All modules now target JVM 17. Previously only Spring and Quarkus modules targeted 17 while the rest targeted 11. The single `jvmTargetVersion = 17` value feeds `options.release`, `-Xjdk-release`, and `jvmTarget`.
  - Kotlin `apiVersion` is bumped from 2.2 to 2.3 for all modules.
  - Kotlin `languageVersion` is now pinned explicitly to 2.3, except for the tx-context modules and the integration-test projects, which use 2.4 because they rely on context parameters (a feature available only since language version 2.4).
- `komapper-processor` test harness (`AbstractKspTest.kt`): the compile-testing language/API versions move from 2.1/2.0 to 2.3/2.3, matching the new minimum supported consumer configuration.
- `README.md`:
  - The prerequisites now state "JRE 17 or later" and "Kotlin 2.3.21 or later" (only the latest 2.3.x patch is supported).
  - The compatibility matrix has a new row: Kotlin 2.3.21 (the minimum supported version) with a minimum JRE of 17, applying to Komapper 7.0.0 or later. The previous row was adjusted to "5.x - 6.1.0" since v6.0.0 and v6.1.0 were built with Kotlin 2.3.x and a minimum JRE of 11.
- `CLAUDE.md`: build configuration notes updated accordingly.

## Why

- Drop support for JRE 11–16 and require JRE 17 or later for all Komapper modules. The raised JRE requirement is a breaking change and will ship in the 7.0.0 release.
- The minimum Kotlin version moves from 2.2.0 to 2.3.21. `apiVersion = 2.3` guarantees no stdlib APIs newer than 2.3 are referenced (protects Maven consumers whose nearest-wins resolution can downgrade the stdlib). Pinning `languageVersion = 2.3` makes the stable artifacts emit metadata version 2.3, so the consumer floor no longer drifts implicitly when the build compiler is upgraded.
- The tx-context modules cannot be pinned to 2.3: they use context parameters, stable since Kotlin 2.4 (the `-Xcontext-parameters` flag was removed in the 2.4 upgrade). They are documented as experimental, so their consumer floor tracks the build compiler (currently: metadata 2.4, readable by Kotlin 2.3+ compilers). The integration-test projects also use the feature via the `komapper.enableEntityStoreContext` KSP option, but they are not published, so their metadata version is irrelevant.

## Notes for reviewers

- Verified on a clean rebuild of `komapper-core`: class files have major version 61 (Java 17) and `kotlin.Metadata` carries `mv=[2,3,0]`.
- `./gradlew test h2` and `./gradlew spotlessCheck` pass.
- Kotlin 2.3 consumers who opt into `komapper.enableEntityStoreContext` need `-Xcontext-parameters` in their own build to compile the generated code; on Kotlin 2.4+ it works out of the box.
- The documentation website (komapper-docs repo) likely also mentions the JRE 11 / Kotlin 2.2 requirements and will need a separate update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
