### PR TITLE
Fix for-directive identifier parsing when the loop variable name contains "in"

### DIFF
--- a/komapper-core/src/main/kotlin/org/komapper/core/template/sql/SqlParser.kt
+++ b/komapper-core/src/main/kotlin/org/komapper/core/template/sql/SqlParser.kt
@@ -259,15 +259,15 @@ internal class SqlParser constructor(
         if (iterationExpression.isEmpty()) {
             throw SqlException("The iteration expression is not found in the for directive at $location")
         }
-        val pos = iterationExpression.indexOf("in")
-        if (pos == -1) {
+        val inKeyword = IN_KEYWORD_REGEX.find(iterationExpression)
+        if (inKeyword == null) {
             throw SqlException("The keyword \"in\" is not found in the iteration expression in the for directive at $location")
         }
-        val identifier = iterationExpression.substring(0, pos).trim()
+        val identifier = iterationExpression.substring(0, inKeyword.range.first).trim()
         if (identifier.isEmpty()) {
             throw SqlException("The identifier is not found in the iteration expression in the for directive at $location")
         }
-        val iterableExpression = iterationExpression.substring(pos + 2).trim()
+        val iterableExpression = iterationExpression.substring(inKeyword.range.last + 1).trim()
         if (iterableExpression.isEmpty()) {
             throw SqlException("The iterable expression is not found in the iteration expression in the for directive at $location")
         }
@@ -322,6 +322,10 @@ internal class SqlParser constructor(
         reducers.peek()?.addNode(node)
     }
 }
+
+// Matches the "in" keyword as a standalone word so that identifiers
+// containing the substring "in" (e.g. "index", "line") are not split incorrectly.
+private val IN_KEYWORD_REGEX = Regex("""\bin\b""")
 
 private fun String.strip(prefix: String, suffix: String): String {
     return this.substring(prefix.length, this.length - suffix.length).trim()

--- a/komapper-core/src/test/kotlin/org/komapper/core/template/sql/SqlParserTest.kt
+++ b/komapper-core/src/test/kotlin/org/komapper/core/template/sql/SqlParserTest.kt
@@ -459,6 +459,46 @@ class SqlParserTest {
         }
 
         @Test
+        fun `identifier and expression are split on the in keyword`() {
+            val sql = "/*%for item in items*/ b /*%end*/"
+            val node = SqlParser(sql).parse() as SqlNode.Statement
+            assertEquals(sql, node.toText())
+            val forBlock = node.nodeList.filterIsInstance<SqlNode.ForBlock>().single()
+            assertEquals("item", forBlock.forDirective.identifier)
+            assertEquals("items", forBlock.forDirective.expression)
+        }
+
+        @Test
+        fun `identifier starting with in`() {
+            val sql = "/*%for index in indexes*/ b /*%end*/"
+            val node = SqlParser(sql).parse() as SqlNode.Statement
+            assertEquals(sql, node.toText())
+            val forBlock = node.nodeList.filterIsInstance<SqlNode.ForBlock>().single()
+            assertEquals("index", forBlock.forDirective.identifier)
+            assertEquals("indexes", forBlock.forDirective.expression)
+        }
+
+        @Test
+        fun `identifier containing in`() {
+            val sql = "/*%for line in lines*/ b /*%end*/"
+            val node = SqlParser(sql).parse() as SqlNode.Statement
+            assertEquals(sql, node.toText())
+            val forBlock = node.nodeList.filterIsInstance<SqlNode.ForBlock>().single()
+            assertEquals("line", forBlock.forDirective.identifier)
+            assertEquals("lines", forBlock.forDirective.expression)
+        }
+
+        @Test
+        fun `expression containing the in keyword`() {
+            val sql = "/*%for x in xs.filter { it in ys }*/ b /*%end*/"
+            val node = SqlParser(sql).parse() as SqlNode.Statement
+            assertEquals(sql, node.toText())
+            val forBlock = node.nodeList.filterIsInstance<SqlNode.ForBlock>().single()
+            assertEquals("x", forBlock.forDirective.identifier)
+            assertEquals("xs.filter { it in ys }", forBlock.forDirective.expression)
+        }
+
+        @Test
         fun `The corresponding end directive is not found`() {
             val sql = "/*%for a in aaa*/ b"
             val exception = assertFailsWith<SqlException> { SqlParser(sql).parse() }


### PR DESCRIPTION
## What

The `for` directive parser in `SqlParser.parseForDirective` located the `in` keyword with `iterationExpression.indexOf("in")`, which does not respect word boundaries. As a result, loop variable names containing the substring `in` were split at the wrong position:

| Template | Before | After |
|---|---|---|
| `/*%for item in items*/` | `item` / `items` ✅ | `item` / `items` ✅ |
| `/*%for index in indexes*/` | ❌ `SqlException: The identifier is not found...` | `index` / `indexes` ✅ |
| `/*%for line in lines*/` | ❌ silently parsed as `l` / `e in lines` | `line` / `lines` ✅ |
| `/*%for win in windows*/` | ❌ silently parsed as `w` / `in windows` | `win` / `windows` ✅ |

The `line`/`win` cases are especially dangerous because no exception is raised — the directive is parsed into a wrong identifier and iterable expression.

## Why

Common loop variable names such as `index`, `input`, `info`, and `line` all contain the substring `in`, so this affects realistic templates. Existing tests only used single-character identifiers (`a`, `c`), so the gap was not covered.

## How

- Match the `in` keyword as a standalone word using the regex `\bin\b` (compiled once as a file-level `private val`). Only a boundary-delimited `in` acts as the separator.
- Use the **first** match, so an `in` appearing later inside the iterable expression (e.g. `xs.filter { it in ys }`) is left intact.
- All existing error cases and messages (`in` keyword missing, identifier missing, iterable expression missing) are preserved.

## Tests

Added `ForBlockTest` cases asserting the parsed `identifier` / `expression`:
- `item in items` → `item` / `items` (baseline)
- `index in indexes` → `index` / `indexes` (previously threw)
- `line in lines` → `line` / `lines` (previously silently wrong)
- `x in xs.filter { it in ys }` → `x` / `xs.filter { it in ys }` (first-match correctness)

### Verification
- `./gradlew :komapper-core:test --tests "org.komapper.core.template.sql.SqlParserTest"` — pass (ForBlockTest: 13 tests, 0 failures)
- `./gradlew :komapper-core:test --tests "org.komapper.core.template.sql.SqlTokenizerTest"` — pass (no regression)
- `./gradlew :komapper-core:spotlessKotlinCheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)