### PR TITLE
Fix expression tokenizer bugs for is/as values and suffix-less decimals

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprTokenizer.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/expression/ExprTokenizer.kt
@@ -142,11 +142,11 @@ class ExprTokenizer(private val expression: String) {
                 type = LE
                 binaryOpAvailable = false
                 return
-            } else if (c[0] == 'i' && c[1] == 's') {
+            } else if (c[0] == 'i' && c[1] == 's' && isWordTerminated()) {
                 type = IS
                 binaryOpAvailable = false
                 return
-            } else if (c[0] == 'a' && c[1] == 's') {
+            } else if (c[0] == 'a' && c[1] == 's' && isWordTerminated()) {
                 type = AS
                 binaryOpAvailable = false
                 return
@@ -208,6 +208,7 @@ class ExprTokenizer(private val expression: String) {
             return
         } else if (c == ',') {
             type = COMMA
+            binaryOpAvailable = false
             return
         } else if (c == '(') {
             type = OPEN_PAREN
@@ -371,6 +372,10 @@ class ExprTokenizer(private val expression: String) {
                 buf.reset()
                 break
             }
+        }
+        if (decimal && type == INT) {
+            // a decimal point requires a type suffix such as F, D or B
+            type = ILLEGAL_NUMBER
         }
         if (!isWordTerminated()) {
             type = ILLEGAL_NUMBER

--- a/komapper-core/src/test/kotlin/org/komapper/core/template/expression/ExprParserTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/template/expression/ExprParserTest.kt
@@ -161,6 +161,34 @@ class ExprParserTest {
     }
 
     @Test
+    fun `An argument starting with is is parsed as a value`() {
+        when (val expr = ExprParser("f(a, isActive)").parse()) {
+            is ExprNode.CallableValue -> {
+                assertEquals("f", expr.name)
+                val args = expr.args
+                assertTrue(args is ExprNode.Comma)
+                assertEquals(2, args.nodeList.size)
+                val first = args.nodeList[0]
+                val second = args.nodeList[1]
+                assertTrue(first is ExprNode.Value)
+                assertEquals("a", first.name)
+                assertTrue(second is ExprNode.Value)
+                assertEquals("isActive", second.name)
+            }
+
+            else -> {
+                throw AssertionError(expr)
+            }
+        }
+    }
+
+    @Test
+    fun `A decimal literal without a type suffix throws an exception`() {
+        val exception = assertFailsWith<ExprException> { ExprParser("1.5").parse() }
+        println(exception)
+    }
+
+    @Test
     fun `The operand is not found`() {
         val exception = assertFailsWith<ExprException> { ExprParser("aaa >").parse() }
         println(exception)

--- a/komapper-core/src/test/kotlin/org/komapper/core/template/expression/ExprTokenizerTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/template/expression/ExprTokenizerTest.kt
@@ -3,12 +3,15 @@ package org.komapper.core.template.expression
 import org.komapper.core.template.expression.ExprTokenType.AND
 import org.komapper.core.template.expression.ExprTokenType.BIG_DECIMAL
 import org.komapper.core.template.expression.ExprTokenType.CLASS_REF
+import org.komapper.core.template.expression.ExprTokenType.COMMA
 import org.komapper.core.template.expression.ExprTokenType.DOUBLE
 import org.komapper.core.template.expression.ExprTokenType.EOE
 import org.komapper.core.template.expression.ExprTokenType.EOL
 import org.komapper.core.template.expression.ExprTokenType.FALSE
 import org.komapper.core.template.expression.ExprTokenType.FLOAT
+import org.komapper.core.template.expression.ExprTokenType.ILLEGAL_NUMBER
 import org.komapper.core.template.expression.ExprTokenType.INT
+import org.komapper.core.template.expression.ExprTokenType.IS
 import org.komapper.core.template.expression.ExprTokenType.LONG
 import org.komapper.core.template.expression.ExprTokenType.NULL
 import org.komapper.core.template.expression.ExprTokenType.PROPERTY
@@ -219,6 +222,51 @@ class ExprTokenizerTest {
         assertEquals("?.bbb", tokenizer.token)
         assertEquals(EOE, tokenizer.next())
         assertEquals("", tokenizer.token)
+    }
+
+    @Test
+    fun `A value starting with is after a comma is not treated as the is operator`() {
+        val tokenizer = ExprTokenizer("a, isActive")
+        assertEquals(VALUE, tokenizer.next())
+        assertEquals("a", tokenizer.token)
+        assertEquals(COMMA, tokenizer.next())
+        assertEquals(",", tokenizer.token)
+        assertEquals(WHITESPACE, tokenizer.next())
+        assertEquals(" ", tokenizer.token)
+        assertEquals(VALUE, tokenizer.next())
+        assertEquals("isActive", tokenizer.token)
+        assertEquals(EOE, tokenizer.next())
+    }
+
+    @Test
+    fun `A value starting with as after a comma is not treated as the as operator`() {
+        val tokenizer = ExprTokenizer("a, aspectRatio")
+        assertEquals(VALUE, tokenizer.next())
+        assertEquals("a", tokenizer.token)
+        assertEquals(COMMA, tokenizer.next())
+        assertEquals(",", tokenizer.token)
+        assertEquals(WHITESPACE, tokenizer.next())
+        assertEquals(" ", tokenizer.token)
+        assertEquals(VALUE, tokenizer.next())
+        assertEquals("aspectRatio", tokenizer.token)
+        assertEquals(EOE, tokenizer.next())
+    }
+
+    @Test
+    fun `The is operator is still recognized`() {
+        val tokenizer = ExprTokenizer("a is @Foo@")
+        assertEquals(VALUE, tokenizer.next())
+        assertEquals("a", tokenizer.token)
+        assertEquals(WHITESPACE, tokenizer.next())
+        assertEquals(IS, tokenizer.next())
+        assertEquals("is", tokenizer.token)
+    }
+
+    @Test
+    fun `A decimal literal without a type suffix is illegal`() {
+        val tokenizer = ExprTokenizer("1.5")
+        assertEquals(ILLEGAL_NUMBER, tokenizer.next())
+        assertEquals("1.5", tokenizer.token)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes two bugs in the template expression tokenizer (`komapper-core` `org.komapper.core.template.expression`).

### Bug 1: identifiers starting with `is`/`as` mis-tokenized after a comma

An identifier whose name starts with `is` or `as` was tokenized as the `is`/`as` **operator** when it appeared in a position where a binary operator was still considered legal — most realistically as a non-first function argument:

```
f(a, isActive)    →  CALLABLE_VALUE "f" ( a , [IS "is"] [VALUE "Active"] )   ← wrong, then fails to parse
f(a, aspectRatio) →  ... , [AS "as"] [VALUE "pectRatio"]                     ← wrong
f(isActive)       →  ... ( [VALUE "isActive"] )                              ← already correct (first arg)
```

`f(a, isActive)` then failed with `ExprException: The operand is not found`. This affects common names such as `isActive`, `isEnabled`, `island`, `assignee`, `asset`, `aspect`.

Two cooperating causes, both in `ExprTokenizer`:
- The `is`/`as` operator matches did not call `isWordTerminated()`, unlike `true`/`false`/`null`, so they greedily matched the prefix of a longer identifier.
- The `,` branch did not reset `binaryOpAvailable`, so after an operand the flag stayed `true` across the comma and the operator matchers were still armed for the next operand.

Fix: add an `isWordTerminated()` guard to the `is`/`as` matches, and reset `binaryOpAvailable = false` in the `COMMA` branch (an operand, not an operator, is expected after a comma).

### Bug 2: suffix-less decimal literal throws a raw `NumberFormatException`

A decimal literal without a type suffix (e.g. `1.5`) was classified as `INT`, so `parseIntLiteral` called `Integer.valueOf("1.5")` and threw a `java.lang.NumberFormatException` with no location — not the package's own `ExprException`.

Fix: in `readNumber`, classify a number containing a decimal point but no `F`/`D`/`B` suffix as `ILLEGAL_NUMBER`, consistent with the existing suffix requirement. The parser now reports a proper `ExprException` with location.

## Tests

- `ExprTokenizerTest`: `a, isActive` and `a, aspectRatio` tokenize the second element as `VALUE`; the `is` operator (`a is @Foo@`) is still recognized; `1.5` tokenizes as `ILLEGAL_NUMBER`.
- `ExprParserTest`: `f(a, isActive)` parses to a `CallableValue` whose args are a 2-element `Comma` of `Value`s (`a`, `isActive`); `1.5` throws `ExprException`.

## Verification

- `komapper-core:test --tests "...expression.*"` — pass
- `komapper-template:test` (`ExprEvaluatorTest`) and `komapper-processor:test --tests "*Expr*"` (`ExprValidatorTest`) — pass (downstream consumers unaffected)
- `spotlessApply` on `komapper-core` — clean

## Note for reviewers

Bug 2's fix makes a suffix-less decimal an explicit error, consistent with the current "non-int numbers need a suffix" design. If the preferred behavior is to instead **accept** `1.5` as a `Double`/`BigDecimal`, that would be a small alternative change — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)