### PR TITLE
Update compatibility matrix for standalone KSP and Kotlin 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,11 @@ See [DESIGN_DOC](DESIGN_DOC.md) for the design policy of this project.
 | 2.0.21-1.0.28          | 2.x - 5.x        | Yes           | 11              | 7.6.4              |
 | 2.1.21-2.0.2           | 5.x              | Yes           | 11              | 7.6.4              |
 | 2.2.20-2.0.3           | 5.x              | Yes           | 11              | 7.6.4              |
-| 2.3.0                  | 5.x - 6.1.0      | Yes           | 11              | 7.6.4              |
-| 2.3.21                 | 7.0.0 or later   | Yes           | 17              | 7.6.4              |
+| 2.3.0                  | 5.x - 6.1.0      | Yes           | 11              | 8.2                |
+| 2.3.21                 | 7.0.0 or later   | Yes           | 17              | 8.2                |
+| 2.4.0                  | 7.0.0 or later   | Yes           | 17              | 8.2                |
+
+For Kotlin 2.3.0 and later, KSP is versioned independently of Kotlin (standalone KSP). These rows were verified with KSP 2.3.9.
 
 Compatibility testing is performed in the [komapper/compatibility-test](https://github.com/komapper/compatibility-test/) repository.
 


### PR DESCRIPTION
## Summary

- Raise the minimum Gradle version from 7.6.4 to 8.2 for the rows that use standalone KSP (KSP 2.3.0 or later), i.e. the Kotlin 2.3.0 and Kotlin 2.3.21 rows.
- Add a new row for Kotlin 2.4.0: Komapper 7.0.0 or later, KSP2 support, JRE 17, Gradle 8.2.
- Add a note that the standalone KSP rows were verified with KSP 2.3.9.
- The legacy KSP rows (1.9.24-1.0.20 through 2.2.20-2.0.3) are unchanged.

## Rationale

- The Kotlin DSL in Gradle 7.6.x through 8.1.x cannot read the Kotlin 2.3 metadata contained in the standalone KSP (2.3.x) plugin jar, and fails at configuration time with `Protocol message contained an invalid tag (zero)`. This is the same mechanism as [KT-73639](https://youtrack.jetbrains.com/issue/KT-73639).
- A bisection in [komapper/compatibility-test](https://github.com/komapper/compatibility-test/) confirmed that Gradle 8.1.1 fails while 8.2.1 succeeds.
- The CI run for [compatibility-test#73](https://github.com/komapper/compatibility-test/pull/73) confirmed that all of the following combinations are green:
  - Kotlin 2.3.0 + KSP 2.3.9 + Komapper 5.7.0 / 6.1.0 (JDK 11, Gradle 8.2.1)
  - Kotlin 2.3.21 + KSP 2.3.9 + Komapper 7.0.0 (JDK 17, Gradle 8.2.1)
  - Kotlin 2.4.0 + KSP 2.3.9 + Komapper 7.0.0 (JDK 17, Gradle 8.2.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)