### PR TITLE
Allow user-defined operators via context parameters by exposing FilterScope.criteriaContext

### DIFF
--- a/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWhereContextParameterTest.kt
+++ b/integration-test-jdbc/src/test/kotlin/integration/jdbc/JdbcSelectWhereContextParameterTest.kt
@@ -1,0 +1,155 @@
+package integration.jdbc
+
+import integration.core.Dbms
+import integration.core.Run
+import integration.core.employee
+import org.junit.jupiter.api.extension.ExtendWith
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.expression.ColumnExpression
+import org.komapper.core.dsl.expression.Operand
+import org.komapper.core.dsl.scope.FilterScope
+import org.komapper.jdbc.JdbcDatabase
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * User-defined operators implemented with context parameters (Kotlin 2.4).
+ *
+ * Unlike [JdbcSelectWhereTest.MyExtension], these operators are plain top-level
+ * functions and can be used directly inside a `where { }` block without wrapping
+ * them in an `extension { }` block. The implicit `FilterScope` receiver of the
+ * block satisfies the `context(scope: FilterScope<*>)` parameter.
+ */
+@ExtendWith(JdbcEnv::class)
+class JdbcSelectWhereContextParameterTest(private val db: JdbcDatabase) {
+    @Test
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    fun regexOperators() {
+        val e = Meta.employee
+        val list = db.runQuery {
+            QueryDsl.from(e).where {
+                e.salary greaterEq BigDecimal(1000)
+                e.employeeName `~` "S"
+                e.employeeName `!~` "T"
+            }.orderBy(e.employeeName)
+        }
+        assertEquals(listOf("ADAMS", "JONES"), list.map { it.employeeName })
+    }
+
+    @Test
+    @Run(onlyIf = [Dbms.POSTGRESQL])
+    fun regexOperators_or_and() {
+        val e = Meta.employee
+        val list = db.runQuery {
+            QueryDsl.from(e).where {
+                e.salary greaterEq BigDecimal(1000)
+                e.employeeName `~` "S"
+                or {
+                    e.employeeName `~` "T"
+                    and {
+                        e.employeeName `~` "S"
+                    }
+                }
+            }.orderBy(e.employeeName)
+        }
+        assertEquals(listOf("ADAMS", "JONES", "SCOTT", "SMITH"), list.map { it.employeeName })
+    }
+
+    @Test
+    fun equivalentToBuiltinOperator() {
+        val e = Meta.employee
+        val custom = db.runQuery {
+            QueryDsl.from(e).where {
+                e.employeeName eqx "SMITH"
+            }.orderBy(e.employeeId)
+        }
+        val builtin = db.runQuery {
+            QueryDsl.from(e).where {
+                e.employeeName eq "SMITH"
+            }.orderBy(e.employeeId)
+        }
+        assertEquals(builtin, custom)
+        assertTrue(custom.isNotEmpty())
+    }
+
+    @Test
+    fun nesting() {
+        val e = Meta.employee
+        // The user-defined operator nested inside `or`/`and` must register its
+        // criterion in the correct (innermost) group. We verify this by comparing
+        // against the built-in `eq` operator used in the very same structure:
+        // if the criterion leaked to the top-level group, the results would differ.
+        val custom = db.runQuery {
+            QueryDsl.from(e).where {
+                e.employeeName eqx "SMITH"
+                or {
+                    e.employeeName eqx "SCOTT"
+                    and {
+                        e.employeeName eqx "KING"
+                    }
+                }
+            }.orderBy(e.employeeId)
+        }
+        val builtin = db.runQuery {
+            QueryDsl.from(e).where {
+                e.employeeName eq "SMITH"
+                or {
+                    e.employeeName eq "SCOTT"
+                    and {
+                        e.employeeName eq "KING"
+                    }
+                }
+            }.orderBy(e.employeeId)
+        }
+        assertEquals(builtin, custom)
+        assertTrue(custom.isNotEmpty())
+    }
+}
+
+/**
+ * The PostgreSQL `~` (regex match) operator.
+ */
+context(scope: FilterScope<*>)
+private infix fun <T : Any> ColumnExpression<T, String>.`~`(pattern: T?) {
+    if (pattern == null) return
+    val left = Operand.Column(this)
+    val right = Operand.Argument(this, pattern)
+    scope.criteriaContext.add {
+        visit(left)
+        append(" ~ ")
+        visit(right)
+    }
+}
+
+/**
+ * The PostgreSQL `!~` (regex not-match) operator.
+ */
+context(scope: FilterScope<*>)
+private infix fun <T : Any> ColumnExpression<T, String>.`!~`(pattern: T?) {
+    if (pattern == null) return
+    val left = Operand.Column(this)
+    val right = Operand.Argument(this, pattern)
+    scope.criteriaContext.add {
+        visit(left)
+        append(" !~ ")
+        visit(right)
+    }
+}
+
+/**
+ * A database-agnostic `=` operator, defined purely to exercise the mechanism.
+ */
+context(scope: FilterScope<*>)
+private infix fun <T : Any, S : Any> ColumnExpression<T, S>.eqx(value: T?) {
+    if (value == null) return
+    val left = Operand.Column(this)
+    val right = Operand.Argument(this, value)
+    scope.criteriaContext.add {
+        visit(left)
+        append(" = ")
+        visit(right)
+    }
+}

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
@@ -343,6 +343,28 @@ interface FilterScope<F : FilterScope<F>> {
     fun CharSequence.asSuffix(): EscapeExpression = this.asSuffixFunction()
 
     /**
+     * The context for registering user-defined criteria.
+     *
+     * Combine this with a context parameter to define custom operators directly,
+     * without wrapping them in an [extension] block. For example:
+     *
+     * ```
+     * context(scope: FilterScope<*>)
+     * infix fun <T : Any> ColumnExpression<T, String>.match(pattern: T?) {
+     *     if (pattern == null) return
+     *     val left = Operand.Column(this)
+     *     val right = Operand.Argument(this, pattern)
+     *     scope.criteriaContext.add {
+     *         visit(left)
+     *         append(" ~ ")
+     *         visit(right)
+     *     }
+     * }
+     * ```
+     */
+    val criteriaContext: CriteriaContext
+
+    /**
      * Adds an extension.
      *
      * @param EXTENSION the type of extension

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScope.kt
@@ -15,6 +15,28 @@ import org.komapper.core.dsl.operator.asSuffix as asSuffixFunction
  */
 interface FilterScope<F : FilterScope<F>> {
     /**
+     * The context for registering user-defined criteria.
+     *
+     * Combine this with a context parameter to define custom operators directly,
+     * without wrapping them in an [extension] block. For example:
+     *
+     * ```
+     * context(scope: FilterScope<*>)
+     * infix fun <T : Any> ColumnExpression<T, String>.match(pattern: T?) {
+     *     if (pattern == null) return
+     *     val left = Operand.Column(this)
+     *     val right = Operand.Argument(this, pattern)
+     *     scope.criteriaContext.add {
+     *         visit(left)
+     *         append(" ~ ")
+     *         visit(right)
+     *     }
+     * }
+     * ```
+     */
+    val criteriaContext: CriteriaContext
+
+    /**
      * Applies the `=` operator.
      */
     infix fun <T : Any, S : Any> ColumnExpression<T, S>.eq(operand: ColumnExpression<T, S>)
@@ -341,28 +363,6 @@ interface FilterScope<F : FilterScope<F>> {
      * Escapes the given string and appends a wildcard character at the beginning.
      */
     fun CharSequence.asSuffix(): EscapeExpression = this.asSuffixFunction()
-
-    /**
-     * The context for registering user-defined criteria.
-     *
-     * Combine this with a context parameter to define custom operators directly,
-     * without wrapping them in an [extension] block. For example:
-     *
-     * ```
-     * context(scope: FilterScope<*>)
-     * infix fun <T : Any> ColumnExpression<T, String>.match(pattern: T?) {
-     *     if (pattern == null) return
-     *     val left = Operand.Column(this)
-     *     val right = Operand.Argument(this, pattern)
-     *     scope.criteriaContext.add {
-     *         visit(left)
-     *         append(" ~ ")
-     *         visit(right)
-     *     }
-     * }
-     * ```
-     */
-    val criteriaContext: CriteriaContext
 
     /**
      * Adds an extension.

--- a/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/dsl/scope/FilterScopeSupport.kt
@@ -17,6 +17,14 @@ class FilterScopeSupport<F : FilterScope<F>>(
     private val deque: Deque<MutableList<Criterion>> = LinkedList(),
     private val criteria: MutableList<Criterion> = mutableListOf(),
 ) : FilterScope<F> {
+    override val criteriaContext: CriteriaContext = object : CriteriaContext {
+        override fun add(build: SqlBuilderScope.() -> Unit) {
+            val criterion = Criterion.UserDefined(build)
+            val target = deque.peek() ?: criteria
+            target.add(criterion)
+        }
+    }
+
     fun toList(): List<Criterion> {
         return criteria.toList()
     }
@@ -382,14 +390,7 @@ class FilterScopeSupport<F : FilterScope<F>>(
     }
 
     override fun <EXTENSION> extension(construct: (context: CriteriaContext) -> EXTENSION, declaration: EXTENSION.() -> Unit) {
-        val context = object : CriteriaContext {
-            override fun add(build: SqlBuilderScope.() -> Unit) {
-                val criterion = Criterion.UserDefined(build)
-                val target = deque.peek() ?: criteria
-                target.add(criterion)
-            }
-        }
-        val scope = construct(context)
+        val scope = construct(criteriaContext)
         scope.declaration()
     }
 }


### PR DESCRIPTION
## Summary

Expose a public `criteriaContext` on `FilterScope` so users can extend the filter DSL with their own operators (like the built-in `eq`/`like`) using **Kotlin context parameters**, without the `extension { }` wrapper.

Inside a `where`/`having`/`on`/`when` block, the implicit scope receiver (a `FilterScope`) now satisfies a `context(scope: FilterScope<*>)` parameter. A user-defined operator therefore reads exactly like a built-in one at the call site:

```kotlin
// user code (Kotlin 2.4)
context(scope: FilterScope<*>)
infix fun <T : Any> ColumnExpression<T, String>.`~`(pattern: T?) {
    if (pattern == null) return
    val left = Operand.Column(this)
    val right = Operand.Argument(this, pattern)
    scope.criteriaContext.add {
        visit(left); append(" ~ "); visit(right)
    }
}

// usage — no extension { } wrapper
QueryDsl.from(e).where {
    e.salary greaterEq BigDecimal(1000)
    e.employeeName `~` "S"
    e.employeeName `!~` "T"
}
```

The query above generates:

```sql
select t0_.employee_id, t0_.employee_name, t0_.salary, ...
from employee as t0_
where t0_.salary >= ? and t0_.employee_name ~ ? and t0_.employee_name !~ ?
order by t0_.employee_name asc
```

The user-defined `~` / `!~` operators emit raw SQL through `criteriaContext.add { ... }`, sitting alongside the built-in `>=` exactly as written.

This is the ergonomic successor to the existing `extension(::MyExtension) { }` mechanism: context parameters provide the second receiver (the criteria-adding scope) that previously required a wrapper object.

## Changes

- **`FilterScope`**: add `val criteriaContext: CriteriaContext`. All scopes (`WhereScope`/`HavingScope`/`OnScope`/`WhenScope`) delegate via `by support`, so no per-scope changes are needed.
- **`FilterScopeSupport`**: implement the property by hoisting the `CriteriaContext` object that was previously created inline inside `extension`. `extension` now reuses it, so its behavior — including the deque-based `and`/`or`/`not` nesting resolution — is byte-for-byte unchanged.
- **Tests**: new `JdbcSelectWhereContextParameterTest` exercising context-parameter operators directly in `where { }`, including nesting. The database-agnostic tests assert that a context-parameter operator nested inside `or`/`and` yields the same result as the built-in `eq` used in the identical structure, which catches a criterion leaking out of its group.

### Nesting is preserved

A user-defined operator nested inside `or`/`and` registers its criterion in the correct (innermost) group. For example:

```kotlin
QueryDsl.from(e).where {
    e.employeeName eqx "SMITH"
    or {
        e.employeeName eqx "SCOTT"
        and {
            e.employeeName eqx "KING"
        }
    }
}
```

generates correctly-parenthesized SQL:

```sql
... from employee as t0_
where t0_.employee_name = ? or (t0_.employee_name = ? and (t0_.employee_name = ?))
order by t0_.employee_id asc
```

## Notes for reviewers

- **Komapper itself stays on Kotlin language version 2.3.** The `context(...)` keyword only appears in user code; `FilterScope`/`CriteriaContext` are ordinary types. Users opt into 2.4 in their own build.
- **API compatibility**: this adds an abstract member to the public `FilterScope` interface, which is technically breaking for any external code that implements `FilterScope` directly. In practice all implementations delegate to `FilterScopeSupport`, so impact is expected to be negligible. Targeting a feature release rather than a patch.

## Verification

- `komapper-core` compiles; `komapper-core:test` passes.
- New tests pass on H2 (`tests=4, skipped=2` — the PostgreSQL-only `~`/`!~` cases; `failures=0`).
- Existing `JdbcSelectWhereTest` passes on H2 (`tests=52, failures=0`) — no regression from the `extension` refactor.
- `spotlessApply` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)